### PR TITLE
Revert ZAP security scans

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -1,12 +1,7 @@
 #!groovy
 
 properties([
-  pipelineTriggers([cron('20 21 * * *')]),
-  parameters([
-      string(name: 'SecurityRules',
-      defaultValue: 'https://raw.githubusercontent.com/hmcts/security-test-rules/master/conf/security-rules.conf',
-      description: 'The URL you want to run these tests against'),
-  ])
+  pipelineTriggers([cron('20 21 * * *')])
 ])
 
 @Library('Infrastructure')
@@ -17,7 +12,6 @@ def product = 'fpl'
 def component = 'case-service'
 
 withNightlyPipeline(type, product, component) {
-  enableSecurityScan()
   enableMutationTest()
   enableFullFunctionalTest()
 
@@ -36,10 +30,5 @@ withNightlyPipeline(type, product, component) {
     } finally {
       archiveArtifacts allowEmptyArchive: true, artifacts: 'output/**/*'
     }
-  }
-
-  before('securityScan') {
-    env.Rules = params.SecurityRules
-    env.URL = 'http://ccd-case-management-web-aat.service.core-compute-aat.internal'
   }
 }

--- a/security.sh
+++ b/security.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-echo ${URL}
-zap-api-scan.py -t ${URL}/v2/api-docs -f openapi -u ${SecurityRules} -P 1001 -l FAIL
-cat zap.out
-zap-cli --zap-url http://0.0.0.0 -p 1001 report -o /zap/api-report.html -f html
-cp /zap/api-report.html functional-output/
-zap-cli -p 1001 alerts -l High


### PR DESCRIPTION
Reverts hmcts/fpl-ccd-configuration#307

Change is reverted due to:
1. it does not work - open API scan is made against frontend which does not have API definitions and HTML reports are not even published
2. it does not make sense - scan is made agains CCD frontend without testing anything that is specific to FPL project - that simple test could have been done by CCD itself, no point doing it on FPL side