### PR TITLE
Retrieve smoke test LA user details from vault for the purpose of E2E tests

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -13,7 +13,9 @@ def component = "case-service"
 List<Map<String, Object>> secrets = [
   secret('ccd-configurer-s2s-secret', 'CCD_CONFIGURER_S2S_SECRET'),
   secret('address-lookup-api-key', 'ADDRESS_LOOKUP_TOKEN'),
-  secret('notify-api-key', 'NOTIFY_API_KEY')
+  secret('notify-api-key', 'NOTIFY_API_KEY'),
+  secret('smoke-test-la-username', 'SMOKE_TEST_LA_USER_USERNAME'),
+  secret('smoke-test-la-password', 'SMOKE_TEST_LA_USER_PASSWORD')
 ]
 
 static Map<String, Object> secret(String secretName, String envVariable) {

--- a/e2e/config.js
+++ b/e2e/config.js
@@ -1,5 +1,7 @@
 /*global process*/
 
+const defaultPassword = 'Password12';
+
 module.exports = {
   // users
   swanseaLocalAuthorityUserOne: {
@@ -17,13 +19,15 @@ module.exports = {
   swanseaLocalAuthorityEmailUserOne: 'kurt@swansea.gov.uk',
   swanseaLocalAuthorityEmailUserTwo: 'damian@swansea.gov.uk',
   hillingdonLocalAuthorityEmailUserOne: 'sam@hillingdon.gov.uk',
-  localAuthorityPassword: process.env.LA_USER_PASSWORD || 'Password12',
+  localAuthorityPassword: process.env.LA_USER_PASSWORD || defaultPassword,
   hmctsAdminEmail: 'hmcts-admin@example.com',
-  hmctsAdminPassword: process.env.CA_USER_PASSWORD || 'Password12',
+  hmctsAdminPassword: process.env.CA_USER_PASSWORD || defaultPassword,
   cafcassEmail: 'cafcass@example.com',
-  cafcassPassword: process.env.CAFCASS_USER_PASSWORD || 'Password12',
+  cafcassPassword: process.env.CAFCASS_USER_PASSWORD || defaultPassword,
   gateKeeperEmail: 'gatekeeper@mailnesia.com',
-  gateKeeperPassword: process.env.GATEKEEPER_USER_PASSWORD || 'Password12',
+  gateKeeperPassword: process.env.GATEKEEPER_USER_PASSWORD || defaultPassword,
+  smokeTestLocalAuthorityEmail: process.env.SMOKE_TEST_LA_USER_USERNAME || 'james@swansea.gov.uk',
+  smokeTestLocalAuthorityPassword: process.env.SMOKE_TEST_LA_USER_PASSWORD || defaultPassword,
   definition: {
     jurisdiction: 'PUBLICLAW',
     caseType: 'CARE_SUPERVISION_EPO',

--- a/e2e/paths/smoke_test.js
+++ b/e2e/paths/smoke_test.js
@@ -3,25 +3,7 @@ const config = require('../config.js');
 Feature('Smoke tests @smoke-tests').retry(2);
 
 Scenario('Sign in as local authority', (I, loginPage) => {
-  loginPage.signIn(config.swanseaLocalAuthorityEmailUserOne, config.localAuthorityPassword);
-  I.see('Create new case');
-  I.signOut();
-});
-
-Scenario('Sign in as court admin', (I, loginPage) => {
-  loginPage.signIn(config.hmctsAdminEmail, config.hmctsAdminPassword);
-  I.see('Create new case');
-  I.signOut();
-});
-
-Scenario('Sign in as CAFCASS', (I, loginPage) => {
-  loginPage.signIn(config.cafcassEmail, config.cafcassPassword);
-  I.see('Create new case');
-  I.signOut();
-});
-
-Scenario('Sign in as gatekeeper', (I, loginPage) => {
-  loginPage.signIn(config.gateKeeperEmail, config.gateKeeperPassword);
+  loginPage.signIn(config.smokeTestLocalAuthorityEmail, config.smokeTestLocalAuthorityPassword);
   I.see('Create new case');
   I.signOut();
 });


### PR DESCRIPTION
### JIRA link (if applicable) ###

None

### Change description ###

This change retrieves smoke test LA user details from vault to use dedicated smoke test user in production.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
