### PR TITLE
Dump browser logs on test failure

### DIFF
--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -27,7 +27,7 @@ exports.config = {
     PuppeteerHelpers: {
       require: './e2e/helpers/puppeter_helper.js',
     },
-    DumpBrowserLogs: {
+    DumpBrowserLogsHelper: {
       require: './e2e/helpers/dump_browser_logs_helper.js',
     },
   },

--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -27,6 +27,9 @@ exports.config = {
     PuppeteerHelpers: {
       require: './e2e/helpers/puppeter_helper.js',
     },
+    DumpBrowserLogs: {
+      require: './e2e/helpers/dump_browser_logs_helper.js',
+    },
   },
   include: {
     config: './e2e/config.js',

--- a/e2e/helpers/dump_browser_logs_helper.js
+++ b/e2e/helpers/dump_browser_logs_helper.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const { clearString, screenshotOutputFolder } = require('codeceptjs/lib/utils');
+
+/**
+ * Builds output file name for given test. Name includes test name and hook name (if applicable).
+ *
+ * @param test
+ */
+function buildOutputFileName (test) {
+  let fileName = clearString(test.title);
+  if (test.ctx && test.ctx.test && test.ctx.test.type === 'hook') {
+    fileName += clearString(`_${test.ctx.test.title}`);
+  }
+  return screenshotOutputFolder(fileName);
+}
+
+/**
+ * Converts a JavaScript value to a JSON string in pretty format.
+ *
+ * @param value - JavaScript object
+ * @returns {string} - pretty formatted value
+ */
+function stringify(value) {
+  const replacer = undefined;
+  const indentationSize = 2;
+  return JSON.stringify(value, replacer, indentationSize);
+}
+
+module.exports = class HooksHelpers extends Helper {
+  async _failed(test) {
+    const logs = (await this.helpers['Puppeteer'].grabBrowserLogs()).map(log => {
+      return {
+        type: log.type(),
+        message: log.text(),
+        location: log.location().url,
+      };
+    });
+
+    if (logs.length > 0) {
+      fs.writeFileSync(`${buildOutputFileName(test)}.browser.log`, stringify(logs));
+    }
+  }
+};

--- a/e2e/helpers/hooks_helper.js
+++ b/e2e/helpers/hooks_helper.js
@@ -1,33 +1,8 @@
 /* global process */
 
-const fs = require('fs');
-const { clearString, screenshotOutputFolder } = require('codeceptjs/lib/utils');
-
-function buildOutputFileName (test, extension) {
-  let fileName = clearString(test.title);
-  if (test.ctx && test.ctx.test && test.ctx.test.type === 'hook') {
-    fileName += clearString(`_${test.ctx.test.title}`);
-  }
-  return screenshotOutputFolder(`${fileName}.${extension}`);
-}
-
 module.exports = class HooksHelpers extends Helper {
   _test(test) {
     test.retries(parseInt(process.env.TEST_RETRIES || '2'));
-  }
-
-  async _failed(test) {
-    const logs = (await this.helpers['Puppeteer'].grabBrowserLogs()).map(log => {
-      return {
-        type: log.type(),
-        message: log.text(),
-        location: log.location().url,
-      };
-    });
-
-    if (logs.length > 0) {
-      fs.writeFileSync(buildOutputFileName(test, 'browser.log'), JSON.stringify(logs, undefined, 2));
-    }
   }
 
   _afterStep(step) {

--- a/e2e/helpers/hooks_helper.js
+++ b/e2e/helpers/hooks_helper.js
@@ -1,8 +1,31 @@
 /* global process */
 
+const fs = require('fs');
+const { clearString, screenshotOutputFolder } = require('codeceptjs/lib/utils');
+
+function buildOutputFileName (test, extension) {
+  let fileName = clearString(test.title);
+  if (test.ctx && test.ctx.test && test.ctx.test.type === 'hook') {
+    fileName += clearString(`_${test.ctx.test.title}`);
+  }
+  return screenshotOutputFolder(`${fileName}.${extension}`);
+}
+
 module.exports = class HooksHelpers extends Helper {
   _test(test) {
     test.retries(parseInt(process.env.TEST_RETRIES || '2'));
+  }
+
+  async _failed(test) {
+    const logs = (await this.helpers['Puppeteer'].grabBrowserLogs()).map(log => {
+      return {
+        type: log.type(),
+        message: log.text(),
+        location: log.location().url,
+      };
+    });
+
+    fs.writeFileSync(buildOutputFileName(test, 'browser.log'), JSON.stringify(logs, undefined, 2));
   }
 
   _afterStep(step) {

--- a/e2e/helpers/hooks_helper.js
+++ b/e2e/helpers/hooks_helper.js
@@ -25,7 +25,9 @@ module.exports = class HooksHelpers extends Helper {
       };
     });
 
-    fs.writeFileSync(buildOutputFileName(test, 'browser.log'), JSON.stringify(logs, undefined, 2));
+    if (logs.length > 0) {
+      fs.writeFileSync(buildOutputFileName(test, 'browser.log'), JSON.stringify(logs, undefined, 2));
+    }
   }
 
   _afterStep(step) {


### PR DESCRIPTION
### JIRA link (if applicable) ###

None

### Change description ###

Dumps browser logs on test failure. File name includes test / hook name same way as screenshot file names e.g. `Application_draft_(empty_draft)_before_each_hook__Before.browser.log`.

Below is an example:

```
[
  {
    "type": "log",
    "message": "Running in the browser with appId=ccd-case-management-web",
    "location": "http://localhost:3451/main.c149fdaa77c1d168cf9e.js"
  },
  {
    "type": "log",
    "message": "Loading app config...",
    "location": "http://localhost:3451/main.c149fdaa77c1d168cf9e.js"
  },
  {
    "type": "log",
    "message": "Loading app config: OK",
    "location": "http://localhost:3451/main.c149fdaa77c1d168cf9e.js"
  },
  {
    "type": "error",
    "message": "Failed to load resource: the server responded with a status of 401 (Unauthorized)",
    "location": "http://localhost:3453/data/internal/profile"
  },
  {
    "type": "error",
    "message": "ERROR JSHandle@error",
    "location": "http://localhost:3451/main.c149fdaa77c1d168cf9e.js"
  },
  {
    "type": "log",
    "message": "Running in the browser with appId=ccd-case-management-web",
    "location": "http://localhost:3451/main.c149fdaa77c1d168cf9e.js"
  },
  {
    "type": "log",
    "message": "Loading app config...",
    "location": "http://localhost:3451/main.c149fdaa77c1d168cf9e.js"
  },
  {
    "type": "log",
    "message": "Loading app config: OK",
    "location": "http://localhost:3451/main.c149fdaa77c1d168cf9e.js"
  },
  {
    "type": "log",
    "message": "Loading app config...",
    "location": "http://localhost:3451/main.c149fdaa77c1d168cf9e.js"
  },
  {
    "type": "log",
    "message": "Loading app config: OK",
    "location": "http://localhost:3451/main.c149fdaa77c1d168cf9e.js"
  },
  {
    "type": "error",
    "message": "Failed to load resource: the server responded with a status of 504 (Gateway Timeout)",
    "location": "http://localhost:3453/data/caseworkers/:uid/jurisdictions/PUBLICLAW/case-types/CARE_SUPERVISION_EPO/cases?ignore-warning=false"
  }
]
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
