### PR TITLE
Make gatekeeper username configurable in E2E tests

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -128,21 +128,23 @@ withPipeline(type, product, component) {
 //  Temporarily disable CCD configuration in AAT and DEMO environment after pointing to SIDAM
 //  Reason: SIDAM does not have testing endpoint used by current version of CCD configurer scripts
 //
-//  before('smoketest:aat-staging') {
+  before('smoketest:aat-staging') {
+    env.GATEKEEPER_USER_USERNAME = 'gatekeeper@mailnesia.com'
 //    env.CCD_DEF_CASE_SERVICE_BASE_URL = env.TEST_URL.replace('https', 'http')
 //
 //    sh """
 //      ./kubernetes/configurer/configure-ccd.sh
 //    """
-//  }
-//
-//  before('smoketest:aat') {
+  }
+
+  before('smoketest:aat') {
+    env.GATEKEEPER_USER_USERNAME = 'gatekeeper@mailnesia.com'
 //    env.CCD_DEF_CASE_SERVICE_BASE_URL = env.TEST_URL.replace('https', 'http')
 //
 //    sh """
 //      ./kubernetes/configurer/configure-ccd.sh
 //    """
-//  }
+  }
 //
 //  before('smoketest:demo-staging') {
 //    env.CCD_DEF_CASE_SERVICE_BASE_URL = env.TEST_URL.replace('https', 'http')

--- a/e2e/config.js
+++ b/e2e/config.js
@@ -22,7 +22,7 @@ module.exports = {
   hmctsAdminPassword: process.env.CA_USER_PASSWORD || 'Password12',
   cafcassEmail: 'cafcass@example.com',
   cafcassPassword: process.env.CAFCASS_USER_PASSWORD || 'Password12',
-  gateKeeperEmail: 'gatekeeper@example.com',
+  gateKeeperEmail: process.env.GATEKEEPER_USER_USERNAME || 'gatekeeper@example.com',
   gateKeeperPassword: process.env.GATEKEEPER_USER_PASSWORD || 'Password12',
   definition: {
     jurisdiction: 'PUBLICLAW',


### PR DESCRIPTION
### JIRA link (if applicable) ###

FPLA-47

### Change description ###

Makes gatekeeper username configurable in E2E tests

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```