### PR TITLE
fix: stabilised judge selection after advancing to next page in C21 e2e tests

### DIFF
--- a/e2e/tests/hmctsAdministersCaseAfterSubmission_test.js
+++ b/e2e/tests/hmctsAdministersCaseAfterSubmission_test.js
@@ -136,7 +136,7 @@ Scenario('HMCTS admin enters hearing details and submits', async (I, caseViewPag
 Scenario('HMCTS admin creates C21 order for the case', async (I, caseViewPage, createC21OrderEventPage) => {
   await caseViewPage.goToNewActions(config.administrationActions.createC21Order);
   await createC21OrderEventPage.enterOrder();
-  I.click('Continue');
+  await I.retryUntilExists(() => I.click('Continue'), '#judgeAndLegalAdvisor_judgeTitle');
   await createC21OrderEventPage.enterJudgeAndLegalAdvisor('Sotomayer', 'Peter Parker');
   await I.completeEvent('Save and continue');
   const now = new Date();

--- a/e2e/tests/judiciaryAdministersCaseAfterSubmission_test.js
+++ b/e2e/tests/judiciaryAdministersCaseAfterSubmission_test.js
@@ -75,7 +75,7 @@ Scenario('Judiciary enters hearing details and submits', async (I, caseViewPage,
 Scenario('Judiciary creates C21 order for the case', async (I, caseViewPage, createC21OrderEventPage) => {
   await caseViewPage.goToNewActions(config.administrationActions.createC21Order);
   await createC21OrderEventPage.enterOrder();
-  I.click('Continue');
+  await I.retryUntilExists(() => I.click('Continue'), '#judgeAndLegalAdvisor_judgeTitle');
   await createC21OrderEventPage.enterJudgeAndLegalAdvisor('Sotomayer', 'Peter Parker');
   await I.completeEvent('Save and continue');
   const now = new Date();


### PR DESCRIPTION
### Change description ###

Use retryUntilExists instead of just click('Continue') in e2e tests to make sure that the next page has been advanced to until selecting the judge title

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
