### PR TITLE
Downsize instances in non production environments

### DIFF
--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -1,5 +1,3 @@
-capacity = "2"
-
 idam_api_url = "https://preprod-idamapi.reform.hmcts.net:3511"
 
 ccd_ui_base_url = "https://ccd-case-management-web-aat.service.core-compute-aat.internal"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -3,6 +3,9 @@ provider "azurerm" {}
 locals {
   ase_name = "${data.terraform_remote_state.core_apps_compute.ase_name[0]}"
 
+  instance_size = "${var.env == "prod" || var.env == "sprod" || var.env == "aat" ? "I2" : "I1"}"
+  capacity = "${var.env == "prod" || var.env == "sprod" || var.env == "aat" ? 2 : 1}"
+
   local_env = "${(var.env == "preview" || var.env == "spreview") ? (var.env == "preview") ? "aat" : "saat" : var.env}"
   local_ase = "${(var.env == "preview" || var.env == "spreview") ? (var.env == "preview") ? "core-compute-aat" : "core-compute-saat" : local.ase_name}"
 
@@ -67,7 +70,8 @@ module "case-service" {
   env                 = "${var.env}"
   ilbIp               = "${var.ilbIp}"
   subscription        = "${var.subscription}"
-  capacity            = "${var.capacity}"
+  instance_size       = "${local.instance_size}"
+  capacity            = "${local.capacity}"
   common_tags         = "${var.common_tags}"
 
   app_settings = {

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -1,5 +1,3 @@
-capacity = "2"
-
 idam_api_url = "https://idam-api.platform.hmcts.net"
 
 ccd_ui_base_url = "https://www.ccd.platform.hmcts.net"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -24,10 +24,6 @@ variable "env" {
 
 variable "ilbIp" {}
 
-variable "capacity" {
-  default = "1"
-}
-
 variable "common_tags" {
   type = "map"
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

None

### Change description ###

To save cost the following configuration is suggested:

- prod, sprod and aat environments: 2x medium instances
- other environments: 1x small instance

This PR aligns ASP configuration with Programme recommendations.

For more details see: https://github.com/hmcts/cnp-module-webapp

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
