### PR TITLE
Exclude android json library from classpath

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -220,6 +220,7 @@ dependencies {
   testCompile (group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot) {
     exclude group: 'junit', module: 'junit'
     exclude group: 'org.mockito', module: 'mockito-core'
+    exclude group: "com.vaadin.external.google", module:"android-json"
   }
   testCompile group: 'org.junit.jupiter', name :'junit-jupiter', version: '5.5.2'
   testCompile group: 'org.mockito', name :'mockito-core', version: '3.0.0'


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Fixes this warning when running the unit tests
```
Found multiple occurrences of org.json.JSONObject on the class path:

	jar:file:/Users/lewisb@kainos.com/.gradle/caches/modules-2/files-2.1/org.json/json/20180813/8566b2b0391d9d4479ea225645c6ed47ef17fe41/json-20180813.jar!/org/json/JSONObject.class
	jar:file:/Users/lewisb@kainos.com/.gradle/caches/modules-2/files-2.1/com.vaadin.external.google/android-json/0.0.20131108.vaadin1/fa26d351fe62a6a17f5cda1287c1c6110dec413f/android-json-0.0.20131108.vaadin1.jar!/org/json/JSONObject.class

You may wish to exclude one of them to ensure predictable runtime behavior
```
by removing the android library

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
