### PR TITLE
Make test retries configurable via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,16 +53,22 @@ To run e2e tests enter `yarn test` in the command line.
 
 ### Optional configuration
 
-To run all tests only in one browser please set `PARALLEL_CHUNKS` environment variable to `1`.
+To run all tests only in one browser please set `PARALLEL_CHUNKS` environment variable to `1`. By default 3 chunks are enabled.
 
 ```$bash
 PARALLEL_CHUNKS=1 yarn test
 ```
 
-To show tests in browser window as they run please set `SHOW_BROWSER_WINDOW` environment variable to `true`.
+To show tests in browser window as they run please set `SHOW_BROWSER_WINDOW` environment variable to `true`. By default browser window is hidden.
 
 ```$bash
 SHOW_BROWSER_WINDOW=true yarn test
+```
+
+To disable retry upon test failure please set `TEST_RETRIES` environment variable to `0`. By default 2 retries are enabled. 
+
+```$bash
+TEST_RETRIES=0 yarn test
 ```
 
 ## Service:

--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -37,7 +37,10 @@ exports.config = {
       },
       windowSize: '1280x960',
     },
-    MyHelpers: {
+    HooksHelper: {
+      require: './e2e/helpers/hooks_helper.js',
+    },
+    PuppeteerHelpers: {
       require: './e2e/helpers/puppeter_helper.js',
     },
   },

--- a/e2e/helpers/hooks_helper.js
+++ b/e2e/helpers/hooks_helper.js
@@ -1,0 +1,7 @@
+/* global process */
+
+module.exports = class HooksHelpers extends Helper {
+  _test(test) {
+    test.retries(parseInt(process.env.TEST_RETRIES || '2'));
+  }
+};

--- a/e2e/helpers/puppeter_helper.js
+++ b/e2e/helpers/puppeter_helper.js
@@ -1,5 +1,4 @@
-module.exports = class MyHelpers extends Helper {
-
+module.exports = class PuppeteerHelpers extends Helper {
   clickBrowserBack() {
     const page = this.helpers['Puppeteer'].page;
     return page.goBack();

--- a/e2e/paths/accessSegregation_test.js
+++ b/e2e/paths/accessSegregation_test.js
@@ -2,7 +2,7 @@ const config = require('../config.js');
 
 let caseId;
 
-Feature('Cases visible only to respective local authority and admin').retry(2);
+Feature('Cases visible only to respective local authority and admin');
 
 Before(async (I, caseViewPage, submitApplicationPage) => {
   I.logInAndCreateCase(config.swanseaLocalAuthorityEmailUserOne, config.localAuthorityPassword);

--- a/e2e/paths/attendingHearing_test.js
+++ b/e2e/paths/attendingHearing_test.js
@@ -1,6 +1,6 @@
 const config = require('../config.js');
 
-Feature('Enter attending hearing information into the application').retry(2);
+Feature('Enter attending hearing information into the application');
 
 Before((I, caseViewPage) => {
   I.logInAndCreateCase(config.swanseaLocalAuthorityEmailUserOne, config.localAuthorityPassword);

--- a/e2e/paths/caseSubmitted_test.js
+++ b/e2e/paths/caseSubmitted_test.js
@@ -3,7 +3,7 @@ const fields = {
   documentLink: 'ccd-read-document-field>a',
 };
 
-Feature('Submit Case').retry(2);
+Feature('Submit Case');
 Before((I, caseViewPage) => {
   I.logInAndCreateCase(config.swanseaLocalAuthorityEmailUserOne, config.localAuthorityPassword);
   I.selectOption(caseViewPage.actionsDropdown, config.applicationActions.submitCase);

--- a/e2e/paths/changeCaseName_test.js
+++ b/e2e/paths/changeCaseName_test.js
@@ -1,6 +1,6 @@
 const config = require('../config.js');
 
-Feature('Change case name').retry(2);
+Feature('Change case name');
 
 Before((I, caseViewPage) => {
   I.logInAndCreateCase(config.swanseaLocalAuthorityEmailUserOne, config.localAuthorityPassword);

--- a/e2e/paths/enterAllocationProposal_test.js
+++ b/e2e/paths/enterAllocationProposal_test.js
@@ -1,6 +1,6 @@
 const config = require('../config.js');
 
-Feature('Enter Allocation Proposal').retry(2);
+Feature('Enter Allocation Proposal');
 
 Before((I, caseViewPage) => {
   I.logInAndCreateCase(config.swanseaLocalAuthorityEmailUserOne, config.localAuthorityPassword);

--- a/e2e/paths/enterApplicant_test.js
+++ b/e2e/paths/enterApplicant_test.js
@@ -2,7 +2,7 @@ const config = require('../config.js');
 const applicant = require('../fixtures/applicant.js');
 const solicitor = require('../fixtures/solicitor.js');
 
-Feature('Enter applicant').retry(2);
+Feature('Enter applicant');
 
 Before((I, caseViewPage) => {
   I.logInAndCreateCase(config.swanseaLocalAuthorityEmailUserOne, config.localAuthorityPassword);

--- a/e2e/paths/enterChildren_test.js
+++ b/e2e/paths/enterChildren_test.js
@@ -25,7 +25,7 @@ const addresses = [
   },
 ];
 
-Feature('Enter children in application').retry(2);
+Feature('Enter children in application');
 
 Before((I, caseViewPage) => {
   I.logInAndCreateCase(config.swanseaLocalAuthorityEmailUserOne, config.localAuthorityPassword);

--- a/e2e/paths/enterFactorsAffectingParenting_test.js
+++ b/e2e/paths/enterFactorsAffectingParenting_test.js
@@ -1,6 +1,6 @@
 const config = require('../config.js');
 
-Feature('EnterFactorsAffectingParenting').retry(2);
+Feature('EnterFactorsAffectingParenting');
 
 Before((I, caseViewPage) => {
   I.logInAndCreateCase(config.swanseaLocalAuthorityEmailUserOne, config.localAuthorityPassword);

--- a/e2e/paths/enterGrounds_test.js
+++ b/e2e/paths/enterGrounds_test.js
@@ -1,6 +1,6 @@
 const config = require('../config.js');
 
-Feature('Enter grounds').retry(2);
+Feature('Enter grounds');
 
 Before((I) => {
   I.logInAndCreateCase(config.swanseaLocalAuthorityEmailUserOne, config.localAuthorityPassword);

--- a/e2e/paths/enterInternationalElements_test.js
+++ b/e2e/paths/enterInternationalElements_test.js
@@ -1,6 +1,6 @@
 const config = require('../config.js');
 
-Feature('Enter international element').retry(2);
+Feature('Enter international element');
 
 Before((I, caseViewPage) => {
   I.logInAndCreateCase(config.swanseaLocalAuthorityEmailUserOne, config.localAuthorityPassword);

--- a/e2e/paths/enterOrdersAndDirections_test.js
+++ b/e2e/paths/enterOrdersAndDirections_test.js
@@ -1,6 +1,6 @@
 const config = require('../config.js');
 
-Feature('Enter order and details').retry(2);
+Feature('Enter order and details');
 
 Before((I, caseViewPage) => {
   I.logInAndCreateCase(config.swanseaLocalAuthorityEmailUserOne, config.localAuthorityPassword);

--- a/e2e/paths/enterOtherProceedings_test.js
+++ b/e2e/paths/enterOtherProceedings_test.js
@@ -1,7 +1,7 @@
 const config = require('../config.js');
 const otherProceedingData = require('../fixtures/otherProceedingData');
 
-Feature('Enter Other Proceedings').retry(2);
+Feature('Enter Other Proceedings');
 
 Before((I, caseViewPage) => {
   I.logInAndCreateCase(config.swanseaLocalAuthorityEmailUserOne, config.localAuthorityPassword);

--- a/e2e/paths/enterOthers_test.js
+++ b/e2e/paths/enterOthers_test.js
@@ -1,7 +1,7 @@
 const config = require('../config.js');
 const others = require('../fixtures/others.js');
 
-Feature('Enter others who should be given notice').retry(2);
+Feature('Enter others who should be given notice');
 
 Before((I, caseViewPage) => {
   I.logInAndCreateCase(config.swanseaLocalAuthorityEmailUserOne, config.localAuthorityPassword);

--- a/e2e/paths/enterRespondents_test.js
+++ b/e2e/paths/enterRespondents_test.js
@@ -1,7 +1,7 @@
 const config = require('../config.js');
 const respondents = require('../fixtures/respondents.js');
 
-Feature('Enter respondents').retry(2);
+Feature('Enter respondents');
 
 Before((I, caseViewPage) => {
   I.logInAndCreateCase(config.swanseaLocalAuthorityEmailUserOne, config.localAuthorityPassword);

--- a/e2e/paths/enterRiskAndHarmToChild_test.js
+++ b/e2e/paths/enterRiskAndHarmToChild_test.js
@@ -1,6 +1,6 @@
 const config = require('../config.js');
 
-Feature('Enter risk and harm to child').retry(2);
+Feature('Enter risk and harm to child');
 
 Before((I, caseViewPage) => {
   I.logInAndCreateCase(config.swanseaLocalAuthorityEmailUserOne, config.localAuthorityPassword);

--- a/e2e/paths/loginAsHmctsAdmin_test.js
+++ b/e2e/paths/loginAsHmctsAdmin_test.js
@@ -1,7 +1,7 @@
 const config = require('../config.js');
 let caseId;
 
-Feature('Login as hmcts admin').retry(2);
+Feature('Login as hmcts admin');
 
 Before(async (I, caseViewPage, submitApplicationPage) => {
   I.logInAndCreateCase(config.swanseaLocalAuthorityEmailUserOne, config.localAuthorityPassword);

--- a/e2e/paths/selectHearing_test.js
+++ b/e2e/paths/selectHearing_test.js
@@ -1,6 +1,6 @@
 const config = require('../config.js');
 
-Feature('Select hearing').retry(2);
+Feature('Select hearing');
 
 Before((I, caseViewPage) => {
   I.logInAndCreateCase(config.swanseaLocalAuthorityEmailUserOne, config.localAuthorityPassword);

--- a/e2e/paths/sendToGatekeeper_test.js
+++ b/e2e/paths/sendToGatekeeper_test.js
@@ -2,7 +2,7 @@ const config = require('../config.js');
 
 let caseId;
 
-Feature('Send notification to gatekeeper').retry(2);
+Feature('Send notification to gatekeeper');
 
 Before(async (I, caseViewPage, loginPage, submitApplicationPage) => {
   I.logInAndCreateCase(config.swanseaLocalAuthorityEmailUserOne, config.localAuthorityPassword);

--- a/e2e/paths/smoke_test.js
+++ b/e2e/paths/smoke_test.js
@@ -1,6 +1,6 @@
 const config = require('../config.js');
 
-Feature('Smoke tests @smoke-tests').retry(2);
+Feature('Smoke tests @smoke-tests');
 
 Scenario('Sign in as local authority', (I, loginPage) => {
   loginPage.signIn(config.smokeTestLocalAuthorityEmail, config.smokeTestLocalAuthorityPassword);

--- a/e2e/paths/uploadDocuments_test.js
+++ b/e2e/paths/uploadDocuments_test.js
@@ -1,6 +1,6 @@
 const config = require('../config.js');
 
-Feature('Upload Documents').retry(2);
+Feature('Upload Documents');
 
 Before((I, caseViewPage) => {
   I.logInAndCreateCase(config.swanseaLocalAuthorityEmailUserOne, config.localAuthorityPassword);


### PR DESCRIPTION
### JIRA link (if applicable) ###

None

### Change description ###

This PR makes test retries configurable in one place for all tests. 

To disable retry upon test failure please set `TEST_RETRIES` environment variable to `0`. By default 2 retries are enabled. 

 ```$bash
TEST_RETRIES=0 yarn test
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```