### PR TITLE
Reduce default pod resources

### DIFF
--- a/charts/fpl-case-service/values.yaml
+++ b/charts/fpl-case-service/values.yaml
@@ -4,6 +4,10 @@ tags:
 
 java:
   image: hmctspublic.azurecr.io/fpl/case-service:latest
+  memoryRequests: 128Mi
+  cpuRequests: 125m
+  memoryLimits: 1024Mi
+  cpuLimits: 500m
   environment:
     IDAM_API_URL: https://idam-api.aat.platform.hmcts.net
     IDAM_S2S_AUTH_URL: http://rpe-service-auth-provider-aat.service.core-compute-aat.internal


### PR DESCRIPTION
### JIRA link (if applicable) ###

None

### Change description ###

As per title

Performance test results in preview:

<img width="1095" alt="image" src="https://user-images.githubusercontent.com/1724691/64854454-8b39f780-d615-11e9-9669-e8f4ce42a8c3.png">

Simulation covered max of 100 concurrent users.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
