### PR TITLE
FPL-329: added the functionality for HMCTS to upload standard directions

### DIFF
--- a/ccd-definition/AuthorisationCaseEvent.json
+++ b/ccd-definition/AuthorisationCaseEvent.json
@@ -145,5 +145,12 @@
     "CaseEventID": "submitApplication",
     "UserRole": "caseworker-publiclaw-cafcass",
     "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "Shared_Storage_DRAFTType",
+    "CaseEventID": "uploadStandardDirections",
+    "UserRole": "caseworker-publiclaw-courtadmin",
+    "CRUD": "CRU"
   }
 ]

--- a/ccd-definition/AuthorisationCaseField.json
+++ b/ccd-definition/AuthorisationCaseField.json
@@ -726,5 +726,26 @@
     "CaseFieldID": "familyManCaseNumber",
     "UserRole": "caseworker-publiclaw-cafcass",
     "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "Shared_Storage_DRAFTType",
+    "CaseFieldID": "standardDirections",
+    "UserRole": "caseworker-publiclaw-courtadmin",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "Shared_Storage_DRAFTType",
+    "CaseFieldID": "standardDirections",
+    "UserRole": "caseworker-publiclaw-solicitor",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "Shared_Storage_DRAFTType",
+    "CaseFieldID": "standardDirections",
+    "UserRole": "caseworker-publiclaw-cafcass",
+    "CRUD": "R"
   }
 ]

--- a/ccd-definition/CaseEvent.json
+++ b/ccd-definition/CaseEvent.json
@@ -226,5 +226,16 @@
     "PreConditionState(s)": "Submitted",
     "PostConditionState": "Submitted",
     "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "Shared_Storage_DRAFTType",
+    "ID": "uploadStandardDirections",
+    "Name": "Standard directions",
+    "Description": "Upload standard directions",
+    "DisplayOrder": 1,
+    "PreConditionState(s)": "Submitted",
+    "PostConditionState": "Submitted",
+    "SecurityClassification": "Public"
   }
 ]

--- a/ccd-definition/CaseEventToFields.json
+++ b/ccd-definition/CaseEventToFields.json
@@ -396,5 +396,16 @@
     "PageID": 1,
     "PageDisplayOrder": 1,
     "PageColumnNumber": 1
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "Shared_Storage_DRAFTType",
+    "CaseEventID": "uploadStandardDirections",
+    "CaseFieldID": "standardDirections",
+    "PageFieldDisplayOrder": 1,
+    "DisplayContext": "OPTIONAL",
+    "PageID": 1,
+    "PageDisplayOrder": 1,
+    "PageColumnNumber": 1
   }
 ]

--- a/ccd-definition/CaseField.json
+++ b/ccd-definition/CaseField.json
@@ -281,5 +281,13 @@
     "Label": "FamilyMan case number",
     "FieldType": "Text",
     "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "Shared_Storage_DRAFTType",
+    "ID": "standardDirections",
+    "Label": "Upload standard directions",
+    "FieldType": "StandardDirections",
+    "SecurityClassification": "Public"
   }
 ]

--- a/ccd-definition/CaseTypeTab.json
+++ b/ccd-definition/CaseTypeTab.json
@@ -218,5 +218,15 @@
     "TabDisplayOrder": 4,
     "CaseFieldID": "submittedForm",
     "TabFieldDisplayOrder": 7
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "Shared_Storage_DRAFTType",
+    "Channel": "CaseWorker",
+    "TabID": "EvidenceTab",
+    "TabLabel": "Evidence",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "standardDirections",
+    "TabFieldDisplayOrder": 8
   }
 ]

--- a/ccd-definition/ComplexTypes.json
+++ b/ccd-definition/ComplexTypes.json
@@ -1278,5 +1278,14 @@
     "FieldType": "TextArea",
     "ElementLabel": "Directions and interim orders, if needed",
     "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "StandardDirections",
+    "ListElementCode": "standardDirectionsDocument",
+    "FieldType": "Document",
+    "ElementLabel": "Upload a file",
+    "SecurityClassification": "Public"
   }
+
 ]

--- a/e2e/config.js
+++ b/e2e/config.js
@@ -34,6 +34,7 @@ module.exports = {
     submitCase: 'Submit application',
   },
   addFamilyManCaseNumber: 'Add case number',
+  standardDirections: 'Standard directions',
   // files
   testFile: './e2e/fixtures/mockFile.txt',
   // urls

--- a/e2e/pages/uploadDocuments/uploadDocuments.js
+++ b/e2e/pages/uploadDocuments/uploadDocuments.js
@@ -9,6 +9,7 @@ module.exports = {
     carePlan: '#documents_socialWorkCarePlan_document_typeOfDocument',
     otherDocuments_1: '#documents_socialWorkOther_0_typeOfDocument',
     otherDocuments_2: '#documents_socialWorkOther_1_typeOfDocument',
+    standardDirections: '#standardDirections_standardDirectionsDocument',
   },
 
   fields: {
@@ -48,5 +49,9 @@ module.exports = {
   selectSocialWorkChronologyToFollow() {
     I.selectOption(this.fields.socialWorkChronologyStatus, 'To follow');
     I.fillField(this.fields.socialWorkChronologyReason, 'mock reason');
+  },
+
+  uploadStandardDirections(file) {
+    I.attachFile(this.documents.standardDirections, file);
   },
 };

--- a/e2e/paths/uploadStandardDirections_test.js
+++ b/e2e/paths/uploadStandardDirections_test.js
@@ -1,0 +1,35 @@
+const config = require('../config.js');
+
+let caseId;
+
+Feature('HMCTS admin upload standard directions');
+
+Before(async (I, caseViewPage, loginPage) => {
+  I.logInAndCreateCase(config.swanseaLocalAuthorityEmailUserOne, config.localAuthorityPassword);
+  caseId = await I.grabTextFrom('.heading-medium');
+  caseViewPage.goToNewActions(config.applicationActions.submitCase);
+  I.click('Submit');
+  I.signOut();
+  loginPage.signIn(config.hmctsAdminEmail, config.hmctsAdminPassword);
+  I.navigateToCaseDetails(caseId);
+});
+
+Scenario('HMCTS admin upload standard directions and see them in evidence tab', (I, caseViewPage, uploadDocumentsPage) => {
+  caseViewPage.goToNewActions(config.standardDirections);
+  uploadDocumentsPage.uploadStandardDirections(config.testFile);
+  I.continueAndSubmit();
+  I.seeEventSubmissionConfirmation(config.standardDirections);
+  caseViewPage.selectTab(caseViewPage.tabs.evidence);
+  I.see('mockFile.txt');
+});
+
+Scenario('Local authority can see standard directions in evidence tab', (I, caseViewPage, uploadDocumentsPage, loginPage) => {
+  caseViewPage.goToNewActions(config.standardDirections);
+  uploadDocumentsPage.uploadStandardDirections(config.testFile);
+  I.continueAndSubmit();
+  I.signOut();
+  loginPage.signIn(config.swanseaLocalAuthorityEmailUserOne, config.localAuthorityPassword);
+  I.navigateToCaseDetails(caseId);
+  caseViewPage.selectTab(caseViewPage.tabs.evidence);
+  I.see('mockFile.txt');
+});

--- a/kubernetes/configurer/configure-ccd.sh
+++ b/kubernetes/configurer/configure-ccd.sh
@@ -12,7 +12,7 @@ ${dir}/utils/idam-create-caseworker.sh james@swansea.gov.uk caseworker,caseworke
 ${dir}/utils/idam-create-caseworker.sh sam@hillingdon.gov.uk caseworker,caseworker-publiclaw,caseworker-publiclaw-solicitor "(local-authority)"
 ${dir}/utils/idam-create-caseworker.sh siva@hillingdon.gov.uk caseworker,caseworker-publiclaw,caseworker-publiclaw-solicitor "(local-authority)"
 ${dir}/utils/idam-create-caseworker.sh hmcts-admin@example.com caseworker,caseworker-publiclaw,caseworker-publiclaw-courtadmin "(hmcts-admin)"
-${dir}/utils/idam-create-caseworker.sh cafcass@example.com caseworker,caseworker-publiclaw,caseworker-publiclaw-cafcass "(caffcass)"
+${dir}/utils/idam-create-caseworker.sh cafcass@example.com caseworker,caseworker-publiclaw,caseworker-publiclaw-cafcass "(cafcass)"
 ${dir}/utils/ccd-add-role.sh caseworker-publiclaw-solicitor
 ${dir}/utils/ccd-add-role.sh caseworker-publiclaw-courtadmin
 ${dir}/utils/ccd-add-role.sh caseworker-publiclaw-cafcass


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FPL-329

### Change description ###
FPL-329: added the functionality for HMCTS to upload standard directions to a submitted case, LA and cafcass can see this in the evidence tab too


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
