### PR TITLE
Remove waiting for navigation to make tests more stable

### DIFF
--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -28,7 +28,6 @@ exports.config = {
     Puppeteer: {
       show: process.env.SHOW_BROWSER_WINDOW || false,
       restart: true,
-      waitForNavigation: 'networkidle0',
       waitForTimeout: 15000,
       chrome: {
         ignoreHTTPSErrors: true,

--- a/e2e/helpers/puppeter_helper.js
+++ b/e2e/helpers/puppeter_helper.js
@@ -9,9 +9,4 @@ module.exports = class MyHelpers extends Helper {
     const page = this.helpers['Puppeteer'].page;
     return page.reload();
   }
-
-  navigateToUrl(url) {
-    const page = this.helpers['Puppeteer'].page;
-    return page.goto(url);
-  }
 };

--- a/e2e/pages/createCase/eventSummary.js
+++ b/e2e/pages/createCase/eventSummary.js
@@ -4,6 +4,7 @@ module.exports = {
 
   submit(button) {
     I.click(button);
+    I.waitForNavigation({ waitUntil: 'networkidle0' });
     I.waitForElement('.alert-success');
   },
 };

--- a/e2e/pages/createCase/eventSummary.js
+++ b/e2e/pages/createCase/eventSummary.js
@@ -4,7 +4,6 @@ module.exports = {
 
   submit(button) {
     I.click(button);
-    I.waitForNavigation({ waitUntil: 'networkidle0' });
     I.waitForElement('.alert-success');
   },
 };

--- a/e2e/pages/login/loginPage.js
+++ b/e2e/pages/login/loginPage.js
@@ -16,6 +16,6 @@ module.exports = {
     I.fillField(this.fields.username, username);
     I.fillField(this.fields.password, password);
     I.click(this.submitButton);
-    I.waitForNavigation();
+    I.waitForText('Sign Out');
   },
 };

--- a/e2e/steps_file.js
+++ b/e2e/steps_file.js
@@ -21,12 +21,14 @@ module.exports = function () {
 
     continueAndSave() {
       this.click('Continue');
+      this.waitForNavigation({ waitUntil: 'networkidle0' });
       this.waitForElement('.check-your-answers');
       eventSummaryPage.submit('Save and continue');
     },
 
     continueAndSubmit() {
       this.click('Continue');
+      this.waitForNavigation({ waitUntil: 'networkidle0' });
       this.waitForElement('.check-your-answers');
       eventSummaryPage.submit('Submit');
     },
@@ -70,8 +72,8 @@ module.exports = function () {
     },
 
     navigateToCaseDetails(caseId) {
-      const href = `${baseUrl}/case/${config.definition.jurisdiction}/${config.definition.caseType}/${caseId.replace(/\D/g, '')}`;
-      this.navigateToUrl(href);
+      this.amOnPage(`${baseUrl}/case/${config.definition.jurisdiction}/${config.definition.caseType}/${caseId.replace(/\D/g, '')}`);
+      this.waitForText('Sign Out');
     },
   });
 };

--- a/e2e/steps_file.js
+++ b/e2e/steps_file.js
@@ -21,14 +21,12 @@ module.exports = function () {
 
     continueAndSave() {
       this.click('Continue');
-      this.waitForNavigation({ waitUntil: 'networkidle0' });
       this.waitForElement('.check-your-answers');
       eventSummaryPage.submit('Save and continue');
     },
 
     continueAndSubmit() {
       this.click('Continue');
-      this.waitForNavigation({ waitUntil: 'networkidle0' });
       this.waitForElement('.check-your-answers');
       eventSummaryPage.submit('Submit');
     },


### PR DESCRIPTION
### JIRA link (if applicable) ###

None

### Change description ###

Previous logic that detected when navigation was finished stopped working with more recent version of SIDAM. This PR removes manual waiting for navigation in favour of waiting for an element.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
