### PR TITLE
Add FPLA team to fixed list of local authorities

### DIFF
--- a/ccd-definition/FixedLists.json
+++ b/ccd-definition/FixedLists.json
@@ -63,7 +63,7 @@
     "LiveFrom": "01/01/2017",
     "ID": "AuthorityFixedList",
     "ListElementCode": "FPLA",
-    "ListElement": "FPLA Team"
+    "ListElement": "FPLA team"
   },
   {
     "LiveFrom": "01/01/2017",

--- a/ccd-definition/FixedLists.json
+++ b/ccd-definition/FixedLists.json
@@ -61,6 +61,12 @@
   },
   {
     "LiveFrom": "01/01/2017",
+    "ID": "AuthorityFixedList",
+    "ListElementCode": "FPLA",
+    "ListElement": "FPLA Team"
+  },
+  {
+    "LiveFrom": "01/01/2017",
     "ID": "GroundsList",
     "ListElementCode": "noCare",
     "ListElement": "Not receiving care that would be reasonably expected from a parent"


### PR DESCRIPTION
### JIRA link (if applicable) ###

None

### Change description ###

This adds `FPLA Team` to list of LA's so that smoke test user in production can create draft case.

Comms have been sent to the users to make them aware of change.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
