### PR TITLE
FPLA-NA fix the owasp dependency problem by pinning the jackson-databind

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -62,11 +62,4 @@
     <cve>CVE-2012-5055</cve>
     <cve>CVE-2018-1260</cve>
   </suppress>
-  <suppress>
-    <notes><![CDATA[file name: jackson-databind-2.9.9.jar]]></notes>
-    <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:.*$</gav>
-    <cve>CVE-2019-12814</cve>
-    <cve>CVE-2019-14379</cve>
-    <cve>CVE-2019-14439</cve>
-  </suppress>
 </suppressions>

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -168,12 +168,15 @@ def versions = [
 dependencies {
   annotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.8'
   compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.8'
-  
+
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: versions.springBoot
 
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: versions.springBoot
 
   compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: '2.1.2.RELEASE'
+
+//   The below fixes https://nvd.nist.gov/vuln/detail/CVE-2019-12384 while waiting for spring to pull new version
+  compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.9.3'
 
   compile group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
   compile group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger


### PR DESCRIPTION

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:



### Change description ###

Fix the CVE-2019-12384 vulnerability by bumping the databind version. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```