### PR TITLE
Fix: Set CRU permissions to submission consent label to fix application submission

### DIFF
--- a/ccd-definition/AuthorisationCaseField.json
+++ b/ccd-definition/AuthorisationCaseField.json
@@ -214,7 +214,7 @@
     "CaseTypeID": "CARE_SUPERVISION_EPO",
     "CaseFieldID": "submissionConsentLabel",
     "UserRole": "caseworker-publiclaw-solicitor",
-    "CRUD": "R"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

None

### Change description ###

Some change in CCD caused our existing definition to stop working. Read-only label that used to be ignored now for some reason triggers error on submission if there is no WRITE access for it.

As a result of this workaround label will land in case data: :(

```
{
  "caseName": null,
  "submittedForm": {
    "document_url": "http://dm-store:8080/documents/4d457839-6bdd-42ae-8251-5c4bf14e703c",
    "document_filename": "1557497668298113.pdf",
    "document_binary_url": "http://dm-store:8080/documents/4d457839-6bdd-42ae-8251-5c4bf14e703c/binary"
  },
  "submissionConsent": [
    "agree"
  ],
  "submissionConsentLabel": "I, damian@swansea.gov.uk (local-authority), believe that the facts stated in this application are true.",
  "caseLocalAuthority": "SA",
}
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```