### PR TITLE
feat: final care order (FPLA-716)

### DIFF
--- a/ccd-definition/FixedLists/FinalOrderType.json
+++ b/ccd-definition/FixedLists/FinalOrderType.json
@@ -5,5 +5,12 @@
     "ListElementCode": "BLANK_ORDER",
     "ListElement": "Blank order (C21)",
     "DisplayOrder": 1
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "FinalOrderType",
+    "ListElementCode": "CARE_ORDER",
+    "ListElement": "Care order",
+    "DisplayOrder": 2
   }
 ]

--- a/e2e/fixtures/orders.js
+++ b/e2e/fixtures/orders.js
@@ -10,4 +10,13 @@ module.exports = [
       legalAdvisorName: 'Peter Parker',
     },
   },
+  {
+    orderType: 'Care order',
+    orderDoc: 'Care order.pdf',
+    judgeAndLegalAdvisor: {
+      judgeTitle: 'Her Honour Judge',
+      judgeLastName: 'Judy',
+      legalAdvisorName: 'Fred Frederickson',
+    },
+  },
 ];

--- a/e2e/tests/hmctsAdministersCaseAfterSubmission_test.js
+++ b/e2e/tests/hmctsAdministersCaseAfterSubmission_test.js
@@ -152,6 +152,21 @@ Scenario('HMCTS admin creates multiple orders for the case', async (I, caseViewP
   I.seeAnswerInTab(1, 'Judge and legal advisor', 'Judge or magistrate\'s title', orders[0].judgeAndLegalAdvisor.judgeTitle);
   I.seeAnswerInTab(2, 'Judge and legal advisor', 'Last name', orders[0].judgeAndLegalAdvisor.judgeLastName);
   I.seeAnswerInTab(3, 'Judge and legal advisor', 'Legal advisor\'s full name',  orders[0].judgeAndLegalAdvisor.legalAdvisorName);
+
+  await caseViewPage.goToNewActions(config.administrationActions.createFinalOrder);
+  await createFinalOrderEventPage.selectOrderType(orders[1].orderType);
+  await I.retryUntilExists(() => I.click('Continue'), '#judgeAndLegalAdvisor_judgeTitle');
+  await createFinalOrderEventPage.enterJudgeAndLegalAdvisor('Judy', 'Fred Frederickson');
+  await I.completeEvent('Save and continue');
+  const careOrderTime = new Date();
+  I.seeEventSubmissionConfirmation(config.administrationActions.createFinalOrder);
+  caseViewPage.selectTab(caseViewPage.tabs.orders);
+  I.seeAnswerInTab(1, 'Order 2', 'Type of order', orders[1].orderType);
+  I.seeAnswerInTab(2, 'Order 2', 'Order document', orders[1].orderDoc);
+  I.seeAnswerInTab(3, 'Order 2', 'Date and time of upload', dateFormat(careOrderTime, 'd mmmm yyyy'));
+  I.seeAnswerInTab(1, 'Judge and legal advisor', 'Judge or magistrate\'s title', orders[1].judgeAndLegalAdvisor.judgeTitle);
+  I.seeAnswerInTab(2, 'Judge and legal advisor', 'Last name', orders[1].judgeAndLegalAdvisor.judgeLastName);
+  I.seeAnswerInTab(3, 'Judge and legal advisor', 'Legal advisor\'s full name',  orders[1].judgeAndLegalAdvisor.legalAdvisorName);
 });
 
 Scenario('HMCTS admin creates notice of proceedings documents', async (I, caseViewPage, createNoticeOfProceedingsEventPage) => {

--- a/e2e/tests/judiciaryAdministersCaseAfterSubmission_test.js
+++ b/e2e/tests/judiciaryAdministersCaseAfterSubmission_test.js
@@ -91,4 +91,19 @@ Scenario('Judiciary creates multiple orders for the case', async (I, caseViewPag
   I.seeAnswerInTab(1, 'Judge and legal advisor', 'Judge or magistrate\'s title', orders[0].judgeAndLegalAdvisor.judgeTitle);
   I.seeAnswerInTab(2, 'Judge and legal advisor', 'Last name', orders[0].judgeAndLegalAdvisor.judgeLastName);
   I.seeAnswerInTab(3, 'Judge and legal advisor', 'Legal advisor\'s full name',  orders[0].judgeAndLegalAdvisor.legalAdvisorName);
+
+  await caseViewPage.goToNewActions(config.administrationActions.createFinalOrder);
+  await createFinalOrderEventPage.selectOrderType(orders[1].orderType);
+  await I.retryUntilExists(() => I.click('Continue'), '#judgeAndLegalAdvisor_judgeTitle');
+  await createFinalOrderEventPage.enterJudgeAndLegalAdvisor(orders[1].judgeAndLegalAdvisor.judgeLastName, orders[1].judgeAndLegalAdvisor.legalAdvisorName);
+  await I.completeEvent('Save and continue');
+  const careOrderTime = new Date();
+  I.seeEventSubmissionConfirmation(config.administrationActions.createFinalOrder);
+  caseViewPage.selectTab(caseViewPage.tabs.orders);
+  I.seeAnswerInTab(1, 'Order 2', 'Type of order', orders[1].orderType);
+  I.seeAnswerInTab(2, 'Order 2', 'Order document', orders[1].orderDoc);
+  I.seeAnswerInTab(3, 'Order 2', 'Date and time of upload', dateFormat(careOrderTime, 'd mmmm yyyy'));
+  I.seeAnswerInTab(1, 'Judge and legal advisor', 'Judge or magistrate\'s title', orders[1].judgeAndLegalAdvisor.judgeTitle);
+  I.seeAnswerInTab(2, 'Judge and legal advisor', 'Last name', orders[1].judgeAndLegalAdvisor.judgeLastName);
+  I.seeAnswerInTab(3, 'Judge and legal advisor', 'Legal advisor\'s full name',  orders[1].judgeAndLegalAdvisor.legalAdvisorName);
 });

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/FinalOrderControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/FinalOrderControllerTest.java
@@ -47,11 +47,13 @@ import static uk.gov.hmcts.reform.fpl.CaseDefinitionConstants.CASE_TYPE;
 import static uk.gov.hmcts.reform.fpl.CaseDefinitionConstants.JURISDICTION;
 import static uk.gov.hmcts.reform.fpl.NotifyTemplates.FINAL_ORDER_NOTIFICATION_TEMPLATE;
 import static uk.gov.hmcts.reform.fpl.enums.FinalOrderType.BLANK_ORDER;
+import static uk.gov.hmcts.reform.fpl.enums.FinalOrderType.CARE_ORDER;
 import static uk.gov.hmcts.reform.fpl.enums.JudgeOrMagistrateTitle.HER_HONOUR_JUDGE;
 import static uk.gov.hmcts.reform.fpl.utils.CaseDataGeneratorHelper.createFinalOrders;
 import static uk.gov.hmcts.reform.fpl.utils.CaseDataGeneratorHelper.createHearingBookings;
 import static uk.gov.hmcts.reform.fpl.utils.CaseDataGeneratorHelper.createRespondents;
 import static uk.gov.hmcts.reform.fpl.utils.CoreCaseDataStoreLoader.callbackRequest;
+import static uk.gov.hmcts.reform.fpl.utils.CoreCaseDataStoreLoader.careOrderRequest;
 import static uk.gov.hmcts.reform.fpl.utils.DocumentManagementStoreLoader.document;
 
 @ActiveProfiles("integration-test")
@@ -159,6 +161,31 @@ class FinalOrderControllerTest {
                 .build();
 
             aboutToSubmitAssertions(caseData, expectedC21Order);
+        }
+
+        @Test
+        void aboutToSubmitShouldUpdateCaseDataAccordinglyWhenCareOrderIsSelected() throws Exception {
+            AboutToStartOrSubmitCallbackResponse callbackResponse = makeRequest(careOrderRequest(),
+                "about-to-submit");
+
+            CaseData caseData = mapper.convertValue(callbackResponse.getData(), CaseData.class);
+
+            FinalOrder expectedCareOrder = FinalOrder.builder()
+                .type(CARE_ORDER)
+                .document(DocumentReference.builder()
+                    .url("some url")
+                    .binaryUrl("some binary url")
+                    .filename("file.pdf").build())
+                .orderDate(dateFormatterService.formatLocalDateTimeBaseUsingFormat(
+                    FixedTimeConfiguration.NOW, "h:mma, d MMMM yyyy"))
+                .judgeAndLegalAdvisor(JudgeAndLegalAdvisor.builder()
+                    .judgeTitle(HER_HONOUR_JUDGE)
+                    .judgeLastName("Judy")
+                    .legalAdvisorName("Peter Parker")
+                    .build())
+                .build();
+
+            aboutToSubmitAssertions(caseData, expectedCareOrder);
         }
 
         private void aboutToSubmitAssertions(CaseData caseData, FinalOrder expectedOrder) {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/FinalOrderService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/FinalOrderService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.document.domain.Document;
 import uk.gov.hmcts.reform.fpl.config.HmctsCourtLookupConfiguration;
+import uk.gov.hmcts.reform.fpl.config.LocalAuthorityNameLookupConfiguration;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.Child;
 import uk.gov.hmcts.reform.fpl.model.FinalOrder;
@@ -92,7 +93,6 @@ public class FinalOrderService {
     public Map<String, Object> getFinalOrderTemplateData(CaseData caseData) {
         ImmutableMap.Builder<String, Object> orderTemplateBuilder = new ImmutableMap.Builder<>();
 
-        //Scalable for future order types
         switch (caseData.getOrderTypeAndDocument().getFinalOrderType()) {
             case BLANK_ORDER:
                 orderTemplateBuilder
@@ -119,7 +119,7 @@ public class FinalOrderService {
     }
 
     public String generateDocumentFileName(OrderTypeAndDocument orderTypeAndDocument) {
-        return orderTypeAndDocument.getFinalOrderType().getType().replaceAll("[()]", "") + ".pdf";
+        return orderTypeAndDocument.getFinalOrderType().getType() + ".pdf";
     }
 
     public String mostRecentUploadedOrderDocumentUrl(final List<Element<FinalOrder>> finalOrders) {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/FinalOrderService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/FinalOrderService.java
@@ -134,7 +134,7 @@ public class FinalOrderService {
     }
 
     public String generateDocumentFileName(OrderTypeAndDocument orderTypeAndDocument) {
-        return orderTypeAndDocument.getFinalOrderType().getType() + ".pdf";
+        return orderTypeAndDocument.getFinalOrderType().getType().replaceAll("[()]", "") + ".pdf";
     }
 
     public String mostRecentUploadedOrderDocumentUrl(final List<Element<FinalOrder>> finalOrders) {

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/FinalOrderServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/FinalOrderServiceTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.reform.fpl.enums.FinalOrderType.BLANK_ORDER;
+import static uk.gov.hmcts.reform.fpl.enums.FinalOrderType.CARE_ORDER;
 import static uk.gov.hmcts.reform.fpl.enums.JudgeOrMagistrateTitle.HER_HONOUR_JUDGE;
 import static uk.gov.hmcts.reform.fpl.utils.CaseDataGeneratorHelper.createFinalOrders;
 import static uk.gov.hmcts.reform.fpl.utils.DocumentManagementStoreLoader.document;
@@ -192,8 +193,8 @@ class FinalOrderServiceTest {
             .finalOrderType(BLANK_ORDER)
             .document(DocumentReference.builder().build()).build();
 
-        assertThat(service.generateDocumentFileName(typeAndDocument)).isEqualTo(BLANK_ORDER.getType().replaceAll(
-            "[()]", "") + ".pdf");
+        assertThat(service.generateDocumentFileName(typeAndDocument)).isEqualTo(
+            CARE_ORDER.getType().replaceAll("[()]", "") + ".pdf");
     }
 
     @Test
@@ -217,7 +218,6 @@ class FinalOrderServiceTest {
     private Map<String, Object> expectedData(String date, FinalOrderType orderType) {
         ImmutableMap.Builder expectedMap = ImmutableMap.<String, Object>builder();
 
-        //Scalable for future order types
         switch (orderType) {
             case BLANK_ORDER:
                 expectedMap
@@ -247,7 +247,6 @@ class FinalOrderServiceTest {
     private CaseData populatedCaseData(FinalOrderType orderType, LocalDate localDate) {
         CaseData.CaseDataBuilder caseDataBuilder = CaseData.builder();
 
-        //Scalable for future order types
         switch (orderType) {
             case BLANK_ORDER:
                 caseDataBuilder

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/FinalOrderServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/FinalOrderServiceTest.java
@@ -206,7 +206,17 @@ class FinalOrderServiceTest {
     }
 
     @Test
-    void shouldGenerateCorrectFileNameWhenGivenOrderType() {
+    void shouldGenerateCorrectFileNameWhenGivenC21OrderType() {
+        OrderTypeAndDocument typeAndDocument = OrderTypeAndDocument.builder()
+            .finalOrderType(BLANK_ORDER)
+            .document(DocumentReference.builder().build()).build();
+
+        assertThat(service.generateDocumentFileName(typeAndDocument)).isEqualTo(
+            BLANK_ORDER.getType().replaceAll("[()]", "") + ".pdf");
+    }
+
+    @Test
+    void shouldGenerateCorrectFileNameWhenGivenCareOrderType() {
         OrderTypeAndDocument typeAndDocument = OrderTypeAndDocument.builder()
             .finalOrderType(CARE_ORDER)
             .document(DocumentReference.builder().build()).build();

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/FinalOrderServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/FinalOrderServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.document.domain.Document;
 import uk.gov.hmcts.reform.fpl.config.HmctsCourtLookupConfiguration;
+import uk.gov.hmcts.reform.fpl.config.LocalAuthorityNameLookupConfiguration;
 import uk.gov.hmcts.reform.fpl.enums.FinalOrderType;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.Child;
@@ -35,10 +36,12 @@ import static uk.gov.hmcts.reform.fpl.utils.DocumentManagementStoreLoader.docume
 @ExtendWith(SpringExtension.class)
 class FinalOrderServiceTest {
     private static final String LOCAL_AUTHORITY_CODE = "example";
+    private static final String LOCAL_AUTHORITY_NAME = "Example Local Authority";
     private static final String COURT_NAME = "Example Court";
     private static final String COURT_EMAIL = "example@court.com";
     private static final String COURT_CONFIG = String.format("%s=>%s:%s", LOCAL_AUTHORITY_CODE, COURT_NAME,
         COURT_EMAIL);
+    private static final String LA_NAME_CONFIG = String.format("%s=>%s", LOCAL_AUTHORITY_CODE, LOCAL_AUTHORITY_NAME);
     private static final LocalDateTime NOW = LocalDateTime.now();
 
     private final Time time = () -> NOW;
@@ -46,12 +49,15 @@ class FinalOrderServiceTest {
     private DateFormatterService dateFormatterService = new DateFormatterService();
     private HmctsCourtLookupConfiguration hmctsCourtLookupConfiguration = new HmctsCourtLookupConfiguration(
         COURT_CONFIG);
+    private LocalAuthorityNameLookupConfiguration localAuthorityNameLookupConfiguration =
+        new LocalAuthorityNameLookupConfiguration(LA_NAME_CONFIG);
 
     private FinalOrderService service;
 
     @BeforeEach
     void setup() {
-        this.service = new FinalOrderService(dateFormatterService, hmctsCourtLookupConfiguration, time);
+        this.service = new FinalOrderService(dateFormatterService, hmctsCourtLookupConfiguration,
+            localAuthorityNameLookupConfiguration, time);
     }
 
     @Test
@@ -188,13 +194,24 @@ class FinalOrderServiceTest {
     }
 
     @Test
+    void shouldCreateExpectedMapForCareOrderWhenGivenPopulatedCaseData() {
+        LocalDate localDate = LocalDate.now();
+        String date = dateFormatterService.formatLocalDateToString(localDate, FormatStyle.LONG);
+        CaseData caseData = populatedCaseData(CARE_ORDER, localDate);
+
+        Map<String, Object> expectedMap = expectedData(date, CARE_ORDER);
+        Map<String, Object> templateData = service.getFinalOrderTemplateData(caseData);
+
+        assertThat(templateData).isEqualTo(expectedMap);
+    }
+
+    @Test
     void shouldGenerateCorrectFileNameWhenGivenOrderType() {
         OrderTypeAndDocument typeAndDocument = OrderTypeAndDocument.builder()
-            .finalOrderType(BLANK_ORDER)
+            .finalOrderType(CARE_ORDER)
             .document(DocumentReference.builder().build()).build();
 
-        assertThat(service.generateDocumentFileName(typeAndDocument)).isEqualTo(
-            CARE_ORDER.getType().replaceAll("[()]", "") + ".pdf");
+        assertThat(service.generateDocumentFileName(typeAndDocument)).isEqualTo(CARE_ORDER.getType() + ".pdf");
     }
 
     @Test
@@ -225,6 +242,14 @@ class FinalOrderServiceTest {
                     .put("orderTitle", "Example Title")
                     .put("childrenAct", "Section 31 Children Act 1989")
                     .put("orderDetails", "Example details");
+                break;
+            case CARE_ORDER:
+                expectedMap
+                    .put("orderType", CARE_ORDER)
+                    .put("orderTitle", "Care Order")
+                    .put("childrenAct", "Children Act 1989")
+                    .put("orderDetails",
+                        "It is ordered that the child is placed in the care of Example Local Authority.");
                 break;
             default:
         }
@@ -257,6 +282,13 @@ class FinalOrderServiceTest {
                     .finalOrder(FinalOrder.builder()
                         .orderTitle("Example Title")
                         .orderDetails("Example details")
+                        .build());
+                break;
+            case CARE_ORDER:
+                caseDataBuilder
+                    .orderTypeAndDocument(OrderTypeAndDocument.builder()
+                        .finalOrderType(CARE_ORDER)
+                        .document(DocumentReference.builder().build())
                         .build());
                 break;
             default:

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/utils/CoreCaseDataStoreLoader.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/utils/CoreCaseDataStoreLoader.java
@@ -28,4 +28,9 @@ public class CoreCaseDataStoreLoader {
         String response = ResourceReader.readString("core-case-data-store-api/callback-request.json");
         return mapper.readValue(response, CallbackRequest.class);
     }
+
+    public static CallbackRequest careOrderRequest() throws IOException {
+        String response = ResourceReader.readString("core-case-data-store-api/care-order.json");
+        return mapper.readValue(response, CallbackRequest.class);
+    }
 }

--- a/service/src/test/resources/core-case-data-store-api/care-order.json
+++ b/service/src/test/resources/core-case-data-store-api/care-order.json
@@ -1,0 +1,20 @@
+{
+  "case_details": {
+    "case_data": {
+      "orderTypeAndDocument": {
+        "finalOrderType": "CARE_ORDER",
+        "document": {
+          "document_url": "some url",
+          "document_binary_url": "some binary url",
+          "document_filename": "file.pdf"
+        }
+      },
+      "judgeAndLegalAdvisor": {
+        "judgeTitle": "HER_HONOUR_JUDGE",
+        "judgeLastName": "Judy",
+        "legalAdvisorName": "Peter Parker"
+      },
+      "familyManCaseNumber": "12345L"
+    }
+  }
+}


### PR DESCRIPTION
### Review #685 first ###
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FPLA-716

### Change description ###

New type of order in the 'Create an order' event: Care order. When selecting this type, user will not see the page for entering title and details. If care order is selected, then the template will display as a Care Order document.

This extends on the C21 refactor and therefore should be reviewed AFTER https://github.com/hmcts/fpl-ccd-configuration/pull/685/. Once 685 has been reviewed, then this can be reviewed. Upon approval, this will merge into 685, and then 685 will be sent to QA.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```