### PR TITLE
fix: add missing LAs to the dropdown list

### DIFF
--- a/ccd-definition/FixedLists/AuthorityFixedList.json
+++ b/ccd-definition/FixedLists/AuthorityFixedList.json
@@ -32,6 +32,48 @@
   {
     "LiveFrom": "01/01/2017",
     "ID": "AuthorityFixedList",
+    "ListElementCode": "SN",
+    "ListElement": "Swindon County Council"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "AuthorityFixedList",
+    "ListElementCode": "SNW",
+    "ListElement": "Wiltshire County Council"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "AuthorityFixedList",
+    "ListElementCode": "RCC",
+    "ListElement": "Reading City Council"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "AuthorityFixedList",
+    "ListElementCode": "NLC",
+    "ListElement": "North Lincolnshire Council"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "AuthorityFixedList",
+    "ListElementCode": "NELC",
+    "ListElement": "North East Lincolnshire Council"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "AuthorityFixedList",
+    "ListElementCode": "LCC",
+    "ListElement": "Liverpool County Council"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "AuthorityFixedList",
+    "ListElementCode": "KBC",
+    "ListElement": "Knowsley Borough Council"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "AuthorityFixedList",
     "ListElementCode": "FPLA",
     "ListElement": "FPLA team"
   }


### PR DESCRIPTION
### Change description ###

Adds missing LAs to the dropdown list on the search screen. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
