### PR TITLE
Updated docker-compose network and docmosis-tornado image/volume/port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,19 +23,17 @@ services:
       - $SERVER_PORT:$SERVER_PORT
     networks:
       - default
-      - ccd
+      - ccd-network
   docmosis-tornado:
-    image: alexisgayte/docmosis
+    image: skeneventures/docmosis-tornado
     environment:
       # not supported in current version of Tornado
       DOCMOSIS_KEY: "XXX"
       DOCMOSIS_SITE: "Free Trial License"
     volumes:
-      - ./docker/docmosis/templates:/tmp/working/templates:rw
-      - ./docker/docmosis/prefs.xml:/root/.java/.userPrefs/com/docmosis/webserver/prefs.xml:ro
+      - ./docker/docmosis/templates:/home/docmosis/templates:rw
     ports:
-      - 5433:80
+      - 5433:8080
 networks:
-  ccd:
-    external:
-      name: compose_default
+  ccd-network:
+      external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     image: hmctspublic.azurecr.io/fpl/case-service
     container_name: fpl-service
     environment:
-      - IDAM_API_URL=http://idam-api:8080
+      - IDAM_API_URL=http://idam-api:5000
       - DOCMOSIS_TORNADO_URL=http://docmosis-tornado:8080
       - DOCMOSIS_TORNADO_KEY
       - DOCUMENT_MANAGEMENT_URL=http://dm-store:8080


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###

Made changes to ensure fpl-service and docmosis-tornado both work when running from docker-compose

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
