### PR TITLE
Disable AKS builds while paused

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -28,7 +28,7 @@ withPipeline(type, product, component) {
   setVaultName('fpl')
   loadVaultSecrets(secrets)
   enableDockerBuild()
-  enableDeployToAKS()
+//  enableDeployToAKS()
   enableSlackNotifications('#fpl-tech')
 
   env.POSTCODE_PLACEHOLDER = '${postcode}'


### PR DESCRIPTION
FPL builds are taking a lot of CPU requests on AKS, this should be tuned to be less when the project is resumed / migrated over to helm charts.
For now disabling builds so that dependabot PRs don't trigger Kubernetes deployments
