### PR TITLE
chore: bumped owasp to 5.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ buildscript {
 
 plugins {
   id 'java'
+  id 'org.owasp.dependencycheck' version '5.1.0'
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,6 @@ buildscript {
 
 plugins {
   id 'java'
-  id 'org.owasp.dependencycheck' version '5.1.0'
 }
 
 allprojects {

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -5,7 +5,7 @@ plugins {
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.8.RELEASE'
   id 'org.springframework.boot' version '2.1.6.RELEASE'
-  id 'org.owasp.dependencycheck' version '4.0.2'
+  id 'org.owasp.dependencycheck' version '5.1.0'
   id 'com.github.ben-manes.versions' version '0.21.0'
   id 'org.sonarqube' version '2.7.1'
 }

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -10,7 +10,6 @@ plugins {
 }
 
 apply plugin: 'info.solidsoft.pitest'
-apply plugin: 'org.owasp.dependencycheck'
 
 group = 'uk.gov.hmcts.reform'
 version = '1.0.0'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -5,12 +5,12 @@ plugins {
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.8.RELEASE'
   id 'org.springframework.boot' version '2.1.6.RELEASE'
-  id 'org.owasp.dependencycheck' version '5.1.0'
   id 'com.github.ben-manes.versions' version '0.21.0'
   id 'org.sonarqube' version '2.7.1'
 }
 
 apply plugin: 'info.solidsoft.pitest'
+apply plugin: 'org.owasp.dependencycheck'
 
 group = 'uk.gov.hmcts.reform'
 version = '1.0.0'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -5,6 +5,7 @@ plugins {
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.8.RELEASE'
   id 'org.springframework.boot' version '2.1.6.RELEASE'
+  id 'org.owasp.dependencycheck' version '5.1.0'
   id 'com.github.ben-manes.versions' version '0.21.0'
   id 'org.sonarqube' version '2.7.1'
 }


### PR DESCRIPTION
Bump to owasp dependecy to fix failing build pipelines.

Luigi B
@here Reminder: On Monday 15th at midnight all the jenkins builds that are still using owasp 4 will start failing! If you are still using owasp 4 you need to migrate to owasp 5 by Monday. For an example you can check draft-store: https://github.com/hmcts/draft-store
