### PR TITLE
Enable and configure GitHub stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,17 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 3
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 4
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  This issue is being closed automatically as it was stale


### PR DESCRIPTION
### JIRA link (if applicable) ###

None

### Change description ###

PR enables stale bot that will mark and close stale PRs to reduce resource usage for piece of work that does not progress.

Copied from: https://github.com/hmcts/cnp-rhubarb-recipes-service/blob/master/.github/stale.yml

Documentation: https://github.com/probot/stale

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```