### PR TITLE
refactor: moved respondent configuration to CaseEventToComplexTypes

### DIFF
--- a/ccd-definition/CaseEventToComplexTypes.json
+++ b/ccd-definition/CaseEventToComplexTypes.json
@@ -58,7 +58,7 @@
     "ID": "RespondentNew",
     "CaseEventID": "enterRespondents",
     "CaseFieldID": "respondents1",
-    "ListElementCode": "party.address",
+    "ListElementCode": "party.address.AddressLine1",
     "FieldDisplayOrder": "7",
     "DisplayContext": "OPTIONAL"
   },
@@ -67,7 +67,7 @@
     "ID": "RespondentNew",
     "CaseEventID": "enterRespondents",
     "CaseFieldID": "respondents1",
-    "ListElementCode": "party.telephoneNumber.telephoneNumber",
+    "ListElementCode": "party.address.AddressLine2",
     "FieldDisplayOrder": "8",
     "DisplayContext": "OPTIONAL"
   },
@@ -76,16 +76,25 @@
     "ID": "RespondentNew",
     "CaseEventID": "enterRespondents",
     "CaseFieldID": "respondents1",
-    "ListElementCode": "party.relationshipLabel",
-    "FieldDisplayOrder": "10",
-    "DisplayContext": "READONLY"
+    "ListElementCode": "party.address.AddressLine3",
+    "FieldDisplayOrder": "9",
+    "DisplayContext": "OPTIONAL"
   },
   {
     "LiveFrom": "01/01/2017",
     "ID": "RespondentNew",
     "CaseEventID": "enterRespondents",
     "CaseFieldID": "respondents1",
-    "ListElementCode": "party.relationshipToChild",
+    "ListElementCode": "party.address.PostTown",
+    "FieldDisplayOrder": "10",
+    "DisplayContext": "OPTIONAL"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "RespondentNew",
+    "CaseEventID": "enterRespondents",
+    "CaseFieldID": "respondents1",
+    "ListElementCode": "party.address.County",
     "FieldDisplayOrder": "11",
     "DisplayContext": "OPTIONAL"
   },
@@ -94,7 +103,7 @@
     "ID": "RespondentNew",
     "CaseEventID": "enterRespondents",
     "CaseFieldID": "respondents1",
-    "ListElementCode": "party.contactDetailsHidden",
+    "ListElementCode": "party.address.Country",
     "FieldDisplayOrder": "12",
     "DisplayContext": "OPTIONAL"
   },
@@ -103,7 +112,7 @@
     "ID": "RespondentNew",
     "CaseEventID": "enterRespondents",
     "CaseFieldID": "respondents1",
-    "ListElementCode": "party.contactDetailsHiddenReason",
+    "ListElementCode": "party.address.PostCode",
     "FieldDisplayOrder": "13",
     "DisplayContext": "OPTIONAL"
   },
@@ -112,7 +121,7 @@
     "ID": "RespondentNew",
     "CaseEventID": "enterRespondents",
     "CaseFieldID": "respondents1",
-    "ListElementCode": "party.proceedingsLabel",
+    "ListElementCode": "party.telephoneNumber.telephoneNumber",
     "FieldDisplayOrder": "14",
     "DisplayContext": "OPTIONAL"
   },
@@ -121,16 +130,16 @@
     "ID": "RespondentNew",
     "CaseEventID": "enterRespondents",
     "CaseFieldID": "respondents1",
-    "ListElementCode": "party.litigationIssues",
+    "ListElementCode": "party.relationshipLabel",
     "FieldDisplayOrder": "15",
-    "DisplayContext": "OPTIONAL"
+    "DisplayContext": "READONLY"
   },
   {
     "LiveFrom": "01/01/2017",
     "ID": "RespondentNew",
     "CaseEventID": "enterRespondents",
     "CaseFieldID": "respondents1",
-    "ListElementCode": "party.litigationIssuesDetails",
+    "ListElementCode": "party.relationshipToChild",
     "FieldDisplayOrder": "16",
     "DisplayContext": "OPTIONAL"
   },
@@ -139,8 +148,53 @@
     "ID": "RespondentNew",
     "CaseEventID": "enterRespondents",
     "CaseFieldID": "respondents1",
+    "ListElementCode": "party.contactDetailsHidden",
+    "FieldDisplayOrder": "17",
+    "DisplayContext": "OPTIONAL"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "RespondentNew",
+    "CaseEventID": "enterRespondents",
+    "CaseFieldID": "respondents1",
+    "ListElementCode": "party.contactDetailsHiddenReason",
+    "FieldDisplayOrder": "18",
+    "DisplayContext": "OPTIONAL"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "RespondentNew",
+    "CaseEventID": "enterRespondents",
+    "CaseFieldID": "respondents1",
+    "ListElementCode": "party.proceedingsLabel",
+    "FieldDisplayOrder": "19",
+    "DisplayContext": "OPTIONAL"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "RespondentNew",
+    "CaseEventID": "enterRespondents",
+    "CaseFieldID": "respondents1",
+    "ListElementCode": "party.litigationIssues",
+    "FieldDisplayOrder": "20",
+    "DisplayContext": "OPTIONAL"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "RespondentNew",
+    "CaseEventID": "enterRespondents",
+    "CaseFieldID": "respondents1",
+    "ListElementCode": "party.litigationIssuesDetails",
+    "FieldDisplayOrder": "21",
+    "DisplayContext": "OPTIONAL"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "RespondentNew",
+    "CaseEventID": "enterRespondents",
+    "CaseFieldID": "respondents1",
     "ListElementCode": "party.respondent_border",
-    "FieldDisplayOrder": "15",
+    "FieldDisplayOrder": "22",
     "DisplayContext": "OPTIONAL"
   }
 ]

--- a/ccd-definition/CaseEventToComplexTypes.json
+++ b/ccd-definition/CaseEventToComplexTypes.json
@@ -168,7 +168,7 @@
     "CaseFieldID": "respondents1",
     "ListElementCode": "party.proceedingsLabel",
     "FieldDisplayOrder": "19",
-    "DisplayContext": "OPTIONAL"
+    "DisplayContext": "READONLY"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -195,6 +195,6 @@
     "CaseFieldID": "respondents1",
     "ListElementCode": "party.respondent_border",
     "FieldDisplayOrder": "22",
-    "DisplayContext": "OPTIONAL"
+    "DisplayContext": "READONLY"
   }
 ]

--- a/ccd-definition/CaseEventToComplexTypes.json
+++ b/ccd-definition/CaseEventToComplexTypes.json
@@ -1,1 +1,146 @@
-[]
+[
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "RespondentNew",
+    "CaseEventID": "enterRespondents",
+    "CaseFieldID": "respondents1",
+    "ListElementCode": "party.firstName",
+    "FieldDisplayOrder": "1",
+    "DisplayContext": "OPTIONAL"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "RespondentNew",
+    "CaseEventID": "enterRespondents",
+    "CaseFieldID": "respondents1",
+    "ListElementCode": "party.lastName",
+    "FieldDisplayOrder": "2",
+    "DisplayContext": "OPTIONAL"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "RespondentNew",
+    "CaseEventID": "enterRespondents",
+    "CaseFieldID": "respondents1",
+    "ListElementCode": "party.dateOfBirth",
+    "FieldDisplayOrder": "3",
+    "DisplayContext": "OPTIONAL"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "RespondentNew",
+    "CaseEventID": "enterRespondents",
+    "CaseFieldID": "respondents1",
+    "ListElementCode": "party.gender",
+    "FieldDisplayOrder": "4",
+    "DisplayContext": "OPTIONAL"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "RespondentNew",
+    "CaseEventID": "enterRespondents",
+    "CaseFieldID": "respondents1",
+    "ListElementCode": "party.genderIdentification",
+    "FieldDisplayOrder": "5",
+    "DisplayContext": "OPTIONAL"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "RespondentNew",
+    "CaseEventID": "enterRespondents",
+    "CaseFieldID": "respondents1",
+    "ListElementCode": "party.placeOfBirth",
+    "FieldDisplayOrder": "6",
+    "DisplayContext": "OPTIONAL"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "RespondentNew",
+    "CaseEventID": "enterRespondents",
+    "CaseFieldID": "respondents1",
+    "ListElementCode": "party.address",
+    "FieldDisplayOrder": "7",
+    "DisplayContext": "OPTIONAL"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "RespondentNew",
+    "CaseEventID": "enterRespondents",
+    "CaseFieldID": "respondents1",
+    "ListElementCode": "party.telephoneNumber.telephoneNumber",
+    "FieldDisplayOrder": "8",
+    "DisplayContext": "OPTIONAL"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "RespondentNew",
+    "CaseEventID": "enterRespondents",
+    "CaseFieldID": "respondents1",
+    "ListElementCode": "party.relationshipLabel",
+    "FieldDisplayOrder": "10",
+    "DisplayContext": "READONLY"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "RespondentNew",
+    "CaseEventID": "enterRespondents",
+    "CaseFieldID": "respondents1",
+    "ListElementCode": "party.relationshipToChild",
+    "FieldDisplayOrder": "11",
+    "DisplayContext": "OPTIONAL"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "RespondentNew",
+    "CaseEventID": "enterRespondents",
+    "CaseFieldID": "respondents1",
+    "ListElementCode": "party.contactDetailsHidden",
+    "FieldDisplayOrder": "12",
+    "DisplayContext": "OPTIONAL"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "RespondentNew",
+    "CaseEventID": "enterRespondents",
+    "CaseFieldID": "respondents1",
+    "ListElementCode": "party.contactDetailsHiddenReason",
+    "FieldDisplayOrder": "13",
+    "DisplayContext": "OPTIONAL"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "RespondentNew",
+    "CaseEventID": "enterRespondents",
+    "CaseFieldID": "respondents1",
+    "ListElementCode": "party.proceedingsLabel",
+    "FieldDisplayOrder": "14",
+    "DisplayContext": "OPTIONAL"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "RespondentNew",
+    "CaseEventID": "enterRespondents",
+    "CaseFieldID": "respondents1",
+    "ListElementCode": "party.litigationIssues",
+    "FieldDisplayOrder": "15",
+    "DisplayContext": "OPTIONAL"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "RespondentNew",
+    "CaseEventID": "enterRespondents",
+    "CaseFieldID": "respondents1",
+    "ListElementCode": "party.litigationIssuesDetails",
+    "FieldDisplayOrder": "16",
+    "DisplayContext": "OPTIONAL"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "RespondentNew",
+    "CaseEventID": "enterRespondents",
+    "CaseFieldID": "respondents1",
+    "ListElementCode": "party.respondent_border",
+    "FieldDisplayOrder": "15",
+    "DisplayContext": "OPTIONAL"
+  }
+]

--- a/ccd-definition/CaseEventToFields.json
+++ b/ccd-definition/CaseEventToFields.json
@@ -356,7 +356,7 @@
     "CaseEventID": "enterRespondents",
     "CaseFieldID": "respondents1",
     "PageFieldDisplayOrder": 3,
-    "DisplayContext": "OPTIONAL",
+    "DisplayContext": "COMPLEX",
     "PageID": 1,
     "PageDisplayOrder": 1,
     "PageColumnNumber": 1,

--- a/ccd-definition/ComplexTypes.json
+++ b/ccd-definition/ComplexTypes.json
@@ -1570,7 +1570,7 @@
     "ID": "RespondentParty",
     "ListElementCode": "partyId",
     "FieldType": "Text",
-    "ElementLabel": " ",
+    "ElementLabel": "partyId",
     "FieldShowCondition": "partyType=\"DO_NOT_SHOW\"",
     "SecurityClassification": "Public"
   },

--- a/ccd-definition/ComplexTypes.json
+++ b/ccd-definition/ComplexTypes.json
@@ -1567,14 +1567,6 @@
   },
   {
     "LiveFrom": "01/01/2017",
-    "ID": "Telephone",
-    "ListElementCode": "contactDirection",
-    "FieldType": "Text",
-    "ElementLabel": "Telephone number",
-    "SecurityClassification": "Public"
-  },
-  {
-    "LiveFrom": "01/01/2017",
     "ID": "RespondentParty",
     "ListElementCode": "partyId",
     "FieldType": "Text",

--- a/ccd-definition/ComplexTypes.json
+++ b/ccd-definition/ComplexTypes.json
@@ -1579,6 +1579,7 @@
     "ListElementCode": "partyId",
     "FieldType": "Text",
     "ElementLabel": " ",
+    "FieldShowCondition": "partyType=\"DO_NOT_SHOW\"",
     "SecurityClassification": "Public"
   },
   {
@@ -1588,6 +1589,7 @@
     "FieldType": "FixedRadioList",
     "FieldTypeParameter": "PartyType",
     "ElementLabel": " ",
+    "FieldShowCondition": "partyType=\"DO_NOT_SHOW\"",
     "SecurityClassification": "Public"
   },
   {
@@ -1732,6 +1734,7 @@
     "ListElementCode": "leadRespondentIndicator",
     "FieldType": "YesOrNo",
     "ElementLabel": "Is this the first respondent?",
+    "FieldShowCondition": "party=\"DO_NOT_SHOW\"",
     "SecurityClassification": "Public"
   },
   {

--- a/ccd-definition/ComplexTypes.json
+++ b/ccd-definition/ComplexTypes.json
@@ -1567,11 +1567,18 @@
   },
   {
     "LiveFrom": "01/01/2017",
+    "ID": "Telephone",
+    "ListElementCode": "contactDirection",
+    "FieldType": "Text",
+    "ElementLabel": "Telephone number",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "01/01/2017",
     "ID": "RespondentParty",
     "ListElementCode": "partyId",
     "FieldType": "Text",
-    "ElementLabel": "Party ID",
-    "FieldShowCondition": "partyType=\"DO_NOT_SHOW\"",
+    "ElementLabel": " ",
     "SecurityClassification": "Public"
   },
   {
@@ -1581,7 +1588,6 @@
     "FieldType": "FixedRadioList",
     "FieldTypeParameter": "PartyType",
     "ElementLabel": " ",
-    "FieldShowCondition": "partyType=\"DO_NOT_SHOW\"",
     "SecurityClassification": "Public"
   },
   {
@@ -1726,7 +1732,6 @@
     "ListElementCode": "leadRespondentIndicator",
     "FieldType": "YesOrNo",
     "ElementLabel": "Is this the first respondent?",
-    "FieldShowCondition": "party=\"DO_NOT_SHOW\"",
     "SecurityClassification": "Public"
   },
   {

--- a/ccd-definition/ComplexTypes.json
+++ b/ccd-definition/ComplexTypes.json
@@ -1570,7 +1570,7 @@
     "ID": "RespondentParty",
     "ListElementCode": "partyId",
     "FieldType": "Text",
-    "ElementLabel": "party ID",
+    "ElementLabel": "Party ID",
     "FieldShowCondition": "partyType=\"DO_NOT_SHOW\"",
     "SecurityClassification": "Public"
   },

--- a/ccd-definition/ComplexTypes.json
+++ b/ccd-definition/ComplexTypes.json
@@ -1570,7 +1570,7 @@
     "ID": "RespondentParty",
     "ListElementCode": "partyId",
     "FieldType": "Text",
-    "ElementLabel": "partyId",
+    "ElementLabel": "party ID",
     "FieldShowCondition": "partyType=\"DO_NOT_SHOW\"",
     "SecurityClassification": "Public"
   },


### PR DESCRIPTION
Children and Applicant both make use of telephoneNumber.contactDirection

This prepares the respondent data structure for this change, and removes the field from the UI