### PR TITLE
Stop returning ResponseEntity from controller methods

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/CaseInitiationController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/CaseInitiationController.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.fpl.controllers;
 import io.swagger.annotations.Api;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -34,7 +33,7 @@ public class CaseInitiationController {
     }
 
     @PostMapping("/about-to-submit")
-    public ResponseEntity handleAboutToSubmitEvent(
+    public AboutToStartOrSubmitCallbackResponse handleAboutToSubmitEvent(
         @RequestHeader(value = "authorization") String authorization,
         @RequestBody CallbackRequest callbackrequest) {
         String caseLocalAuthority = localAuthorityNameService.getLocalAuthorityCode(authorization);
@@ -43,11 +42,9 @@ public class CaseInitiationController {
         Map<String, Object> data = caseDetails.getData();
         data.put("caseLocalAuthority", caseLocalAuthority);
 
-        AboutToStartOrSubmitCallbackResponse body = AboutToStartOrSubmitCallbackResponse.builder()
+        return AboutToStartOrSubmitCallbackResponse.builder()
             .data(data)
             .build();
-
-        return ResponseEntity.ok(body);
     }
 
     @PostMapping("/submitted")

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/CaseSubmissionController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/CaseSubmissionController.java
@@ -35,7 +35,7 @@ public class CaseSubmissionController {
     }
 
     @PostMapping("/about-to-start")
-    public AboutToStartOrSubmitCallbackResponse handleAboutToSubmitEvent(
+    public AboutToStartOrSubmitCallbackResponse handleAboutToStartEvent(
         @RequestHeader(value = "authorization") String authorization,
         @RequestBody CallbackRequest callbackrequest) {
         CaseDetails caseDetails = callbackrequest.getCaseDetails();

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/CaseSubmissionController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/CaseSubmissionController.java
@@ -3,8 +3,6 @@ package uk.gov.hmcts.reform.fpl.controllers;
 import io.swagger.annotations.Api;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -37,7 +35,7 @@ public class CaseSubmissionController {
     }
 
     @PostMapping("/about-to-start")
-    public AboutToStartOrSubmitCallbackResponse handleCaseStart(
+    public AboutToStartOrSubmitCallbackResponse handleAboutToSubmitEvent(
         @RequestHeader(value = "authorization") String authorization,
         @RequestBody CallbackRequest callbackrequest) {
         CaseDetails caseDetails = callbackrequest.getCaseDetails();
@@ -53,13 +51,11 @@ public class CaseSubmissionController {
     }
 
     @PostMapping("/submitted")
-    public ResponseEntity handleCaseSubmission(
+    public void handleSubmittedEvent(
         @RequestHeader(value = "authorization") String authorization,
         @RequestHeader(value = "user-id") String userId,
         @RequestBody @NotNull CallbackRequest callbackRequest) {
 
         applicationEventPublisher.publishEvent(new SubmittedCaseEvent(callbackRequest, authorization, userId));
-
-        return new ResponseEntity(HttpStatus.OK);
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/NotifyGatekeeperController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/NotifyGatekeeperController.java
@@ -24,7 +24,7 @@ public class NotifyGatekeeperController {
     }
 
     @PostMapping("/submitted")
-    public void handleSubmitEvent(
+    public void handleSubmittedEvent(
         @RequestHeader(value = "authorization") String authorization,
         @RequestHeader(value = "user-id") String userId,
         @RequestBody CallbackRequest callbackRequest) {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/RootController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/RootController.java
@@ -1,10 +1,7 @@
 package uk.gov.hmcts.reform.fpl.controllers;
 
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import static org.springframework.http.ResponseEntity.ok;
 
 /**
  * Default endpoints per application.
@@ -22,7 +19,7 @@ public class RootController {
      * @return Welcome message from the service.
      */
     @GetMapping("/")
-    public ResponseEntity<String> welcome() {
-        return ok("Welcome to fpl-service");
+    public String welcome() {
+        return "Welcome to fpl-service";
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

None

### Change description ###

Stop returning ResponseEntity from controller methods. Returning response itself is easier.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
