### PR TITLE
Add missing callback in prod part of the pipeline

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -81,6 +81,16 @@ withPipeline(type, product, component) {
     env.URL = "https://ccd-case-management-web-aat.service.core-compute-aat.internal"
   }
 
+  after('deploy:prod') {
+    env.PROXY_SERVER = "proxyout.reform.hmcts.net:8080"
+
+    env.IDAM_API_BASE_URL = "https://idam-api.platform.hmcts.net"
+    env.SERVICE_AUTH_PROVIDER_API_BASE_URL = "http://rpe-service-auth-provider-prod.service.core-compute-prod.internal"
+    env.CCD_DEFINITION_STORE_API_BASE_URL = "http://ccd-definition-store-api-prod.service.core-compute-prod.internal"
+    env.CCD_USER_PROFILE_API_BASE_URL = "http://ccd-user-profile-api-prod.service.core-compute-prod.internal"
+    env.URL = "https://ccd-case-management-web-prod.service.core-compute-prod.internal"
+  }
+
   after('deploy:demo') {
     env.PROXY_SERVER = "proxyout.reform.hmcts.net:8080"
 
@@ -113,6 +123,14 @@ withPipeline(type, product, component) {
     sh """
       ./kubernetes/configurer/configure-ccd.sh
     """
+  }
+
+  before('smoketest:prod-staging') {
+    env.SKIP_SMOKE_TESTS = 'true'
+  }
+
+  before('smoketest:prod') {
+    env.SKIP_SMOKE_TESTS = 'true'
   }
 
   before('smoketest:demo-staging') {

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -69,6 +69,12 @@ task awaitApplicationReadiness(type: Exec, description: 'Awaits until applicatio
 }
 
 task runSmokeTests(type: Exec, description: 'Runs smoke tests.') {
+  onlyIf(new Spec<Task>() {
+    boolean isSatisfiedBy(Task task) {
+      String skipTestsEnvironmentVariable = System.env.SKIP_SMOKE_TESTS
+      return skipTestsEnvironmentVariable == null || skipTestsEnvironmentVariable == 'false'
+    }
+  })
   commandLine '/usr/bin/yarn', '--silent', 'test:smoke'
 }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

None

### Change description ###

Currently stages that are supported to run smoke tests in production actually runs these against AAT. This PR fixes it by introducing the following changes:
- environment variables are correctly set for prod environments on deployment
- smoke tests against prod (staging) and prod slots are disabled as we have no test user in env

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```