### PR TITLE
FPL-180: Repurposing event summary page

### DIFF
--- a/ccd-definition/CaseEvent.json
+++ b/ccd-definition/CaseEvent.json
@@ -250,6 +250,8 @@
     "PreConditionState(s)": "Submitted",
     "PostConditionState": "Submitted",
     "SecurityClassification": "Public",
+    "ShowSummary": "N",
+    "ShowEventNotes": "N",
     "EndButtonLabel": "Save and continue"    
   },
   {
@@ -262,6 +264,8 @@
     "PreConditionState(s)": "Submitted",
     "PostConditionState": "Submitted",
     "SecurityClassification": "Public",
+    "ShowSummary": "N",
+    "ShowEventNotes": "N",
     "EndButtonLabel": "Save and continue"    
   }
 ]

--- a/ccd-definition/CaseEvent.json
+++ b/ccd-definition/CaseEvent.json
@@ -11,7 +11,8 @@
     "CallBackURLAboutToSubmitEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/case-initiation/about-to-submit",
     "RetriesTimeoutURLAboutToSubmitEvent": "1,2,3,4,5",
     "CallBackURLSubmittedEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/case-initiation/submitted",
-    "RetriesTimeoutURLSubmittedEvent": "1,2,3,4,5"
+    "RetriesTimeoutURLSubmittedEvent": "1,2,3,4,5",
+    "EndButtonLabel": "Save and continue"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -22,7 +23,8 @@
     "DisplayOrder": 2,
     "PreConditionState(s)": "Open",
     "PostConditionState": "Open",
-    "SecurityClassification": "Public"
+    "SecurityClassification": "Public",
+    "EndButtonLabel": "Save and continue"    
   },
   {
     "LiveFrom": "01/01/2017",
@@ -33,7 +35,8 @@
     "DisplayOrder": 3,
     "PreConditionState(s)": "Open",
     "PostConditionState": "Open",
-    "SecurityClassification": "Public"
+    "SecurityClassification": "Public",
+    "EndButtonLabel": "Save and continue"    
   },
   {
     "LiveFrom": "01/01/2017",
@@ -44,7 +47,8 @@
     "DisplayOrder": 4,
     "PreConditionState(s)": "Open",
     "PostConditionState": "Open",
-    "SecurityClassification": "Public"
+    "SecurityClassification": "Public",
+    "EndButtonLabel": "Save and continue"    
   },
   {
     "LiveFrom": "01/01/2017",
@@ -55,7 +59,8 @@
     "DisplayOrder": 5,
     "PreConditionState(s)": "Open",
     "PostConditionState": "Open",
-    "SecurityClassification": "Public"
+    "SecurityClassification": "Public",
+    "EndButtonLabel": "Save and continue"    
   },
   {
     "LiveFrom": "01/01/2017",
@@ -66,7 +71,8 @@
     "DisplayOrder": 6,
     "PreConditionState(s)": "Open",
     "PostConditionState": "Open",
-    "SecurityClassification": "Public"
+    "SecurityClassification": "Public",
+    "EndButtonLabel": "Save and continue"    
   },
   {
     "LiveFrom": "01/01/2017",
@@ -77,7 +83,8 @@
     "DisplayOrder": 7,
     "PreConditionState(s)": "Open",
     "PostConditionState": "Open",
-    "SecurityClassification": "Public"
+    "SecurityClassification": "Public",
+    "EndButtonLabel": "Save and continue"    
   },
   {
     "LiveFrom": "01/01/2017",
@@ -88,7 +95,8 @@
     "DisplayOrder": 8,
     "PreConditionState(s)": "Open",
     "PostConditionState": "Open",
-    "SecurityClassification": "Public"
+    "SecurityClassification": "Public",
+    "EndButtonLabel": "Save and continue"    
   },
   {
     "LiveFrom": "01/01/2017",
@@ -99,7 +107,8 @@
     "DisplayOrder": 9,
     "PreConditionState(s)": "Open",
     "PostConditionState": "Open",
-    "SecurityClassification": "Public"
+    "SecurityClassification": "Public",
+    "EndButtonLabel": "Save and continue"    
   },
   {
     "LiveFrom": "01/01/2017",
@@ -110,7 +119,8 @@
     "DisplayOrder": 10,
     "PreConditionState(s)": "Open",
     "PostConditionState": "Open",
-    "SecurityClassification": "Public"
+    "SecurityClassification": "Public",
+    "EndButtonLabel": "Save and continue"    
   },
   {
     "LiveFrom": "01/01/2017",
@@ -121,7 +131,8 @@
     "DisplayOrder": 11,
     "PreConditionState(s)": "Open",
     "PostConditionState": "Open",
-    "SecurityClassification": "Public"
+    "SecurityClassification": "Public",
+    "EndButtonLabel": "Save and continue"    
   },
   {
     "LiveFrom": "01/01/2017",
@@ -132,7 +143,8 @@
     "DisplayOrder": 12,
     "PreConditionState(s)": "Open",
     "PostConditionState": "Open",
-    "SecurityClassification": "Public"
+    "SecurityClassification": "Public",
+    "EndButtonLabel": "Save and continue"    
   },
   {
     "LiveFrom": "01/01/2017",
@@ -143,7 +155,8 @@
     "DisplayOrder": 13,
     "PreConditionState(s)": "Open",
     "PostConditionState": "Open",
-    "SecurityClassification": "Public"
+    "SecurityClassification": "Public",
+    "EndButtonLabel": "Save and continue"    
   },
   {
     "LiveFrom": "01/01/2017",
@@ -154,7 +167,8 @@
     "DisplayOrder": 13,
     "PreConditionState(s)": "Open",
     "PostConditionState": "Open",
-    "SecurityClassification": "Public"
+    "SecurityClassification": "Public",
+    "EndButtonLabel": "Save and continue"    
   },
   {
     "LiveFrom": "01/01/2017",
@@ -165,7 +179,8 @@
     "DisplayOrder": 14,
     "PreConditionState(s)": "Open;Submitted",
     "PostConditionState": "Open",
-    "SecurityClassification": "Public"
+    "SecurityClassification": "Public",
+    "EndButtonLabel": "Save and continue"    
   },
   {
     "LiveFrom": "01/01/2017",
@@ -177,7 +192,8 @@
     "PreConditionState(s)": "Open",
     "PostConditionState": "Open",
     "SecurityClassification": "Public",
-    "ShowSummary": "N"
+    "ShowSummary": "N",
+    "EndButtonLabel": "Save and continue"    
   },
   {
     "LiveFrom": "01/01/2017",
@@ -189,7 +205,8 @@
     "PreConditionState(s)": "Open",
     "PostConditionState": "Open",
     "SecurityClassification": "Public",
-    "ShowSummary": "N"
+    "ShowSummary": "N",
+    "EndButtonLabel": "Save and continue"    
   },
   {
     "LiveFrom": "01/01/2017",
@@ -206,7 +223,8 @@
     "CallBackURLAboutToStartEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/case-submission/about-to-start",
     "RetriesTimeoutAboutToStartEvent": "1,2,3,4,5",
     "CallBackURLSubmittedEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/case-submission/submitted",
-    "RetriesTimeoutURLSubmittedEvent": "1,2,3,4,5"
+    "RetriesTimeoutURLSubmittedEvent": "1,2,3,4,5",
+    "EndButtonLabel": "Submit"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -219,7 +237,8 @@
     "PostConditionState": "Submitted",
     "SecurityClassification": "Public",
     "ShowSummary": "N",
-    "ShowEventNotes": "N"
+    "ShowEventNotes": "N",
+    "EndButtonLabel": "Save and continue"    
   },
   {
     "LiveFrom": "01/01/2017",
@@ -230,7 +249,8 @@
     "DisplayOrder": 1,
     "PreConditionState(s)": "Submitted",
     "PostConditionState": "Submitted",
-    "SecurityClassification": "Public"
+    "SecurityClassification": "Public",
+    "EndButtonLabel": "Save and continue"    
   },
   {
     "LiveFrom": "01/01/2017",
@@ -241,6 +261,7 @@
     "DisplayOrder": 1,
     "PreConditionState(s)": "Submitted",
     "PostConditionState": "Submitted",
-    "SecurityClassification": "Public"
+    "SecurityClassification": "Public",
+    "EndButtonLabel": "Save and continue"    
   }
 ]

--- a/ccd-definition/CaseEvent.json
+++ b/ccd-definition/CaseEvent.json
@@ -12,6 +12,8 @@
     "RetriesTimeoutURLAboutToSubmitEvent": "1,2,3,4,5",
     "CallBackURLSubmittedEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/case-initiation/submitted",
     "RetriesTimeoutURLSubmittedEvent": "1,2,3,4,5",
+    "ShowSummary": "N",
+    "ShowEventNotes": "N",
     "EndButtonLabel": "Save and continue"
   },
   {
@@ -24,6 +26,8 @@
     "PreConditionState(s)": "Open",
     "PostConditionState": "Open",
     "SecurityClassification": "Public",
+    "ShowSummary": "N",
+    "ShowEventNotes": "N",
     "EndButtonLabel": "Save and continue"    
   },
   {
@@ -36,6 +40,8 @@
     "PreConditionState(s)": "Open",
     "PostConditionState": "Open",
     "SecurityClassification": "Public",
+    "ShowSummary": "N",
+    "ShowEventNotes": "N",
     "EndButtonLabel": "Save and continue"    
   },
   {
@@ -48,6 +54,8 @@
     "PreConditionState(s)": "Open",
     "PostConditionState": "Open",
     "SecurityClassification": "Public",
+    "ShowSummary": "N",
+    "ShowEventNotes": "N",
     "EndButtonLabel": "Save and continue"    
   },
   {
@@ -60,6 +68,8 @@
     "PreConditionState(s)": "Open",
     "PostConditionState": "Open",
     "SecurityClassification": "Public",
+    "ShowSummary": "N",
+    "ShowEventNotes": "N",
     "EndButtonLabel": "Save and continue"    
   },
   {
@@ -72,6 +82,8 @@
     "PreConditionState(s)": "Open",
     "PostConditionState": "Open",
     "SecurityClassification": "Public",
+    "ShowSummary": "N",
+    "ShowEventNotes": "N",
     "EndButtonLabel": "Save and continue"    
   },
   {
@@ -84,6 +96,8 @@
     "PreConditionState(s)": "Open",
     "PostConditionState": "Open",
     "SecurityClassification": "Public",
+    "ShowSummary": "N",
+    "ShowEventNotes": "N",
     "EndButtonLabel": "Save and continue"    
   },
   {
@@ -96,6 +110,8 @@
     "PreConditionState(s)": "Open",
     "PostConditionState": "Open",
     "SecurityClassification": "Public",
+    "ShowSummary": "N",
+    "ShowEventNotes": "N",
     "EndButtonLabel": "Save and continue"    
   },
   {
@@ -108,6 +124,8 @@
     "PreConditionState(s)": "Open",
     "PostConditionState": "Open",
     "SecurityClassification": "Public",
+    "ShowSummary": "N",
+    "ShowEventNotes": "N",
     "EndButtonLabel": "Save and continue"    
   },
   {
@@ -120,6 +138,8 @@
     "PreConditionState(s)": "Open",
     "PostConditionState": "Open",
     "SecurityClassification": "Public",
+    "ShowSummary": "N",
+    "ShowEventNotes": "N",
     "EndButtonLabel": "Save and continue"    
   },
   {
@@ -132,6 +152,8 @@
     "PreConditionState(s)": "Open",
     "PostConditionState": "Open",
     "SecurityClassification": "Public",
+    "ShowSummary": "N",
+    "ShowEventNotes": "N",
     "EndButtonLabel": "Save and continue"    
   },
   {
@@ -144,6 +166,8 @@
     "PreConditionState(s)": "Open",
     "PostConditionState": "Open",
     "SecurityClassification": "Public",
+    "ShowSummary": "N",
+    "ShowEventNotes": "N",
     "EndButtonLabel": "Save and continue"    
   },
   {
@@ -156,6 +180,8 @@
     "PreConditionState(s)": "Open",
     "PostConditionState": "Open",
     "SecurityClassification": "Public",
+    "ShowSummary": "N",
+    "ShowEventNotes": "N",
     "EndButtonLabel": "Save and continue"    
   },
   {
@@ -168,6 +194,8 @@
     "PreConditionState(s)": "Open",
     "PostConditionState": "Open",
     "SecurityClassification": "Public",
+    "ShowSummary": "N",
+    "ShowEventNotes": "N",
     "EndButtonLabel": "Save and continue"    
   },
   {
@@ -180,6 +208,8 @@
     "PreConditionState(s)": "Open;Submitted",
     "PostConditionState": "Open",
     "SecurityClassification": "Public",
+    "ShowSummary": "N",
+    "ShowEventNotes": "N", 
     "EndButtonLabel": "Save and continue"    
   },
   {
@@ -193,6 +223,7 @@
     "PostConditionState": "Open",
     "SecurityClassification": "Public",
     "ShowSummary": "N",
+    "ShowEventNotes": "N",    
     "EndButtonLabel": "Save and continue"    
   },
   {
@@ -206,6 +237,7 @@
     "PostConditionState": "Open",
     "SecurityClassification": "Public",
     "ShowSummary": "N",
+    "ShowEventNotes": "N",    
     "EndButtonLabel": "Save and continue"    
   },
   {
@@ -218,12 +250,12 @@
     "PreConditionState(s)": "Open",
     "PostConditionState": "Submitted",
     "SecurityClassification": "Public",
-    "ShowSummary": "N",
-    "ShowEventNotes": "N",
     "CallBackURLAboutToStartEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/case-submission/about-to-start",
     "RetriesTimeoutAboutToStartEvent": "1,2,3,4,5",
     "CallBackURLSubmittedEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/case-submission/submitted",
     "RetriesTimeoutURLSubmittedEvent": "1,2,3,4,5",
+    "ShowSummary": "N",
+    "ShowEventNotes": "N",
     "EndButtonLabel": "Submit"
   },
   {

--- a/e2e/pages/createCase/addEventSummary.js
+++ b/e2e/pages/createCase/addEventSummary.js
@@ -2,7 +2,7 @@ const I = actor();
 
 module.exports = {
 
-  submitButton: 'Submit',
+  submitButton: 'Save and continue',
 
   submitCase() {
     I.click(this.submitButton);

--- a/e2e/paths/uploadStandardDirections_test.js
+++ b/e2e/paths/uploadStandardDirections_test.js
@@ -20,7 +20,7 @@ Scenario('HMCTS admin upload standard directions and see them in evidence tab', 
   caseViewPage.goToNewActions(config.standardDirections);
   uploadDocumentsPage.uploadStandardDirections(config.testFile);
   I.click('Continue');
-  I.click('Submit');
+  I.click('Save and continue');
   I.seeEventSubmissionConfirmation(config.standardDirections);
   caseViewPage.selectTab(caseViewPage.tabs.evidence);
   I.see('mockFile.txt');
@@ -30,7 +30,7 @@ Scenario('Local authority can see standard directions in evidence tab', (I, case
   caseViewPage.goToNewActions(config.standardDirections);
   uploadDocumentsPage.uploadStandardDirections(config.testFile);
   I.click('Continue');
-  I.click('Submit');
+  I.click('Save and continue');
   I.signOut();
   loginPage.signIn(config.swanseaLocalAuthorityEmailUserOne, config.localAuthorityPassword);
   I.navigateToCaseDetails(caseId);


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FPL-180


### Change description ###
Removed all cases of event summary description
All case events, excluding submit case now have an end button label of 'Save and continue' 
Submit case end button label reads 'Submit'
Updated e2e tests to support updated event summary button

![screen shot 2018-12-17 at 11 45 22](https://user-images.githubusercontent.com/4429628/50085249-65e89c00-01f1-11e9-8500-ee8eea2b46ff.png)
![screen shot 2018-12-17 at 11 45 41](https://user-images.githubusercontent.com/4429628/50085250-65e89c00-01f1-11e9-9d9e-d639818e0d5c.png)
![screen shot 2018-12-17 at 11 46 00](https://user-images.githubusercontent.com/4429628/50085251-65e89c00-01f1-11e9-8a1f-0d02be159dcc.png)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
