### PR TITLE
FPLA-770 Changed court name mapping to be policy compliant on documents

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -76,6 +76,8 @@
     <cve>CVE-2019-14540</cve>
     <cve>CVE-2019-14540</cve>
     <cve>CVE-2019-16335</cve>
+    <cve>CVE-2019-16942</cve>
+    <cve>CVE-2019-16943</cve>
   </suppress>
   <suppress>
     <notes><![CDATA[file name: netty]]></notes>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - IDAM_S2S_AUTH_URL=http://service-auth-provider-api:8080
       - CCD_UI_BASE_URL=http://localhost:3451
       - SPRING_PROFILES_ACTIVE=local,user-mappings
+      - NOTIFY_API_KEY
       # these environment variables are used by java-logging library
     ports:
       - $SERVER_PORT:$SERVER_PORT

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/config/HmctsCourtLookupConfiguration.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/config/HmctsCourtLookupConfiguration.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.fpl.config;
 
-import lombok.Data;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import uk.gov.hmcts.reform.fpl.config.utils.LookupConfigParser;
@@ -31,10 +32,10 @@ public class HmctsCourtLookupConfiguration {
         return checkNotNull(mapping.get(localAuthorityCode), "Local authority '" + localAuthorityCode + "' not found");
     }
 
-    @Data
+    @RequiredArgsConstructor
     public static class Court {
-        private final String name;
-        private final String email;
+        @Getter private final String name;
+        @Getter private final String email;
     }
 }
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/config/HmctsCourtLookupConfiguration.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/config/HmctsCourtLookupConfiguration.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.fpl.config;
 
+import lombok.Data;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import uk.gov.hmcts.reform.fpl.config.utils.LookupConfigParser;
@@ -30,22 +31,10 @@ public class HmctsCourtLookupConfiguration {
         return checkNotNull(mapping.get(localAuthorityCode), "Local authority '" + localAuthorityCode + "' not found");
     }
 
+    @Data
     public static class Court {
         private final String name;
         private final String email;
-
-        public Court(String name, String email) {
-            this.name = name;
-            this.email = email;
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        public String getEmail() {
-            return email;
-        }
     }
 }
 

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -83,11 +83,11 @@ core_case_data:
 
 docmosis:
   tornado:
-    url: https://docmosis-development.platform.hmcts.net
+    url: http://localhost:5433
     key: ACCESS_KEY
 
 document_management:
-  url: http://localhost:4506
+  url: http://localhost:3453
 
 notify:
   api_key: fake-key
@@ -106,6 +106,6 @@ fpl:
   local_authority_code_to_name:
     mapping: 'SA=>Swansea City Council;HN=>London Borough Hillingdon;PCC=>Portsmouth City Council;STF=>Staffordshire County Council;SCC=>Southampton City Council'
   local_authority_code_to_hmcts_court:
-    mapping: 'SA=>Swansea Family Court:FamilyPublicLaw+sa@gmail.com;HN=>Portsmouth Combined Court:FamilyPublicLaw+hn@gmail.com'
+    mapping: 'SA=>Family Court sitting at Swansea:FamilyPublicLaw+sa@gmail.com;HN=>Family Court sitting at Portsmouth:FamilyPublicLaw+hn@gmail.com'
   local_authority_code_to_cafcass:
     mapping: 'SA=>Cafcass Cymru:FamilyPublicLaw+cafcassWales@gmail.com;HN=>Cafcass:FamilyPublicLaw+cafcassEngland@gmail.com'


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FPLA-770

### Change description ###

Changed the LA-to-court-name mapping to be policy compliant. Also changed Court class in lookup configuration to use lombok and fixed the link to docmosis tornado in application.yaml

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```