### PR TITLE
FPLA-711: Split-Orders-And-Hearing-Into-Separate-Tabs

### DIFF
--- a/ccd-definition/CaseTypeTab.json
+++ b/ccd-definition/CaseTypeTab.json
@@ -13,9 +13,19 @@
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
     "Channel": "CaseWorker",
-    "TabID": "OrdersHearingTab",
-    "TabLabel": "Orders and hearing",
+    "TabID": "HearingTab",
+    "TabLabel": "Hearing",
     "TabDisplayOrder": 2,
+    "CaseFieldID": "hearing",
+    "TabFieldDisplayOrder": 1
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "Channel": "CaseWorker",
+    "TabID": "OrdersTab",
+    "TabLabel": "Orders",
+    "TabDisplayOrder": 3,
     "CaseFieldID": "orders",
     "TabFieldDisplayOrder": 1
   },
@@ -23,19 +33,9 @@
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
     "Channel": "CaseWorker",
-    "TabID": "OrdersHearingTab",
-    "TabLabel": "Orders and hearing",
-    "TabDisplayOrder": 2,
-    "CaseFieldID": "hearing",
-    "TabFieldDisplayOrder": 2
-  },
-  {
-    "LiveFrom": "01/01/2017",
-    "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "Channel": "CaseWorker",
     "TabID": "CasePeopleTab",
     "TabLabel": "People in the case",
-    "TabDisplayOrder": 3,
+    "TabDisplayOrder": 4,
     "CaseFieldID": "children",
     "TabFieldDisplayOrder": 1
   },
@@ -45,7 +45,7 @@
     "Channel": "CaseWorker",
     "TabID": "CasePeopleTab",
     "TabLabel": "People in the case",
-    "TabDisplayOrder": 3,
+    "TabDisplayOrder": 4,
     "CaseFieldID": "respondents1",
     "TabFieldDisplayOrder": 2
   },
@@ -55,7 +55,7 @@
     "Channel": "CaseWorker",
     "TabID": "CasePeopleTab",
     "TabLabel": "People in the case",
-    "TabDisplayOrder": 3,
+    "TabDisplayOrder": 4,
     "CaseFieldID": "applicants",
     "TabFieldDisplayOrder": 3
   },
@@ -65,7 +65,7 @@
     "Channel": "CaseWorker",
     "TabID": "CasePeopleTab",
     "TabLabel": "People in the case",
-    "TabDisplayOrder": 3,
+    "TabDisplayOrder": 4,
     "CaseFieldID": "solicitor",
     "TabFieldDisplayOrder": 4
   },
@@ -75,7 +75,7 @@
     "Channel": "CaseWorker",
     "TabID": "CasePeopleTab",
     "TabLabel": "People in the case",
-    "TabDisplayOrder": 3,
+    "TabDisplayOrder": 4,
     "CaseFieldID": "others",
     "TabFieldDisplayOrder": 5
   },
@@ -85,7 +85,7 @@
     "Channel": "CaseWorker",
     "TabID": "LegalBasisTab",
     "TabLabel": "Legal basis",
-    "TabDisplayOrder": 4,
+    "TabDisplayOrder": 5,
     "CaseFieldID": "caseIDReference",
     "TabFieldDisplayOrder": 1
   },
@@ -95,7 +95,7 @@
     "Channel": "CaseWorker",
     "TabID": "LegalBasisTab",
     "TabLabel": "Legal basis",
-    "TabDisplayOrder": 4,
+    "TabDisplayOrder": 5,
     "CaseFieldID": "groundsForEPO",
     "TabFieldDisplayOrder": 2
   },
@@ -105,7 +105,7 @@
     "Channel": "CaseWorker",
     "TabID": "LegalBasisTab",
     "TabLabel": "Legal basis",
-    "TabDisplayOrder": 4,
+    "TabDisplayOrder": 5,
     "CaseFieldID": "grounds",
     "TabFieldDisplayOrder": 3
   },
@@ -115,7 +115,7 @@
     "Channel": "CaseWorker",
     "TabID": "LegalBasisTab",
     "TabLabel": "Legal basis",
-    "TabDisplayOrder": 4,
+    "TabDisplayOrder": 5,
     "CaseFieldID": "risks",
     "TabFieldDisplayOrder": 4
   },
@@ -125,7 +125,7 @@
     "Channel": "CaseWorker",
     "TabID": "LegalBasisTab",
     "TabLabel": "Legal basis",
-    "TabDisplayOrder": 4,
+    "TabDisplayOrder": 5,
     "CaseFieldID": "factorsParenting",
     "TabFieldDisplayOrder": 5
   },
@@ -135,7 +135,7 @@
     "Channel": "CaseWorker",
     "TabID": "LegalBasisTab",
     "TabLabel": "Legal basis",
-    "TabDisplayOrder": 4,
+    "TabDisplayOrder": 5,
     "CaseFieldID": "internationalElement",
     "TabFieldDisplayOrder": 6
   },
@@ -145,7 +145,7 @@
     "Channel": "CaseWorker",
     "TabID": "LegalBasisTab",
     "TabLabel": "Legal basis",
-    "TabDisplayOrder": 4,
+    "TabDisplayOrder": 5,
     "CaseFieldID": "proceeding",
     "TabFieldDisplayOrder": 7
   },
@@ -155,7 +155,7 @@
     "Channel": "CaseWorker",
     "TabID": "LegalBasisTab",
     "TabLabel": "Legal basis",
-    "TabDisplayOrder": 4,
+    "TabDisplayOrder": 5,
     "CaseFieldID": "allocationProposal",
     "TabFieldDisplayOrder": 8
   },
@@ -165,7 +165,7 @@
     "Channel": "CaseWorker",
     "TabID": "LegalBasisTab",
     "TabLabel": "Legal basis",
-    "TabDisplayOrder": 4,
+    "TabDisplayOrder": 5,
     "CaseFieldID": "hearingPreferences",
     "TabFieldDisplayOrder": 9
   },
@@ -175,7 +175,7 @@
     "Channel": "CaseWorker",
     "TabID": "DocumentsTab",
     "TabLabel": "Documents",
-    "TabDisplayOrder": 5,
+    "TabDisplayOrder": 6,
     "CaseFieldID": "caseIDReference",
     "TabFieldDisplayOrder": 1
   },
@@ -185,7 +185,7 @@
     "Channel": "CaseWorker",
     "TabID": "DocumentsTab",
     "TabLabel": "Documents",
-    "TabDisplayOrder": 5,
+    "TabDisplayOrder": 6,
     "CaseFieldID": "documents_socialWorkChronology_document",
     "TabFieldDisplayOrder": 2
   },
@@ -195,7 +195,7 @@
     "Channel": "CaseWorker",
     "TabID": "DocumentsTab",
     "TabLabel": "Documents",
-    "TabDisplayOrder": 5,
+    "TabDisplayOrder": 6,
     "CaseFieldID": "documents_socialWorkStatement_document",
     "TabFieldDisplayOrder": 3
   },
@@ -205,7 +205,7 @@
     "Channel": "CaseWorker",
     "TabID": "DocumentsTab",
     "TabLabel": "Documents",
-    "TabDisplayOrder": 5,
+    "TabDisplayOrder": 6,
     "CaseFieldID": "documents_socialWorkAssessment_document",
     "TabFieldDisplayOrder": 4
   },
@@ -215,7 +215,7 @@
     "Channel": "CaseWorker",
     "TabID": "DocumentsTab",
     "TabLabel": "Documents",
-    "TabDisplayOrder": 5,
+    "TabDisplayOrder": 6,
     "CaseFieldID": "documents_socialWorkCarePlan_document",
     "TabFieldDisplayOrder": 5
   },
@@ -225,7 +225,7 @@
     "Channel": "CaseWorker",
     "TabID": "DocumentsTab",
     "TabLabel": "Documents",
-    "TabDisplayOrder": 5,
+    "TabDisplayOrder": 6,
     "CaseFieldID": "standardDirectionsDocument",
     "TabFieldDisplayOrder": 6
   },
@@ -235,7 +235,7 @@
     "Channel": "CaseWorker",
     "TabID": "DocumentsTab",
     "TabLabel": "Documents",
-    "TabDisplayOrder": 5,
+    "TabDisplayOrder": 6,
     "CaseFieldID": "otherCourtAdminDocuments",
     "TabFieldDisplayOrder": 7
   },
@@ -245,7 +245,7 @@
     "Channel": "CaseWorker",
     "TabID": "DocumentsTab",
     "TabLabel": "Documents",
-    "TabDisplayOrder": 5,
+    "TabDisplayOrder": 6,
     "CaseFieldID": "courtBundle",
     "TabFieldDisplayOrder": 8
   },
@@ -255,7 +255,7 @@
     "Channel": "CaseWorker",
     "TabID": "DocumentsTab",
     "TabLabel": "Documents",
-    "TabDisplayOrder": 5,
+    "TabDisplayOrder": 6,
     "CaseFieldID": "documents_socialWorkEvidenceTemplate_document",
     "TabFieldDisplayOrder": 9
   },
@@ -265,7 +265,7 @@
     "Channel": "CaseWorker",
     "TabID": "DocumentsTab",
     "TabLabel": "Documents",
-    "TabDisplayOrder": 5,
+    "TabDisplayOrder": 6,
     "CaseFieldID": "documents_threshold_document",
     "TabFieldDisplayOrder": 10
   },
@@ -275,7 +275,7 @@
     "Channel": "CaseWorker",
     "TabID": "DocumentsTab",
     "TabLabel": "Documents",
-    "TabDisplayOrder": 5,
+    "TabDisplayOrder": 6,
     "CaseFieldID": "documents_checklist_document",
     "TabFieldDisplayOrder": 11
   },
@@ -285,7 +285,7 @@
     "Channel": "CaseWorker",
     "TabID": "DocumentsTab",
     "TabLabel": "Documents",
-    "TabDisplayOrder": 5,
+    "TabDisplayOrder": 6,
     "CaseFieldID": "documents_socialWorkOther",
     "TabFieldDisplayOrder": 12
   },
@@ -295,7 +295,7 @@
     "Channel": "CaseWorker",
     "TabID": "DocumentsTab",
     "TabLabel": "Documents",
-    "TabDisplayOrder": 5,
+    "TabDisplayOrder": 6,
     "CaseFieldID": "submittedForm",
     "TabFieldDisplayOrder": 13
   }

--- a/e2e/pages/caseView.page.js
+++ b/e2e/pages/caseView.page.js
@@ -4,7 +4,8 @@ module.exports = {
 
   file: 'mockFile.txt',
   tabs: {
-    ordersHearing: 'Orders and hearing',
+    orders: 'Orders',
+    hearing: 'Hearing',
     casePeople: 'People in the case',
     legalBasis: 'Legal basis',
     documents: 'cut-tabs>div>ul>li>a[href*=Documents]',

--- a/e2e/tests/enterOrdersAndDirections_test.js
+++ b/e2e/tests/enterOrdersAndDirections_test.js
@@ -11,7 +11,7 @@ Scenario('Select the care order case order and continue', (I, caseViewPage, ente
   enterOrdersAndDirectionsNeededEventPage.checkCareOrder();
   I.continueAndSave();
   I.seeEventSubmissionConfirmation(config.applicationActions.selectOrders);
-  caseViewPage.selectTab(caseViewPage.tabs.ordersHearing);
+  caseViewPage.selectTab(caseViewPage.tabs.orders);
   I.seeAnswerInTab(1, 'Orders and directions needed', 'Which orders do you need?', 'Care order');
 });
 
@@ -39,7 +39,7 @@ Scenario('Select all case orders and fill in directions & interim information', 
   enterOrdersAndDirectionsNeededEventPage.enterDirections('Test');
   I.continueAndSave();
   I.seeEventSubmissionConfirmation(config.applicationActions.selectOrders);
-  caseViewPage.selectTab(caseViewPage.tabs.ordersHearing);
+  caseViewPage.selectTab(caseViewPage.tabs.orders);
   I.seeAnswerInTab(1, 'Orders and directions needed', 'Which orders do you need?',
     ['Care order', 'Interim care order', 'Supervision order', 'Interim supervision order', 'Education supervision' +
     ' order', 'Emergency protection order', 'Other order under part 4 of the Children Act 1989']);

--- a/e2e/tests/selectHearing_test.js
+++ b/e2e/tests/selectHearing_test.js
@@ -12,7 +12,7 @@ Scenario('completing half the fields in the Select hearing section of the c110a 
   enterHearingNeededEventPage.enterHearingType();
   I.continueAndSave();
   I.seeEventSubmissionConfirmation(config.applicationActions.selectHearing);
-  caseViewPage.selectTab(caseViewPage.tabs.ordersHearing);
+  caseViewPage.selectTab(caseViewPage.tabs.hearing);
   I.seeAnswerInTab(1, 'Hearing needed', 'When do you need a hearing?', enterHearingNeededEventPage.fields.timeFrame.sameDay);
   I.seeAnswerInTab(2, 'Hearing needed', 'Give reason', 'test reason');
   I.seeAnswerInTab(3, 'Hearing needed', 'What type of hearing do you need?', enterHearingNeededEventPage.fields.hearingType.contestedICO);
@@ -26,7 +26,7 @@ Scenario('completing the Select hearing section of the c110a application', (I, c
   enterHearingNeededEventPage.enterRespondentsAware();
   I.continueAndSave();
   I.seeEventSubmissionConfirmation(config.applicationActions.selectHearing);
-  caseViewPage.selectTab(caseViewPage.tabs.ordersHearing);
+  caseViewPage.selectTab(caseViewPage.tabs.hearing);
   I.seeAnswerInTab(1, 'Hearing needed', 'When do you need a hearing?', enterHearingNeededEventPage.fields.timeFrame.sameDay);
   I.seeAnswerInTab(2, 'Hearing needed', 'Give reason', 'test reason');
   I.seeAnswerInTab(3, 'Hearing needed', 'What type of hearing do you need?', enterHearingNeededEventPage.fields.hearingType.contestedICO);


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FPLA-711

### Change description ###
Splits Orders and hearing tabs into 'orders' and 'hearing'
Minor updates to e2e tests to reference new tabs

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
<img width="1437" alt="Screenshot 2019-08-22 at 09 25 32" src="https://user-images.githubusercontent.com/4429628/63499251-655e7e80-c4bf-11e9-8165-b367868cd7ee.png">
<img width="1436" alt="Screenshot 2019-08-22 at 09 25 41" src="https://user-images.githubusercontent.com/4429628/63499262-68f20580-c4bf-11e9-87fb-ba2e200e273b.png">
