### PR TITLE
fix: capitalisation typo in C6 event

### DIFF
--- a/ccd-definition/ComplexTypes/NoticeOfProceedings.json
+++ b/ccd-definition/ComplexTypes/NoticeOfProceedings.json
@@ -4,7 +4,7 @@
     "ID": "NoticeOfProceedings",
     "ListElementCode": "judgeAndLegalAdvisor",
     "FieldType": "JudgeAndLegalAdvisor",
-    "ElementLabel": "Judge and legal Advisor",
+    "ElementLabel": "Judge and legal advisor",
     "SecurityClassification": "Public"
   },
   {


### PR DESCRIPTION
### Change description ###

C6 should show 'Judge and legal advisor' as the header to the judge input widget, but currently shows 'Judge and legal Advisor'

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
