### PR TITLE
Remove health check from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,6 @@ FROM hmctspublic.azurecr.io/base/java:openjdk-11-distroless-1.0
 
 EXPOSE 4000
 
-HEALTHCHECK --interval=10s --timeout=10s --retries=10 CMD http_proxy="" curl --silent --fail http://localhost:4000/health
-
 COPY --from=downloader /tmp/applicationinsights-agent-2.5.0-BETA.3.jar /opt/app/
 COPY lib/AI-Agent.xml /opt/app/
 COPY build/libs/service.jar /opt/app/


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FPLA-594

### Change description ###

Health check in Dockerfile has to removed before migration to AKS is approached. Kubernetes will make their own calls to `/health` endpoints to asses service health. What is more solution that is being removed did not work for a while because distroless images does not come with `curl` installed.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
