### PR TITLE
fix: added back in midevent definition on respondent event

### DIFF
--- a/ccd-definition/CaseEventToFields.json
+++ b/ccd-definition/CaseEventToFields.json
@@ -334,7 +334,8 @@
     "DisplayContext": "OPTIONAL",
     "PageID": 1,
     "PageDisplayOrder": 1,
-    "PageColumnNumber": 1
+    "PageColumnNumber": 1,
+    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/enter-respondents/mid-event"
   },
   {
     "LiveFrom": "01/01/2017",


### PR DESCRIPTION
adds mid event to definition