### PR TITLE
Fixed docmosis URL and docker-compose notify api key

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - IDAM_S2S_AUTH_URL=http://service-auth-provider-api:8080
       - CCD_UI_BASE_URL=http://localhost:3451
       - SPRING_PROFILES_ACTIVE=local,user-mappings
+      - NOTIFY_API_KEY
       # these environment variables are used by java-logging library
     ports:
       - $SERVER_PORT:$SERVER_PORT

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -83,7 +83,7 @@ core_case_data:
 
 docmosis:
   tornado:
-    url: https://docmosis-development.platform.hmcts.net
+    url: http://localhost:5543
     key: ACCESS_KEY
 
 document_management:


### PR DESCRIPTION
### Change description ###

Fixed docmosis tornado URL in application.yml and added empty environmental variable NOTIFY_API_KEY to fpl-service in docker-compose.yml

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```