### PR TITLE
Add /health/liveness endpoint that checks whether application is up

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -178,6 +178,7 @@ dependencies {
   compile group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
   compile group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger
 
+  compile group: 'uk.gov.hmcts.reform', name: 'health-spring-boot-starter', version: '0.0.4'
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging', version: versions.reformLogging
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging-appinsights', version: versions.reformLogging
 

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -5,6 +5,9 @@ management:
   endpoints:
     web:
       base-path: /
+  endpoint:
+    health:
+      show-details: "always"
 
 spring:
   application:


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FPLA-357

### Change description ###

Adds /health/liveness endpoint that checks whether application is up needed for AKS

See https://github.com/hmcts/health-spring-boot-starter for more details.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```