### PR TITLE
Add SQL script that projects event permissions from last uploaded CCD definitions

### DIFF
--- a/bin/utils/project-event-permissions.sh
+++ b/bin/utils/project-event-permissions.sh
@@ -2,22 +2,27 @@
 
 set -eu
 
+case_type_clause="WHERE reference = 'CARE_SUPERVISION_EPO'"
 state_where_clause=""
 role_where_clause=""
 
-while getopts ":s:r:h" option; do
+while getopts "c::s:r:h" option; do
   case ${option} in
+    c)
+      case_type_clause="WHERE reference = '${OPTARG}'"
+      ;;
     s)
-      state_where_clause="AND s.reference='${OPTARG}'"
+      state_where_clause="AND s.reference = '${OPTARG}'"
       ;;
     r)
-      role_where_clause="AND r.reference='${OPTARG}'"
+      role_where_clause="AND r.reference = '${OPTARG}'"
       ;;
     h)
       echo "
-        Usage: ${0} [-s state] [-r role]
+        Usage: ${0} [-c case type] [-s case state] [-r user role]
 
         Options:
+          -c: allows to select case type (optional, defaults to 'CARE_SUPERVISION_EPO')
           -s: allows to narrow down the list to specific case state (optional)
           -r: allows to narrow down the list to specific user role (optional)
       "
@@ -38,7 +43,7 @@ query="
     LEFT JOIN state s ON eps.state_id = s.id
     JOIN event_acl ea ON e.id = ea.event_id
     JOIN role r ON ea.role_id = r.id
-  WHERE e.case_type_id = (SELECT MAX(id) FROM case_type)
+  WHERE e.case_type_id = (SELECT MAX(id) FROM case_type ${case_type_clause})
     AND \"create\" IS TRUE
     ${state_where_clause}
     ${role_where_clause}

--- a/bin/utils/project-event-permissions.sh
+++ b/bin/utils/project-event-permissions.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -eu
+
+query="
+  SELECT COALESCE(s.reference, '*') as state,
+    r.reference as user_role,
+    e.reference as event_id,
+    e.name as event_name
+  FROM event e
+    LEFT JOIN event_pre_state eps ON e.id = eps.event_id
+    LEFT JOIN state s ON eps.state_id = s.id
+    JOIN event_acl ea ON e.id = ea.event_id
+    JOIN role r ON ea.role_id = r.id
+  WHERE e.case_type_id = (SELECT MAX(id) FROM case_type)
+    AND \"create\" IS TRUE
+  ORDER BY s.display_order,
+    user_role,
+    event_id;
+"
+
+docker run -e PGPASSWORD='ccd' --rm --network ccd-network postgres:11-alpine psql --host ccd-shared-database --username ccd --command "${query}" ccd_definition

--- a/bin/utils/project-event-permissions.sh
+++ b/bin/utils/project-event-permissions.sh
@@ -2,6 +2,32 @@
 
 set -eu
 
+state_where_clause=""
+role_where_clause=""
+
+while getopts ":s:r:h" option; do
+  case ${option} in
+    s)
+      state_where_clause="AND s.reference='${OPTARG}'"
+      ;;
+    r)
+      role_where_clause="AND r.reference='${OPTARG}'"
+      ;;
+    h)
+      echo "
+        Usage: ${0} [-s state] [-r role]
+
+        Options:
+          -s: allows to narrow down the list to specific case state (optional)
+          -r: allows to narrow down the list to specific user role (optional)
+      "
+      exit 1
+      ;;
+    *)
+      ;;
+  esac
+done
+
 query="
   SELECT COALESCE(s.reference, '*') as state,
     r.reference as user_role,
@@ -14,6 +40,8 @@ query="
     JOIN role r ON ea.role_id = r.id
   WHERE e.case_type_id = (SELECT MAX(id) FROM case_type)
     AND \"create\" IS TRUE
+    ${state_where_clause}
+    ${role_where_clause}
   ORDER BY s.display_order,
     user_role,
     event_id;


### PR DESCRIPTION
### JIRA link (if applicable) ###

None

### Change description ###

Projects event permissions per user ans state from last version of uploaded CCD definitions.

Running `bin/utils/project-event-permissions.sh` script will give the following result:

state | user_role | event_id | event_name
-- | -- | -- | --
Open | caseworker-publiclaw-gatekeeper | otherProposal | Allocation proposal
Open | caseworker-publiclaw-solicitor | ordersNeeded | Orders and directions needed
Open | caseworker-publiclaw-solicitor | hearingNeeded | Hearing needed
Open | caseworker-publiclaw-solicitor | enterChildren | Children
Open | caseworker-publiclaw-solicitor | enterRespondents | Respondents
'*' | caseworker-publiclaw-solicitor | openCase | Start application
'*' | caseworker-publiclaw-solicitor | uploadDocuments | Documents

Optionally it allows narrowing down results to specific role by using `-s Open` flag or to specific role by using `-r caseworker-publiclaw-solicitor` flag.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
