### PR TITLE
Fix E2E tests issue caused by stateful page objects

### DIFF
--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -29,7 +29,7 @@ exports.config = {
       show: process.env.SHOW_BROWSER_WINDOW || false,
       restart: true,
       waitForNavigation: 'networkidle0',
-      waitForTimeout: 30000,
+      waitForTimeout: 15000,
       chrome: {
         ignoreHTTPSErrors: true,
         args: process.env.PROXY_SERVER ? [
@@ -90,7 +90,7 @@ exports.config = {
     },
   },
   tests: './e2e/paths/*_test.js',
-  timeout: 30000,
+  timeout: 15000,
   mocha: {
     reporterOptions: {
       'codeceptjs-cli-reporter': {

--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -49,17 +49,27 @@ exports.config = {
     ordersNeededPage: './e2e/pages/ordersNeeded/ordersNeeded.js',
     enterFamilyManPage: './e2e/pages/enterFamilyMan/enterFamilyMan.js',
     changeCaseNamePage: './e2e/pages/changeCaseName/changeCaseName.js',
-    submitApplicationPage: './e2e/pages/submitApplication/submitApplication.js'
+    submitApplicationPage: './e2e/pages/submitApplication/submitApplication.js',
   },
   plugins: {
     autoDelay: {
       enabled: true,
+      methods: [
+        'click',
+        'doubleClick',
+        'rightClick',
+        'fillField',
+        'pressKey',
+        'checkOption',
+        'selectOption',
+      ],
     },
     retryFailedStep: {
       enabled: true,
     },
     screenshotOnFail: {
       enabled: true,
+      fullPageScreenshots: true,
     },
   },
   tests: './e2e/paths/*_test.js',

--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -1,4 +1,21 @@
-/* global process */
+/* global require, process */
+const _ = require('lodash');
+
+const container = require('codeceptjs').container;
+
+container.support = new Proxy(container.support, {
+  /**
+   * Handler that makes deep clone of registered support objects declared via `include` configuration property.
+   *
+   * @param target
+   * @param thisArg
+   * @param argumentsList
+   * @returns {*}
+   */
+  apply(target, thisArg, argumentsList) {
+    return _.cloneDeep(target.apply(thisArg, argumentsList));
+  },
+});
 
 exports.config = {
   output: './output',

--- a/e2e/fragments/addressPostcodeLookup.js
+++ b/e2e/fragments/addressPostcodeLookup.js
@@ -19,10 +19,11 @@ module.exports = {
   },
   findAddressButton: 'Find address',
   cantEnterPostcodeLink: locate('span').withText('I can\'t enter a UK postcode'),
-  
+
   lookupPostcode(address) {
     I.fillField(this.fields.postcodeLookup, address.postcode);
     I.click(this.findAddressButton);
+    I.waitForElement(locate(this.fields.addressList).find('option').withText(address.lookupOption));
     I.selectOption(this.fields.addressList, address.lookupOption);
   },
 

--- a/e2e/pages/enterChildren/enterChildren.js
+++ b/e2e/pages/enterChildren/enterChildren.js
@@ -1,5 +1,6 @@
 const I = actor();
 const postcodeLookup = require('../../fragments/addressPostcodeLookup');
+
 let activeChild = 'firstChild';
 
 module.exports = {
@@ -48,6 +49,7 @@ module.exports = {
 
   enterChildDetails(name, day, month, year, gender = 'Boy') {
     I.fillField(this.fields(activeChild).fullName, name);
+    I.click(this.fields(activeChild).DOB.day);
     I.fillField(this.fields(activeChild).DOB.day, day);
     I.fillField(this.fields(activeChild).DOB.month, month);
     I.fillField(this.fields(activeChild).DOB.year, year);

--- a/e2e/pages/enterChildren/enterChildren.js
+++ b/e2e/pages/enterChildren/enterChildren.js
@@ -1,11 +1,14 @@
 const I = actor();
 const postcodeLookup = require('../../fragments/addressPostcodeLookup');
 
-let activeChild = 'firstChild';
-
 module.exports = {
-
-  fields: (childNo) => {
+  state: {
+    context: 'firstChild',
+  },
+  
+  fields: function() {
+    const childNo = this.state.context;
+    
     return {
       fullName: `#children_${childNo}_childName`,
       DOB: {
@@ -39,68 +42,68 @@ module.exports = {
   addChildButton: 'Add new',
 
   addChild() {
-    if (activeChild === 'additionalChildren_0') {
+    if (this.state.context === 'additionalChildren_0') {
       throw new Error('Adding more children is not supported in the test');
     }
 
     I.click(this.addChildButton);
-    activeChild = 'additionalChildren_0';
+    this.state.context = 'additionalChildren_0';
   },
 
   enterChildDetails(name, day, month, year, gender = 'Boy') {
-    I.fillField(this.fields(activeChild).fullName, name);
-    I.click(this.fields(activeChild).DOB.day);
-    I.fillField(this.fields(activeChild).DOB.day, day);
-    I.fillField(this.fields(activeChild).DOB.month, month);
-    I.fillField(this.fields(activeChild).DOB.year, year);
-    I.selectOption(this.fields(activeChild).gender, gender);
+    I.fillField(this.fields().fullName, name);
+    I.click(this.fields().DOB.day);
+    I.fillField(this.fields().DOB.day, day);
+    I.fillField(this.fields().DOB.month, month);
+    I.fillField(this.fields().DOB.year, year);
+    I.selectOption(this.fields().gender, gender);
   },
 
   defineChildSituation(day, month, year, situation = 'Living with respondents') {
-    I.selectOption(this.fields(activeChild).situation.selector, situation);
-    I.fillField(this.fields(activeChild).situation.dateStartedStaying.day, day);
-    I.fillField(this.fields(activeChild).situation.dateStartedStaying.month, month);
-    I.fillField(this.fields(activeChild).situation.dateStartedStaying.year, year);
+    I.selectOption(this.fields().situation.selector, situation);
+    I.fillField(this.fields().situation.dateStartedStaying.day, day);
+    I.fillField(this.fields().situation.dateStartedStaying.month, month);
+    I.fillField(this.fields().situation.dateStartedStaying.year, year);
   },
 
   enterAddress(address) {
-    within(this.fields(activeChild).situation.addressOfChild, () => {
+    within(this.fields().situation.addressOfChild, () => {
       postcodeLookup.lookupPostcode(address);
     });
   },
 
   enterKeyDatesAffectingHearing(keyDates = 'Tuesday the 11th') {
-    I.fillField(this.fields(activeChild).keyDates, keyDates);
+    I.fillField(this.fields().keyDates, keyDates);
   },
 
   enterSummaryOfCarePlan(carePlan = 'care plan summary') {
-    I.fillField(this.fields(activeChild).careAndContactPlan, carePlan);
+    I.fillField(this.fields().careAndContactPlan, carePlan);
   },
 
   defineAdoptionIntention() {
-    I.click(this.fields(activeChild).adoptionNo);
+    I.click(this.fields().adoptionNo);
   },
 
   enterParentsDetails(fatherResponsible = 'Yes', motherName = 'Laura Smith', fatherName = 'David Smith') {
-    I.fillField(this.fields(activeChild).mothersName, motherName);
-    I.fillField(this.fields(activeChild).fathersName, fatherName);
-    I.selectOption(this.fields(activeChild).fatherResponsible, fatherResponsible);
+    I.fillField(this.fields().mothersName, motherName);
+    I.fillField(this.fields().fathersName, fatherName);
+    I.selectOption(this.fields().fatherResponsible, fatherResponsible);
   },
 
   enterSocialWorkerDetails(socialWorkerName = 'James Jackson', socialWorkerTel = '01234567') {
-    I.fillField(this.fields(activeChild).socialWorkerName, socialWorkerName);
-    I.fillField(this.fields(activeChild).socialWorkerTel, socialWorkerTel);
+    I.fillField(this.fields().socialWorkerName, socialWorkerName);
+    I.fillField(this.fields().socialWorkerTel, socialWorkerTel);
   },
 
   defineChildAdditionalNeeds() {
-    I.click(this.fields(activeChild).additionalNeedsNo);
+    I.click(this.fields().additionalNeedsNo);
   },
 
   defineContactDetailsVisibility() {
-    I.click(this.fields(activeChild).contactHiddenNo);
+    I.click(this.fields().contactHiddenNo);
   },
 
   defineAbilityToTakePartInProceedings() {
-    I.click(this.fields(activeChild).litigationNo);
+    I.click(this.fields().litigationNo);
   },
 };

--- a/e2e/pages/enterOthers/enterOthers.js
+++ b/e2e/pages/enterOthers/enterOthers.js
@@ -1,10 +1,14 @@
 const I = actor();
 const postcodeLookup = require('../../fragments/addressPostcodeLookup');
-let activeOther = 'firstOther';
 
 module.exports = {
+  state: {
+    context: 'firstOther',
+  },
 
-  fields: (otherNo) => {
+  fields: function () {
+    const otherNo = this.state.context;
+    
     return {
       name: `#others_${otherNo}_name`,
       DOB: {
@@ -35,43 +39,43 @@ module.exports = {
   addOtherButton: 'Add new',
 
   addOther() {
-    if (activeOther === 'additionalOthers_0') {
+    if (this.state.context === 'additionalOthers_0') {
       throw new Error('Adding additional others is not supported in the test');
     }
 
     I.click(this.addOtherButton);
-    activeOther = 'additionalOthers_0';
+    this.state.context = 'additionalOthers_0';
   },
 
   enterOtherDetails(other) {
-    I.waitForElement(this.fields(activeOther).name);
-    I.fillField(this.fields(activeOther).name, other.name);
-    I.fillField(this.fields(activeOther).DOB.day, other.DOB.day);
-    I.fillField(this.fields(activeOther).DOB.month, other.DOB.month);
-    I.fillField(this.fields(activeOther).DOB.year, other.DOB.year);
-    I.selectOption(this.fields(activeOther).gender, other.gender);
-    I.fillField(this.fields(activeOther).birthPlace, other.birthPlace);
-    within(this.fields(activeOther).address, () => {
+    I.fillField(this.fields().name, other.name);
+    I.click(this.fields().DOB.day);
+    I.fillField(this.fields().DOB.day, other.DOB.day);
+    I.fillField(this.fields().DOB.month, other.DOB.month);
+    I.fillField(this.fields().DOB.year, other.DOB.year);
+    I.selectOption(this.fields().gender, other.gender);
+    I.fillField(this.fields().birthPlace, other.birthPlace);
+    within(this.fields().address, () => {
       postcodeLookup.lookupPostcode(other.address);
     });
-    I.fillField(this.fields(activeOther).telephoneNumber, other.telephoneNumber);
+    I.fillField(this.fields().telephoneNumber, other.telephoneNumber);
   },
 
   enterRelationshipToChild(childInformation) {
-    I.fillField(this.fields(activeOther).relationshipToChild, childInformation);
+    I.fillField(this.fields().relationshipToChild, childInformation);
   },
 
   enterContactDetailsHidden(option) {
-    I.click(this.fields(activeOther).detailsHidden(option).option);
+    I.click(this.fields().detailsHidden(option).option);
     if (option === 'Yes') {
-      I.fillField(this.fields(activeOther).detailsHidden(option).reason, 'mock reason');
+      I.fillField(this.fields().detailsHidden(option).reason, 'mock reason');
     }
   },
 
   enterLitigationIssues(option) {
-    I.click(this.fields(activeOther).litigationIssues(option).option);
+    I.click(this.fields().litigationIssues(option).option);
     if (option === 'Yes') {
-      I.fillField(this.fields(activeOther).litigationIssues(option).reason, 'mock reason');
+      I.fillField(this.fields().litigationIssues(option).reason, 'mock reason');
     }
   },
 };

--- a/e2e/pages/enterRiskAndHarmToChild/enterRiskAndHarmToChild.js
+++ b/e2e/pages/enterRiskAndHarmToChild/enterRiskAndHarmToChild.js
@@ -18,7 +18,7 @@ module.exports = {
     },
   },
 
-  completePhyiscalHarm() {
+  completePhysicalHarm() {
     I.click(this.fields.physicalHarm.yes);
     I.checkOption(this.fields.physicalHarm.pastHarm);
   },

--- a/e2e/paths/enterChildren_test.js
+++ b/e2e/paths/enterChildren_test.js
@@ -1,4 +1,5 @@
 const config = require('../config.js');
+
 const addresses = [
   {
     lookupOption: 'Flat 2, Caversham House 15-17, Church Road, Reading',

--- a/e2e/paths/enterRiskAndHarmToChild_test.js
+++ b/e2e/paths/enterRiskAndHarmToChild_test.js
@@ -9,7 +9,7 @@ Before((I, caseViewPage) => {
 
 Scenario('complete half of the enter risk and harm to children in the c110a' +
   ' application', (I, enterRiskAndHarmToChildPage, caseViewPage) => {
-  enterRiskAndHarmToChildPage.completePhyiscalHarm();
+  enterRiskAndHarmToChildPage.completePhysicalHarm();
   enterRiskAndHarmToChildPage.completeEmotionalHarm();
   I.continueAndSubmit();
   I.seeEventSubmissionConfirmation(config.applicationActions.enterRisk);
@@ -22,7 +22,7 @@ Scenario('complete half of the enter risk and harm to children in the c110a' +
 
 Scenario('complete entering risk and harm to children in the c110a' +
   ' application', (I, enterRiskAndHarmToChildPage, caseViewPage) => {
-  enterRiskAndHarmToChildPage.completePhyiscalHarm();
+  enterRiskAndHarmToChildPage.completePhysicalHarm();
   enterRiskAndHarmToChildPage.completeEmotionalHarm();
   enterRiskAndHarmToChildPage.completeSexualAbuse();
   enterRiskAndHarmToChildPage.completeNeglect();


### PR DESCRIPTION
### JIRA link (if applicable) ###

None

### Change description ###

This PR changes the way state in page objects is handled. From now on state will is kept inside of the page object and when page object is injected into test scenario a deep clone is performed to get initial state.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
