### PR TITLE
refactor: refactor of C21 in preparation for extending 'Create an order' event

### DIFF
--- a/ccd-definition/AuthorisationCaseEvent/AuthorisationCaseEvent.json
+++ b/ccd-definition/AuthorisationCaseEvent/AuthorisationCaseEvent.json
@@ -499,28 +499,28 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "CaseEventID": "createC21Order",
+    "CaseEventID": "createOrder",
     "UserRole": "caseworker-publiclaw-courtadmin",
     "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "CaseEventID": "createC21OrderGatekeeping",
+    "CaseEventID": "createOrderGatekeeping",
     "UserRole": "caseworker-publiclaw-courtadmin",
     "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "CaseEventID": "createC21Order",
+    "CaseEventID": "createOrder",
     "UserRole": "caseworker-publiclaw-judiciary",
     "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "CaseEventID": "createC21OrderGatekeeping",
+    "CaseEventID": "createOrderGatekeeping",
     "UserRole": "caseworker-publiclaw-judiciary",
     "CRUD": "CRU"
   }

--- a/ccd-definition/AuthorisationCaseField/court-admin.json
+++ b/ccd-definition/AuthorisationCaseField/court-admin.json
@@ -359,7 +359,7 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "CaseFieldID": "generatedOrders",
+    "CaseFieldID": "orderCollection",
     "UserRole": "caseworker-publiclaw-courtadmin",
     "CRUD": "CRU"
   },

--- a/ccd-definition/AuthorisationCaseField/court-admin.json
+++ b/ccd-definition/AuthorisationCaseField/court-admin.json
@@ -359,14 +359,14 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "CaseFieldID": "c21Orders",
+    "CaseFieldID": "generatedOrders",
     "UserRole": "caseworker-publiclaw-courtadmin",
     "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "CaseFieldID": "c21Order",
+    "CaseFieldID": "order",
     "UserRole": "caseworker-publiclaw-courtadmin",
     "CRUD": "CRU"
   },

--- a/ccd-definition/AuthorisationCaseField/judiciary.json
+++ b/ccd-definition/AuthorisationCaseField/judiciary.json
@@ -23,14 +23,14 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "CaseFieldID": "c21Orders",
+    "CaseFieldID": "generatedOrders",
     "UserRole": "caseworker-publiclaw-judiciary",
     "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "CaseFieldID": "c21Order",
+    "CaseFieldID": "order",
     "UserRole": "caseworker-publiclaw-judiciary",
     "CRUD": "CRU"
   },

--- a/ccd-definition/AuthorisationCaseField/judiciary.json
+++ b/ccd-definition/AuthorisationCaseField/judiciary.json
@@ -23,7 +23,7 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "CaseFieldID": "generatedOrders",
+    "CaseFieldID": "orderCollection",
     "UserRole": "caseworker-publiclaw-judiciary",
     "CRUD": "CRU"
   },

--- a/ccd-definition/CaseEvent/Gatekeeping.json
+++ b/ccd-definition/CaseEvent/Gatekeeping.json
@@ -181,7 +181,7 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "ID": "createC21OrderGatekeeping",
+    "ID": "createOrderGatekeeping",
     "Name": "Create an order",
     "Description": "Create an order",
     "DisplayOrder": 12,

--- a/ccd-definition/CaseEvent/Submitted.json
+++ b/ccd-definition/CaseEvent/Submitted.json
@@ -192,7 +192,7 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "ID": "createC21Order",
+    "ID": "createOrder",
     "Name": "Create an order",
     "Description": "Create an order",
     "DisplayOrder": 14,

--- a/ccd-definition/CaseEventToComplexTypes/create-order/create-order-gatekeeping.json
+++ b/ccd-definition/CaseEventToComplexTypes/create-order/create-order-gatekeeping.json
@@ -1,9 +1,9 @@
 [
   {
     "LiveFrom": "01/01/2017",
-    "ID": "C21OrderComplexType",
-    "CaseEventID": "createC21Order",
-    "CaseFieldID": "c21Order",
+    "ID": "GeneratedOrderComplexType",
+    "CaseEventID": "createOrderGatekeeping",
+    "CaseFieldID": "order",
     "ListElementCode": "orderTitle",
     "EventElementLabel": "Order title",
     "FieldDisplayOrder": 1,
@@ -11,9 +11,9 @@
   },
   {
     "LiveFrom": "01/01/2017",
-    "ID": "C21OrderComplexType",
-    "CaseEventID": "createC21Order",
-    "CaseFieldID": "c21Order",
+    "ID": "GeneratedOrderComplexType",
+    "CaseEventID": "createOrderGatekeeping",
+    "CaseFieldID": "order",
     "ListElementCode": "orderDetails",
     "EventElementLabel": "Order details",
     "FieldDisplayOrder": 2,
@@ -21,9 +21,9 @@
   },
   {
     "LiveFrom": "01/01/2017",
-    "ID": "C21OrderComplexType",
-    "CaseEventID": "createC21Order",
-    "CaseFieldID": "c21Order",
+    "ID": "GeneratedOrderComplexType",
+    "CaseEventID": "createOrderGatekeeping",
+    "CaseFieldID": "order",
     "ListElementCode": "document",
     "EventElementLabel": "Order document",
     "FieldDisplayOrder": 3,
@@ -32,9 +32,9 @@
   },
   {
     "LiveFrom": "01/01/2017",
-    "ID": "C21OrderComplexType",
-    "CaseEventID": "createC21Order",
-    "CaseFieldID": "c21Order",
+    "ID": "GeneratedOrderComplexType",
+    "CaseEventID": "createOrderGatekeeping",
+    "CaseFieldID": "order",
     "ListElementCode": "orderDate",
     "EventElementLabel": "Date and time of upload",
     "FieldDisplayOrder": 4,
@@ -44,7 +44,7 @@
   {
     "LiveFrom": "01/01/2017",
     "ID": "JudgeAndLegalAdvisorComplexType",
-    "CaseEventID": "createC21Order",
+    "CaseEventID": "createOrderGatekeeping",
     "CaseFieldID": "judgeAndLegalAdvisor",
     "ListElementCode": "judgeTitle",
     "EventElementLabel": "Judge or magistrate's title",
@@ -54,7 +54,7 @@
   {
     "LiveFrom": "01/01/2017",
     "ID": "JudgeAndLegalAdvisorComplexType",
-    "CaseEventID": "createC21Order",
+    "CaseEventID": "createOrderGatekeeping",
     "CaseFieldID": "judgeAndLegalAdvisor",
     "ListElementCode": "judgeLastName",
     "EventElementLabel": "Last name",
@@ -64,7 +64,7 @@
   {
     "LiveFrom": "01/01/2017",
     "ID": "JudgeAndLegalAdvisorComplexType",
-    "CaseEventID": "createC21Order",
+    "CaseEventID": "createOrderGatekeeping",
     "CaseFieldID": "judgeAndLegalAdvisor",
     "ListElementCode": "judgeFullName",
     "EventElementLabel": "Full name",
@@ -74,7 +74,7 @@
   {
     "LiveFrom": "01/01/2017",
     "ID": "JudgeAndLegalAdvisorComplexType",
-    "CaseEventID": "createC21Order",
+    "CaseEventID": "createOrderGatekeeping",
     "CaseFieldID": "judgeAndLegalAdvisor",
     "ListElementCode": "legalAdvisorName",
     "EventElementLabel": "Legal advisor's full name",

--- a/ccd-definition/CaseEventToComplexTypes/create-order/create-order-submitted.json
+++ b/ccd-definition/CaseEventToComplexTypes/create-order/create-order-submitted.json
@@ -1,9 +1,9 @@
 [
   {
     "LiveFrom": "01/01/2017",
-    "ID": "C21OrderComplexType",
-    "CaseEventID": "createC21OrderGatekeeping",
-    "CaseFieldID": "c21Order",
+    "ID": "GeneratedOrderComplexType",
+    "CaseEventID": "createOrder",
+    "CaseFieldID": "order",
     "ListElementCode": "orderTitle",
     "EventElementLabel": "Order title",
     "FieldDisplayOrder": 1,
@@ -11,9 +11,9 @@
   },
   {
     "LiveFrom": "01/01/2017",
-    "ID": "C21OrderComplexType",
-    "CaseEventID": "createC21OrderGatekeeping",
-    "CaseFieldID": "c21Order",
+    "ID": "GeneratedOrderComplexType",
+    "CaseEventID": "createOrder",
+    "CaseFieldID": "order",
     "ListElementCode": "orderDetails",
     "EventElementLabel": "Order details",
     "FieldDisplayOrder": 2,
@@ -21,9 +21,9 @@
   },
   {
     "LiveFrom": "01/01/2017",
-    "ID": "C21OrderComplexType",
-    "CaseEventID": "createC21OrderGatekeeping",
-    "CaseFieldID": "c21Order",
+    "ID": "GeneratedOrderComplexType",
+    "CaseEventID": "createOrder",
+    "CaseFieldID": "order",
     "ListElementCode": "document",
     "EventElementLabel": "Order document",
     "FieldDisplayOrder": 3,
@@ -32,9 +32,9 @@
   },
   {
     "LiveFrom": "01/01/2017",
-    "ID": "C21OrderComplexType",
-    "CaseEventID": "createC21OrderGatekeeping",
-    "CaseFieldID": "c21Order",
+    "ID": "GeneratedOrderComplexType",
+    "CaseEventID": "createOrder",
+    "CaseFieldID": "order",
     "ListElementCode": "orderDate",
     "EventElementLabel": "Date and time of upload",
     "FieldDisplayOrder": 4,
@@ -44,7 +44,7 @@
   {
     "LiveFrom": "01/01/2017",
     "ID": "JudgeAndLegalAdvisorComplexType",
-    "CaseEventID": "createC21OrderGatekeeping",
+    "CaseEventID": "createOrder",
     "CaseFieldID": "judgeAndLegalAdvisor",
     "ListElementCode": "judgeTitle",
     "EventElementLabel": "Judge or magistrate's title",
@@ -54,7 +54,7 @@
   {
     "LiveFrom": "01/01/2017",
     "ID": "JudgeAndLegalAdvisorComplexType",
-    "CaseEventID": "createC21OrderGatekeeping",
+    "CaseEventID": "createOrder",
     "CaseFieldID": "judgeAndLegalAdvisor",
     "ListElementCode": "judgeLastName",
     "EventElementLabel": "Last name",
@@ -64,7 +64,7 @@
   {
     "LiveFrom": "01/01/2017",
     "ID": "JudgeAndLegalAdvisorComplexType",
-    "CaseEventID": "createC21OrderGatekeeping",
+    "CaseEventID": "createOrder",
     "CaseFieldID": "judgeAndLegalAdvisor",
     "ListElementCode": "judgeFullName",
     "EventElementLabel": "Full name",
@@ -74,7 +74,7 @@
   {
     "LiveFrom": "01/01/2017",
     "ID": "JudgeAndLegalAdvisorComplexType",
-    "CaseEventID": "createC21OrderGatekeeping",
+    "CaseEventID": "createOrder",
     "CaseFieldID": "judgeAndLegalAdvisor",
     "ListElementCode": "legalAdvisorName",
     "EventElementLabel": "Legal advisor's full name",

--- a/ccd-definition/CaseEventToFields/createOrder.json
+++ b/ccd-definition/CaseEventToFields/createOrder.json
@@ -2,8 +2,8 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "CaseEventID": "createC21Order",
-    "CaseFieldID": "c21Order",
+    "CaseEventID": "createOrder",
+    "CaseFieldID": "order",
     "PageFieldDisplayOrder": 1,
     "DisplayContext": "COMPLEX",
     "PageID": "OrderInformation",
@@ -15,7 +15,7 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "CaseEventID": "createC21Order",
+    "CaseEventID": "createOrder",
     "CaseFieldID": "judgeAndLegalAdvisor",
     "PageFieldDisplayOrder": 1,
     "DisplayContext": "COMPLEX",

--- a/ccd-definition/CaseEventToFields/createOrderGatekeeping.json
+++ b/ccd-definition/CaseEventToFields/createOrderGatekeeping.json
@@ -2,8 +2,8 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "CaseEventID": "createC21OrderGatekeeping",
-    "CaseFieldID": "c21Order",
+    "CaseEventID": "createOrderGatekeeping",
+    "CaseFieldID": "order",
     "PageFieldDisplayOrder": 1,
     "DisplayContext": "COMPLEX",
     "PageID": "OrderInformation",
@@ -15,7 +15,7 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "CaseEventID": "createC21OrderGatekeeping",
+    "CaseEventID": "createOrderGatekeeping",
     "CaseFieldID": "judgeAndLegalAdvisor",
     "PageFieldDisplayOrder": 1,
     "DisplayContext": "COMPLEX",

--- a/ccd-definition/CaseField.json
+++ b/ccd-definition/CaseField.json
@@ -616,20 +616,20 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "ID": "c21Orders",
-    "Label": "C21 order",
+    "ID": "generatedOrders",
+    "Label": "C21 Order",
     "FieldType": "Collection",
-    "FieldTypeParameter": "C21Order",
+    "FieldTypeParameter": "GeneratedOrder",
     "SecurityClassification": "Public"
   },
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "ID": "c21Order",
+    "ID": "order",
     "Label": "Create an order",
-    "FieldType": "C21Order",
+    "FieldType": "GeneratedOrder",
     "SecurityClassification": "Public",
-    "Comment": "Event is single order centric: c21Order added to Collection of orders above (displayed in orders tab) then deleted from case data so that event can be used to create a new order"
+    "Comment": "Event is single order centric: order added to Collection of generatedOrders above (displayed in orders tab) then deleted from case data so that event can be used to create a new order"
   },
   {
     "LiveFrom": "01/01/2017",

--- a/ccd-definition/CaseField.json
+++ b/ccd-definition/CaseField.json
@@ -616,7 +616,7 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "ID": "generatedOrders",
+    "ID": "orderCollection",
     "Label": "C21 order",
     "FieldType": "Collection",
     "FieldTypeParameter": "GeneratedOrder",
@@ -629,7 +629,7 @@
     "Label": "Create an order",
     "FieldType": "GeneratedOrder",
     "SecurityClassification": "Public",
-    "Comment": "Event is single order centric: order added to Collection of generatedOrders above (displayed in orders tab) then deleted from case data so that event can be used to create a new order"
+    "Comment": "Event is single order centric: order added to Collection of orderCollection above (displayed in orders tab) then deleted from case data so that event can be used to create a new order"
   },
   {
     "LiveFrom": "01/01/2017",

--- a/ccd-definition/CaseField.json
+++ b/ccd-definition/CaseField.json
@@ -617,7 +617,7 @@
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
     "ID": "generatedOrders",
-    "Label": "C21 Order",
+    "Label": "C21 order",
     "FieldType": "Collection",
     "FieldTypeParameter": "GeneratedOrder",
     "SecurityClassification": "Public"

--- a/ccd-definition/CaseTypeTab.json
+++ b/ccd-definition/CaseTypeTab.json
@@ -98,7 +98,7 @@
     "TabID": "OrdersTab",
     "TabLabel": "Orders",
     "TabDisplayOrder": 4,
-    "CaseFieldID": "generatedOrders",
+    "CaseFieldID": "orderCollection",
     "TabFieldDisplayOrder": 3
   },
   {

--- a/ccd-definition/CaseTypeTab.json
+++ b/ccd-definition/CaseTypeTab.json
@@ -98,7 +98,7 @@
     "TabID": "OrdersTab",
     "TabLabel": "Orders",
     "TabDisplayOrder": 4,
-    "CaseFieldID": "c21Orders",
+    "CaseFieldID": "generatedOrders",
     "TabFieldDisplayOrder": 3
   },
   {

--- a/ccd-definition/ComplexTypes/GeneratedOrder.json
+++ b/ccd-definition/ComplexTypes/GeneratedOrder.json
@@ -1,7 +1,7 @@
 [
   {
     "LiveFrom": "01/01/2017",
-    "ID": "C21Order",
+    "ID": "GeneratedOrder",
     "ListElementCode": "orderTitle",
     "FieldType": "Text",
     "ElementLabel": "Order title",
@@ -10,7 +10,7 @@
   },
   {
     "LiveFrom": "01/01/2017",
-    "ID": "C21Order",
+    "ID": "GeneratedOrder",
     "ListElementCode": "orderDetails",
     "FieldType": "TextArea",
     "ElementLabel": "Order details",
@@ -20,7 +20,7 @@
   },
   {
     "LiveFrom": "01/01/2017",
-    "ID": "C21Order",
+    "ID": "GeneratedOrder",
     "ListElementCode": "document",
     "FieldType": "Document",
     "ElementLabel": "Order document",
@@ -28,7 +28,7 @@
   },
   {
     "LiveFrom": "01/01/2017",
-    "ID": "C21Order",
+    "ID": "GeneratedOrder",
     "ListElementCode": "orderDate",
     "FieldType": "Text",
     "ElementLabel": "Date and time of upload",
@@ -36,7 +36,7 @@
   },
   {
     "LiveFrom": "01/01/2017",
-    "ID": "C21Order",
+    "ID": "GeneratedOrder",
     "ListElementCode": "judgeAndLegalAdvisor",
     "FieldType": "JudgeAndLegalAdvisor",
     "ElementLabel": "Judge and legal advisor",

--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -66,7 +66,7 @@ exports.config = {
     addStatementOfServiceEventPage: './e2e/pages/events/addStatementOfServiceEvent.page.js',
     uploadC2DocumentsEventPage: './e2e/pages/events/uploadC2DocumentsEvent.page.js',
     draftStandardDirectionsEventPage: './e2e/pages/events/draftStandardDirectionsEvent.page.js',
-    createC21OrderEventPage: './e2e/pages/events/createC21OrderEvent.page.js',
+    createOrderEventPage: './e2e/pages/events/createOrderEvent.page.js',
     draftCaseManagementOrderEventPage: './e2e/pages/events/draftCaseManagementOrderEvent.page.js',
     complyWithDirectionsEventPage: './e2e/pages/events/complyWithDirectionsEvent.page.js',
   },

--- a/e2e/config.js
+++ b/e2e/config.js
@@ -71,7 +71,7 @@ module.exports = {
     addStatementOfService: 'Add statement of service (c9)',
     uploadC2Documents: 'Upload a C2',
     draftStandardDirections: 'Draft standard directions',
-    createC21Order: 'Create an order',
+    createOrder: 'Create an order',
   },
   // files
   testFile: './e2e/fixtures/mockFile.txt',

--- a/e2e/fixtures/orders.js
+++ b/e2e/fixtures/orders.js
@@ -1,0 +1,12 @@
+module.exports = [
+  {
+    orderTitle: 'Example Order Title',
+    orderDetails: 'Example order details here - Lorem ipsum dolor sit amet...',
+    orderDoc: 'C21_order.pdf',
+    judgeAndLegalAdvisor: {
+      judgeTitle: 'Her Honour Judge',
+      judgeLastName: 'Sotomayer',
+      legalAdvisorName: 'Peter Parker',
+    },
+  },
+];

--- a/e2e/pages/events/createOrderEvent.page.js
+++ b/e2e/pages/events/createOrderEvent.page.js
@@ -1,15 +1,16 @@
 const {I} = inject();
 const judgeAndLegalAdvisor = require('../../fragments/judgeAndLegalAdvisor');
+const orders = require('../../fixtures/orders.js');
 
 module.exports = {
   fields: {
-    orderTitle: '#c21Order_orderTitle',
-    orderDetails: '#c21Order_orderDetails',
+    orderTitle: '#order_orderTitle',
+    orderDetails: '#order_orderDetails',
   },
 
-  enterOrder() {
-    I.fillField(this.fields.orderTitle, 'Example Title');
-    I.fillField(this.fields.orderDetails, 'Example order details here - Lorem ipsum dolor sit amet...');
+  enterC21OrderDetails() {
+    I.fillField(this.fields.orderTitle, orders[0].orderTitle);
+    I.fillField(this.fields.orderDetails, orders[0].orderDetails);
   },
 
   async enterJudgeAndLegalAdvisor(judgeLastName, legalAdvisorName) {

--- a/e2e/tests/hmctsAdministersCaseAfterSubmission_test.js
+++ b/e2e/tests/hmctsAdministersCaseAfterSubmission_test.js
@@ -144,9 +144,9 @@ Scenario('HMCTS admin creates C21 order for the case', async (I, caseViewPage, c
 
   I.seeEventSubmissionConfirmation(config.administrationActions.createOrder);
   caseViewPage.selectTab(caseViewPage.tabs.orders);
-  I.seeAnswerInTab(1, 'C21 Order 1', 'Order title', orders[0].orderTitle);
-  I.seeAnswerInTab(3, 'C21 Order 1', 'Order document', orders[0].orderDoc);
-  I.seeAnswerInTab(4, 'C21 Order 1', 'Date and time of upload', dateFormat(now, 'd mmmm yyyy'));
+  I.seeAnswerInTab(1, 'C21 order 1', 'Order title', orders[0].orderTitle);
+  I.seeAnswerInTab(3, 'C21 order 1', 'Order document', orders[0].orderDoc);
+  I.seeAnswerInTab(4, 'C21 order 1', 'Date and time of upload', dateFormat(now, 'd mmmm yyyy'));
   I.seeAnswerInTab(1, 'Judge and legal advisor', 'Judge or magistrate\'s title', orders[0].judgeAndLegalAdvisor.judgeTitle);
   I.seeAnswerInTab(2, 'Judge and legal advisor', 'Last name', orders[0].judgeAndLegalAdvisor.judgeLastName);
   I.seeAnswerInTab(3, 'Judge and legal advisor', 'Legal advisor\'s full name', orders[0].judgeAndLegalAdvisor.legalAdvisorName);

--- a/e2e/tests/hmctsAdministersCaseAfterSubmission_test.js
+++ b/e2e/tests/hmctsAdministersCaseAfterSubmission_test.js
@@ -1,5 +1,6 @@
 const config = require('../config.js');
 const hearingDetails = require('../fixtures/hearingTypeDetails.js');
+const orders = require('../fixtures/orders.js');
 const dateFormat = require('dateformat');
 const dateToString = require('../helpers/date_to_string_helper');
 
@@ -133,22 +134,22 @@ Scenario('HMCTS admin enters hearing details and submits', async (I, caseViewPag
   I.seeAnswerInTab(4, 'Judge and legal advisor', 'Legal advisor\'s full name', hearingDetails[1].judgeAndLegalAdvisor.legalAdvisorName);
 });
 
-Scenario('HMCTS admin creates C21 order for the case', async (I, caseViewPage, createC21OrderEventPage) => {
-  await caseViewPage.goToNewActions(config.administrationActions.createC21Order);
-  await createC21OrderEventPage.enterOrder();
+Scenario('HMCTS admin creates C21 order for the case', async (I, caseViewPage, createOrderEventPage) => {
+  await caseViewPage.goToNewActions(config.administrationActions.createOrder);
+  await createOrderEventPage.enterC21OrderDetails();
   await I.retryUntilExists(() => I.click('Continue'), '#judgeAndLegalAdvisor_judgeTitle');
-  await createC21OrderEventPage.enterJudgeAndLegalAdvisor('Sotomayer', 'Peter Parker');
+  await createOrderEventPage.enterJudgeAndLegalAdvisor(orders[0].judgeAndLegalAdvisor.judgeLastName, orders[0].judgeAndLegalAdvisor.legalAdvisorName);
   await I.completeEvent('Save and continue');
   const now = new Date();
-  I.seeEventSubmissionConfirmation(config.administrationActions.createC21Order);
-  caseViewPage.selectTab(caseViewPage.tabs.orders);
-  I.seeAnswerInTab(1, 'C21 order 1', 'Order title', 'Example Title');
-  I.seeAnswerInTab(3, 'C21 order 1', 'Order document', 'C21_order.pdf');
-  I.seeAnswerInTab(4, 'C21 order 1', 'Date and time of upload', dateFormat(now, 'd mmmm yyyy'));
-  I.seeAnswerInTab(1, 'Judge and legal advisor', 'Judge or magistrate\'s title', 'Her Honour Judge');
-  I.seeAnswerInTab(2, 'Judge and legal advisor', 'Last name', 'Sotomayer');
-  I.seeAnswerInTab(3, 'Judge and legal advisor', 'Legal advisor\'s full name', 'Peter Parker');
 
+  I.seeEventSubmissionConfirmation(config.administrationActions.createOrder);
+  caseViewPage.selectTab(caseViewPage.tabs.orders);
+  I.seeAnswerInTab(1, 'C21 Order 1', 'Order title', orders[0].orderTitle);
+  I.seeAnswerInTab(3, 'C21 Order 1', 'Order document', orders[0].orderDoc);
+  I.seeAnswerInTab(4, 'C21 Order 1', 'Date and time of upload', dateFormat(now, 'd mmmm yyyy'));
+  I.seeAnswerInTab(1, 'Judge and legal advisor', 'Judge or magistrate\'s title', orders[0].judgeAndLegalAdvisor.judgeTitle);
+  I.seeAnswerInTab(2, 'Judge and legal advisor', 'Last name', orders[0].judgeAndLegalAdvisor.judgeLastName);
+  I.seeAnswerInTab(3, 'Judge and legal advisor', 'Legal advisor\'s full name', orders[0].judgeAndLegalAdvisor.legalAdvisorName);
 });
 
 Scenario('HMCTS admin creates notice of proceedings documents', async (I, caseViewPage, createNoticeOfProceedingsEventPage) => {

--- a/e2e/tests/judiciaryAdministersCaseAfterSubmission_test.js
+++ b/e2e/tests/judiciaryAdministersCaseAfterSubmission_test.js
@@ -1,5 +1,6 @@
 const config = require('../config.js');
 const hearingDetails = require('../fixtures/hearingTypeDetails.js');
+const orders = require('../fixtures/orders.js');
 const dateFormat = require('dateformat');
 const dateToString = require('../helpers/date_to_string_helper');
 
@@ -33,7 +34,7 @@ Before(async (I, caseViewPage, submitApplicationEventPage, enterFamilyManCaseNum
   await I.navigateToCaseDetails(caseId);
 });
 
-Scenario('Judiciary enters hearing details and submits', async (I, caseViewPage, loginPage, addHearingBookingDetailsEventPage) => {
+xScenario('Judiciary enters hearing details and submits', async (I, caseViewPage, loginPage, addHearingBookingDetailsEventPage) => {
   await caseViewPage.goToNewActions(config.administrationActions.addHearingBookingDetails);
   await addHearingBookingDetailsEventPage.enterHearingDetails(hearingDetails[0]);
   await I.addAnotherElementToCollection();
@@ -72,20 +73,20 @@ Scenario('Judiciary enters hearing details and submits', async (I, caseViewPage,
   I.seeAnswerInTab(4, 'Judge and legal advisor', 'Legal advisor\'s full name', hearingDetails[1].judgeAndLegalAdvisor.legalAdvisorName);
 });
 
-Scenario('Judiciary creates C21 order for the case', async (I, caseViewPage, createC21OrderEventPage) => {
-  await caseViewPage.goToNewActions(config.administrationActions.createC21Order);
-  await createC21OrderEventPage.enterOrder();
+Scenario('Judiciary creates C21 order for the case', async (I, caseViewPage, createOrderEventPage) => {
+  await caseViewPage.goToNewActions(config.administrationActions.createOrder);
+  await createOrderEventPage.enterC21OrderDetails();
   await I.retryUntilExists(() => I.click('Continue'), '#judgeAndLegalAdvisor_judgeTitle');
-  await createC21OrderEventPage.enterJudgeAndLegalAdvisor('Sotomayer', 'Peter Parker');
+  await createOrderEventPage.enterJudgeAndLegalAdvisor(orders[0].judgeAndLegalAdvisor.judgeLastName, orders[0].judgeAndLegalAdvisor.legalAdvisorName);
   await I.completeEvent('Save and continue');
   const now = new Date();
 
-  I.seeEventSubmissionConfirmation(config.administrationActions.createC21Order);
+  I.seeEventSubmissionConfirmation(config.administrationActions.createOrder);
   caseViewPage.selectTab(caseViewPage.tabs.orders);
-  I.seeAnswerInTab(1, 'C21 order 1', 'Order title', 'Example Title');
-  I.seeAnswerInTab(3, 'C21 order 1', 'Order document', 'C21_order.pdf');
-  I.seeAnswerInTab(4, 'C21 order 1', 'Date and time of upload', dateFormat(now, 'd mmmm yyyy'));
-  I.seeAnswerInTab(1, 'Judge and legal advisor', 'Judge or magistrate\'s title', 'Her Honour Judge');
-  I.seeAnswerInTab(2, 'Judge and legal advisor', 'Last name', 'Sotomayer');
-  I.seeAnswerInTab(3, 'Judge and legal advisor', 'Legal advisor\'s full name', 'Peter Parker');
+  I.seeAnswerInTab(1, 'C21 Order 1', 'Order title', orders[0].orderTitle);
+  I.seeAnswerInTab(3, 'C21 Order 1', 'Order document', orders[0].orderDoc);
+  I.seeAnswerInTab(4, 'C21 Order 1', 'Date and time of upload', dateFormat(now, 'd mmmm yyyy'));
+  I.seeAnswerInTab(1, 'Judge and legal advisor', 'Judge or magistrate\'s title', orders[0].judgeAndLegalAdvisor.judgeTitle);
+  I.seeAnswerInTab(2, 'Judge and legal advisor', 'Last name', orders[0].judgeAndLegalAdvisor.judgeLastName);
+  I.seeAnswerInTab(3, 'Judge and legal advisor', 'Legal advisor\'s full name', orders[0].judgeAndLegalAdvisor.legalAdvisorName);
 });

--- a/e2e/tests/judiciaryAdministersCaseAfterSubmission_test.js
+++ b/e2e/tests/judiciaryAdministersCaseAfterSubmission_test.js
@@ -34,7 +34,7 @@ Before(async (I, caseViewPage, submitApplicationEventPage, enterFamilyManCaseNum
   await I.navigateToCaseDetails(caseId);
 });
 
-xScenario('Judiciary enters hearing details and submits', async (I, caseViewPage, loginPage, addHearingBookingDetailsEventPage) => {
+Scenario('Judiciary enters hearing details and submits', async (I, caseViewPage, loginPage, addHearingBookingDetailsEventPage) => {
   await caseViewPage.goToNewActions(config.administrationActions.addHearingBookingDetails);
   await addHearingBookingDetailsEventPage.enterHearingDetails(hearingDetails[0]);
   await I.addAnotherElementToCollection();
@@ -83,9 +83,9 @@ Scenario('Judiciary creates C21 order for the case', async (I, caseViewPage, cre
 
   I.seeEventSubmissionConfirmation(config.administrationActions.createOrder);
   caseViewPage.selectTab(caseViewPage.tabs.orders);
-  I.seeAnswerInTab(1, 'C21 Order 1', 'Order title', orders[0].orderTitle);
-  I.seeAnswerInTab(3, 'C21 Order 1', 'Order document', orders[0].orderDoc);
-  I.seeAnswerInTab(4, 'C21 Order 1', 'Date and time of upload', dateFormat(now, 'd mmmm yyyy'));
+  I.seeAnswerInTab(1, 'C21 order 1', 'Order title', orders[0].orderTitle);
+  I.seeAnswerInTab(3, 'C21 order 1', 'Order document', orders[0].orderDoc);
+  I.seeAnswerInTab(4, 'C21 order 1', 'Date and time of upload', dateFormat(now, 'd mmmm yyyy'));
   I.seeAnswerInTab(1, 'Judge and legal advisor', 'Judge or magistrate\'s title', orders[0].judgeAndLegalAdvisor.judgeTitle);
   I.seeAnswerInTab(2, 'Judge and legal advisor', 'Last name', orders[0].judgeAndLegalAdvisor.judgeLastName);
   I.seeAnswerInTab(3, 'Judge and legal advisor', 'Legal advisor\'s full name', orders[0].judgeAndLegalAdvisor.legalAdvisorName);

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/GeneratedOrderControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/GeneratedOrderControllerTest.java
@@ -193,7 +193,7 @@ class GeneratedOrderControllerTest {
             .caseDetails(CaseDetails.builder()
                 .id(19898989L)
                 .data(ImmutableMap.of(
-                    "generatedOrders", createOrders(),
+                    "orderCollection", createOrders(),
                     "hearingDetails", createHearingBookings(dateIn3Months, dateIn3Months.plusHours(4)),
                     "respondents1", createRespondents(),
                     "caseLocalAuthority", LOCAL_AUTHORITY_CODE,

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/GeneratedOrderControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/GeneratedOrderControllerTest.java
@@ -15,8 +15,8 @@ import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.document.domain.Document;
-import uk.gov.hmcts.reform.fpl.model.C21Order;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
+import uk.gov.hmcts.reform.fpl.model.GeneratedOrder;
 import uk.gov.hmcts.reform.fpl.model.common.DocmosisDocument;
 import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
@@ -42,19 +42,19 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.reform.fpl.CaseDefinitionConstants.CASE_TYPE;
 import static uk.gov.hmcts.reform.fpl.CaseDefinitionConstants.JURISDICTION;
-import static uk.gov.hmcts.reform.fpl.NotifyTemplates.C21_ORDER_NOTIFICATION_TEMPLATE;
+import static uk.gov.hmcts.reform.fpl.NotifyTemplates.ORDER_NOTIFICATION_TEMPLATE;
 import static uk.gov.hmcts.reform.fpl.enums.DocmosisTemplates.C21;
 import static uk.gov.hmcts.reform.fpl.enums.JudgeOrMagistrateTitle.HER_HONOUR_JUDGE;
-import static uk.gov.hmcts.reform.fpl.utils.CaseDataGeneratorHelper.createC21Orders;
 import static uk.gov.hmcts.reform.fpl.utils.CaseDataGeneratorHelper.createHearingBookings;
+import static uk.gov.hmcts.reform.fpl.utils.CaseDataGeneratorHelper.createOrders;
 import static uk.gov.hmcts.reform.fpl.utils.CaseDataGeneratorHelper.createRespondents;
 import static uk.gov.hmcts.reform.fpl.utils.CoreCaseDataStoreLoader.callbackRequest;
 import static uk.gov.hmcts.reform.fpl.utils.DocumentManagementStoreLoader.document;
 
 @ActiveProfiles("integration-test")
-@WebMvcTest(C21OrderController.class)
+@WebMvcTest(GeneratedOrderController.class)
 @OverrideAutoConfiguration(enabled = true)
-class C21OrderControllerTest {
+class GeneratedOrderControllerTest {
     private static final String AUTH_TOKEN = "Bearer token";
     private static final String USER_ID = "1";
     private static final String LOCAL_AUTHORITY_CODE = "example";
@@ -102,7 +102,7 @@ class C21OrderControllerTest {
     }
 
     @Test
-    void midEventShouldGenerateC21OrderDocument() throws Exception {
+    void midEventShouldGenerateOrderDocument() throws Exception {
         byte[] pdf = {1, 2, 3, 4, 5};
         Document document = document();
         DocmosisDocument docmosisDocument = new DocmosisDocument(C21.getDocumentTitle(), pdf);
@@ -115,7 +115,7 @@ class C21OrderControllerTest {
 
         CaseData caseData = mapper.convertValue(callbackResponse.getData(), CaseData.class);
 
-        assertThat(caseData.getC21Order().getDocument()).isEqualTo(DocumentReference.builder()
+        assertThat(caseData.getOrder().getDocument()).isEqualTo(DocumentReference.builder()
             .binaryUrl(document.links.binary.href)
             .filename(document.originalDocumentName)
             .url(document.links.self.href)
@@ -128,7 +128,7 @@ class C21OrderControllerTest {
 
         CaseData caseData = mapper.convertValue(callbackResponse.getData(), CaseData.class);
 
-        C21Order expectedOrder = C21Order.builder()
+        GeneratedOrder expectedOrder = GeneratedOrder.builder()
             .orderTitle("Example Order")
             .orderDetails("Example order details here - Lorem ipsum dolor sit amet, consectetur adipiscing elit")
             .orderDate(dateFormatterService.formatLocalDateTimeBaseUsingFormat(
@@ -140,25 +140,25 @@ class C21OrderControllerTest {
                 .build())
             .build();
 
-        List<Element<C21Order>> c21Orders = caseData.getC21Orders();
+        List<Element<GeneratedOrder>> orders = caseData.getGeneratedOrders();
 
-        assertThat(caseData.getC21Order()).isEqualTo(null);
+        assertThat(caseData.getOrder()).isEqualTo(null);
         assertThat(caseData.getJudgeAndLegalAdvisor()).isEqualTo(null);
-        assertThat(c21Orders.get(0).getValue()).isEqualTo(expectedOrder);
+        assertThat(orders.get(0).getValue()).isEqualTo(expectedOrder);
     }
 
     @Test
-    void shouldTriggerC21EventWhenSubmitted() throws Exception {
+    void shouldTriggerOrderEventWhenSubmitted() throws Exception {
         String expectedCaseReference = "19898989";
         makeSubmittedRequest(buildCallbackRequest());
 
         verify(notificationClient, times(1)).sendEmail(
-            eq(C21_ORDER_NOTIFICATION_TEMPLATE), eq(LOCAL_AUTHORITY_EMAIL_ADDRESS),
-            eq(expectedC21LocalAuthorityParameters()), eq(expectedCaseReference));
+            eq(ORDER_NOTIFICATION_TEMPLATE), eq(LOCAL_AUTHORITY_EMAIL_ADDRESS),
+            eq(expectedOrderLocalAuthorityParameters()), eq(expectedCaseReference));
 
         verify(notificationClient, times(1)).sendEmail(
-            eq(C21_ORDER_NOTIFICATION_TEMPLATE), eq(CAFCASS_EMAIL_ADDRESS),
-            eq(expectedC21CafcassParameters()), eq(expectedCaseReference));
+            eq(ORDER_NOTIFICATION_TEMPLATE), eq(CAFCASS_EMAIL_ADDRESS),
+            eq(expectedOrderCafcassParameters()), eq(expectedCaseReference));
     }
 
     private AboutToStartOrSubmitCallbackResponse makeRequest(CallbackRequest request, String endpoint)
@@ -193,7 +193,7 @@ class C21OrderControllerTest {
             .caseDetails(CaseDetails.builder()
                 .id(19898989L)
                 .data(ImmutableMap.of(
-                    "c21Orders", createC21Orders(),
+                    "generatedOrders", createOrders(),
                     "hearingDetails", createHearingBookings(dateIn3Months, dateIn3Months.plusHours(4)),
                     "respondents1", createRespondents(),
                     "caseLocalAuthority", LOCAL_AUTHORITY_CODE,
@@ -216,14 +216,14 @@ class C21OrderControllerTest {
             .build();
     }
 
-    private Map<String, Object> expectedC21CafcassParameters() {
+    private Map<String, Object> expectedOrderCafcassParameters() {
         return ImmutableMap.<String, Object>builder()
             .putAll(commonNotificationParameters())
             .put("localAuthorityOrCafcass", CAFCASS_NAME)
             .build();
     }
 
-    private Map<String, Object> expectedC21LocalAuthorityParameters() {
+    private Map<String, Object> expectedOrderLocalAuthorityParameters() {
         return ImmutableMap.<String, Object>builder()
             .putAll(commonNotificationParameters())
             .put("localAuthorityOrCafcass", LOCAL_AUTHORITY_NAME)

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/NotifyTemplates.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/NotifyTemplates.java
@@ -11,5 +11,5 @@ public class NotifyTemplates {
     public static final String GATEKEEPER_SUBMISSION_TEMPLATE = "c1d5d634-f654-4afc-9e35-3e9e96f7a07c";
     public static final String STANDARD_DIRECTION_ORDER_ISSUED_TEMPLATE = "c06968ea-048b-49d6-a4b5-1f13ee995ba1";
     public static final String C2_UPLOAD_NOTIFICATION_TEMPLATE = "6b961e81-c5ff-4f6f-8c56-f90d932a2f9b";
-    public static final String C21_ORDER_NOTIFICATION_TEMPLATE = "1f7c134e-f9c0-44ba-aa50-fce53eb208f7";
+    public static final String ORDER_NOTIFICATION_TEMPLATE = "1f7c134e-f9c0-44ba-aa50-fce53eb208f7";
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/config/RestrictionsConfiguration.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/config/RestrictionsConfiguration.java
@@ -1,0 +1,28 @@
+package uk.gov.hmcts.reform.fpl.config;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.copyOf;
+import static org.springframework.beans.factory.config.ConfigurableBeanFactory.SCOPE_SINGLETON;
+
+@Configuration
+@Scope(SCOPE_SINGLETON)
+@Getter
+@Slf4j
+public class RestrictionsConfiguration {
+    private final List<String> localAuthorityCodesForbiddenCaseSubmission;
+
+    public RestrictionsConfiguration(
+        @Value("${fpl.local_authority_codes_forbidden_case_submission}")
+        List<String> localAuthorityCodesForbiddenCaseSubmission
+    ) {
+        this.localAuthorityCodesForbiddenCaseSubmission = copyOf(localAuthorityCodesForbiddenCaseSubmission);
+        log.info("Local authorities forbidden case submission: {}", localAuthorityCodesForbiddenCaseSubmission);
+    }
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/CaseSubmissionController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/CaseSubmissionController.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.document.domain.Document;
+import uk.gov.hmcts.reform.fpl.config.RestrictionsConfiguration;
 import uk.gov.hmcts.reform.fpl.enums.OrderType;
 import uk.gov.hmcts.reform.fpl.events.SubmittedCaseEvent;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
@@ -47,6 +48,7 @@ public class CaseSubmissionController {
     private final ApplicationEventPublisher applicationEventPublisher;
     private final CaseValidatorService caseValidatorService;
     private final ObjectMapper mapper;
+    private final RestrictionsConfiguration restrictionsConfiguration;
 
     @Autowired
     public CaseSubmissionController(
@@ -55,13 +57,15 @@ public class CaseSubmissionController {
         UploadDocumentService uploadDocumentService,
         CaseValidatorService caseValidatorService,
         ObjectMapper mapper,
-        ApplicationEventPublisher applicationEventPublisher) {
+        ApplicationEventPublisher applicationEventPublisher,
+        RestrictionsConfiguration restrictionsConfiguration) {
         this.userDetailsService = userDetailsService;
         this.documentGeneratorService = documentGeneratorService;
         this.uploadDocumentService = uploadDocumentService;
         this.applicationEventPublisher = applicationEventPublisher;
         this.caseValidatorService = caseValidatorService;
         this.mapper = mapper;
+        this.restrictionsConfiguration = restrictionsConfiguration;
     }
 
     @PostMapping("/about-to-start")
@@ -84,7 +88,8 @@ public class CaseSubmissionController {
     private List<String> validate(CaseData caseData) {
         ImmutableList.Builder<String> builder = ImmutableList.builder();
 
-        if ("FPLA".equals(caseData.getCaseLocalAuthority())) {
+        if (restrictionsConfiguration.getLocalAuthorityCodesForbiddenCaseSubmission()
+            .contains(caseData.getCaseLocalAuthority())) {
             builder.add("Test local authority cannot submit cases");
         }
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/GeneratedOrderController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/GeneratedOrderController.java
@@ -24,7 +24,7 @@ import uk.gov.hmcts.reform.fpl.service.DocmosisDocumentGeneratorService;
 import uk.gov.hmcts.reform.fpl.service.GeneratedOrderService;
 import uk.gov.hmcts.reform.fpl.service.UploadDocumentService;
 import uk.gov.hmcts.reform.fpl.service.ValidateGroupService;
-import uk.gov.hmcts.reform.fpl.validation.groups.ValidateCaseNumberGroup;
+import uk.gov.hmcts.reform.fpl.validation.groups.ValidateFamilyManCaseNumberGroup;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -69,7 +69,7 @@ public class GeneratedOrderController {
 
         return AboutToStartOrSubmitCallbackResponse.builder()
             .data(caseDetails.getData())
-            .errors(validateGroupService.validateGroup(caseData, ValidateCaseNumberGroup.class))
+            .errors(validateGroupService.validateGroup(caseData, ValidateFamilyManCaseNumberGroup.class))
             .build();
     }
 
@@ -100,7 +100,7 @@ public class GeneratedOrderController {
 
         orders.add(service.addCustomValuesToOrder(caseData.getOrder(), caseData.getJudgeAndLegalAdvisor()));
 
-        caseDetails.getData().put("generatedOrders", orders);
+        caseDetails.getData().put("orderCollection", orders);
         caseDetails.getData().remove("order");
         caseDetails.getData().remove("judgeAndLegalAdvisor");
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/GeneratedOrderController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/GeneratedOrderController.java
@@ -15,16 +15,16 @@ import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.document.domain.Document;
 import uk.gov.hmcts.reform.fpl.config.GatewayConfiguration;
-import uk.gov.hmcts.reform.fpl.events.C21OrderEvent;
-import uk.gov.hmcts.reform.fpl.model.C21Order;
+import uk.gov.hmcts.reform.fpl.events.GeneratedOrderEvent;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
+import uk.gov.hmcts.reform.fpl.model.GeneratedOrder;
 import uk.gov.hmcts.reform.fpl.model.common.DocmosisDocument;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
-import uk.gov.hmcts.reform.fpl.service.CreateC21OrderService;
 import uk.gov.hmcts.reform.fpl.service.DocmosisDocumentGeneratorService;
+import uk.gov.hmcts.reform.fpl.service.GeneratedOrderService;
 import uk.gov.hmcts.reform.fpl.service.UploadDocumentService;
 import uk.gov.hmcts.reform.fpl.service.ValidateGroupService;
-import uk.gov.hmcts.reform.fpl.validation.groups.C21CaseOrderGroup;
+import uk.gov.hmcts.reform.fpl.validation.groups.ValidateCaseNumberGroup;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -36,9 +36,9 @@ import static uk.gov.hmcts.reform.fpl.enums.DocmosisTemplates.C21;
 @Api
 @RequestMapping("/callback/create-order")
 @RestController
-public class C21OrderController {
+public class GeneratedOrderController {
     private final ObjectMapper mapper;
-    private final CreateC21OrderService service;
+    private final GeneratedOrderService service;
     private final ValidateGroupService validateGroupService;
     private final DocmosisDocumentGeneratorService docmosisDocumentGeneratorService;
     private final UploadDocumentService uploadDocumentService;
@@ -46,13 +46,13 @@ public class C21OrderController {
     private final GatewayConfiguration gatewayConfiguration;
 
     @Autowired
-    public C21OrderController(ObjectMapper mapper,
-                              CreateC21OrderService service,
-                              ValidateGroupService validateGroupService,
-                              DocmosisDocumentGeneratorService docmosisDocumentGeneratorService,
-                              UploadDocumentService uploadDocumentService,
-                              ApplicationEventPublisher applicationEventPublisher,
-                              GatewayConfiguration gatewayConfiguration) {
+    public GeneratedOrderController(ObjectMapper mapper,
+                                    GeneratedOrderService service,
+                                    ValidateGroupService validateGroupService,
+                                    DocmosisDocumentGeneratorService docmosisDocumentGeneratorService,
+                                    UploadDocumentService uploadDocumentService,
+                                    ApplicationEventPublisher applicationEventPublisher,
+                                    GatewayConfiguration gatewayConfiguration) {
         this.mapper = mapper;
         this.service = service;
         this.validateGroupService = validateGroupService;
@@ -69,7 +69,7 @@ public class C21OrderController {
 
         return AboutToStartOrSubmitCallbackResponse.builder()
             .data(caseDetails.getData())
-            .errors(validateGroupService.validateGroup(caseData, C21CaseOrderGroup.class))
+            .errors(validateGroupService.validateGroup(caseData, ValidateCaseNumberGroup.class))
             .build();
     }
 
@@ -81,9 +81,9 @@ public class C21OrderController {
         CaseDetails caseDetails = callbackRequest.getCaseDetails();
         CaseData caseData = mapper.convertValue(caseDetails.getData(), CaseData.class);
 
-        Document c21Document = getDocument(authorization, userId, caseData);
+        Document orderDoc = getDocument(authorization, userId, caseData);
 
-        caseDetails.getData().put("c21Order", service.addDocumentToC21(caseData.getC21Order(), c21Document));
+        caseDetails.getData().put("order", service.addDocumentToOrder(caseData.getOrder(), orderDoc));
 
         return AboutToStartOrSubmitCallbackResponse.builder()
             .data(caseDetails.getData())
@@ -96,12 +96,12 @@ public class C21OrderController {
         CaseDetails caseDetails = callbackRequest.getCaseDetails();
         CaseData caseData = mapper.convertValue(caseDetails.getData(), CaseData.class);
 
-        List<Element<C21Order>> c21Orders = caseData.getC21Orders();
+        List<Element<GeneratedOrder>> orders = caseData.getGeneratedOrders();
 
-        c21Orders.add(service.addCustomValuesToC21Order(caseData.getC21Order(), caseData.getJudgeAndLegalAdvisor()));
+        orders.add(service.addCustomValuesToOrder(caseData.getOrder(), caseData.getJudgeAndLegalAdvisor()));
 
-        caseDetails.getData().put("c21Orders", c21Orders);
-        caseDetails.getData().remove("c21Order");
+        caseDetails.getData().put("generatedOrders", orders);
+        caseDetails.getData().remove("order");
         caseDetails.getData().remove("judgeAndLegalAdvisor");
 
         return AboutToStartOrSubmitCallbackResponse.builder()
@@ -114,31 +114,32 @@ public class C21OrderController {
                                      @RequestHeader(value = "user-id") String userId,
                                      @RequestBody CallbackRequest callbackRequest) {
         CaseData caseData = mapper.convertValue(callbackRequest.getCaseDetails().getData(), CaseData.class);
-        String mostRecentUploadedDocumentUrl = service.mostRecentUploadedC21DocumentUrl(caseData.getC21Orders());
+        String mostRecentUploadedDocumentUrl = service.mostRecentUploadedOrderDocumentUrl(
+            caseData.getGeneratedOrders());
 
-        applicationEventPublisher.publishEvent(new C21OrderEvent(callbackRequest, authorization, userId,
-            concatGatewayConfigurationUrlAndMostRecentUploadedC21DocumentPath(mostRecentUploadedDocumentUrl)));
+        applicationEventPublisher.publishEvent(new GeneratedOrderEvent(callbackRequest, authorization, userId,
+            concatGatewayConfigurationUrlAndMostRecentUploadedOrderDocumentPath(mostRecentUploadedDocumentUrl)));
     }
 
     private Document getDocument(String authorization,
                                  String userId,
                                  CaseData caseData) {
         DocmosisDocument document = docmosisDocumentGeneratorService.generateDocmosisDocument(
-            service.getC21OrderTemplateData(caseData), C21);
+            service.getOrderTemplateData(caseData), C21);
 
         return uploadDocumentService.uploadPDF(userId, authorization, document.getBytes(),
             C21.getDocumentTitle());
     }
 
-    private String concatGatewayConfigurationUrlAndMostRecentUploadedC21DocumentPath(
-        final String mostRecentUploadedC21DocumentUrl) {
+    private String concatGatewayConfigurationUrlAndMostRecentUploadedOrderDocumentPath(
+        final String mostRecentUploadedOrderDocumentUrl) {
         final String gatewayUrl = gatewayConfiguration.getUrl();
 
         try {
-            URI uri = new URI(mostRecentUploadedC21DocumentUrl);
+            URI uri = new URI(mostRecentUploadedOrderDocumentUrl);
             return gatewayUrl + uri.getPath();
         } catch (URISyntaxException e) {
-            log.error(mostRecentUploadedC21DocumentUrl + " url incorrect.", e);
+            log.error(mostRecentUploadedOrderDocumentUrl + " url incorrect.", e);
         }
         return "";
     }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/NotifyGatekeeperController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/NotifyGatekeeperController.java
@@ -16,7 +16,7 @@ import uk.gov.hmcts.reform.fpl.events.NotifyGatekeeperEvent;
 import uk.gov.hmcts.reform.fpl.events.PopulateStandardDirectionsEvent;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.service.ValidateGroupService;
-import uk.gov.hmcts.reform.fpl.validation.groups.NotifyGatekeeperGroup;
+import uk.gov.hmcts.reform.fpl.validation.groups.ValidateCaseNumberGroup;
 
 @Api
 @RestController
@@ -43,7 +43,7 @@ public class NotifyGatekeeperController {
 
         return AboutToStartOrSubmitCallbackResponse.builder()
             .data(caseDetails.getData())
-            .errors(validateGroupService.validateGroup(caseData, NotifyGatekeeperGroup.class))
+            .errors(validateGroupService.validateGroup(caseData, ValidateCaseNumberGroup.class))
             .build();
     }
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/NotifyGatekeeperController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/NotifyGatekeeperController.java
@@ -16,7 +16,7 @@ import uk.gov.hmcts.reform.fpl.events.NotifyGatekeeperEvent;
 import uk.gov.hmcts.reform.fpl.events.PopulateStandardDirectionsEvent;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.service.ValidateGroupService;
-import uk.gov.hmcts.reform.fpl.validation.groups.ValidateCaseNumberGroup;
+import uk.gov.hmcts.reform.fpl.validation.groups.ValidateFamilyManCaseNumberGroup;
 
 @Api
 @RestController
@@ -43,7 +43,7 @@ public class NotifyGatekeeperController {
 
         return AboutToStartOrSubmitCallbackResponse.builder()
             .data(caseDetails.getData())
-            .errors(validateGroupService.validateGroup(caseData, ValidateCaseNumberGroup.class))
+            .errors(validateGroupService.validateGroup(caseData, ValidateFamilyManCaseNumberGroup.class))
             .build();
     }
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/events/GeneratedOrderEvent.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/events/GeneratedOrderEvent.java
@@ -6,11 +6,11 @@ import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
-public class C21OrderEvent extends CallbackEvent {
+public class GeneratedOrderEvent extends CallbackEvent {
 
     private final String mostRecentUploadedDocumentUrl;
 
-    public C21OrderEvent(CallbackRequest callbackRequest, String authorization, String userId,
+    public GeneratedOrderEvent(CallbackRequest callbackRequest, String authorization, String userId,
                          String mostRecentUploadedDocumentUrl) {
         super(callbackRequest, authorization, userId);
         this.mostRecentUploadedDocumentUrl = mostRecentUploadedDocumentUrl;

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/NotificationHandler.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/NotificationHandler.java
@@ -10,17 +10,17 @@ import uk.gov.hmcts.reform.fpl.config.CafcassLookupConfiguration;
 import uk.gov.hmcts.reform.fpl.config.HmctsCourtLookupConfiguration;
 import uk.gov.hmcts.reform.fpl.config.LocalAuthorityEmailLookupConfiguration;
 import uk.gov.hmcts.reform.fpl.enums.UserRole;
-import uk.gov.hmcts.reform.fpl.events.C21OrderEvent;
 import uk.gov.hmcts.reform.fpl.events.C2UploadedEvent;
+import uk.gov.hmcts.reform.fpl.events.GeneratedOrderEvent;
 import uk.gov.hmcts.reform.fpl.events.NotifyGatekeeperEvent;
 import uk.gov.hmcts.reform.fpl.events.StandardDirectionsOrderIssuedEvent;
 import uk.gov.hmcts.reform.fpl.events.SubmittedCaseEvent;
 import uk.gov.hmcts.reform.fpl.service.InboxLookupService;
-import uk.gov.hmcts.reform.fpl.service.email.content.C21OrderEmailContentProvider;
 import uk.gov.hmcts.reform.fpl.service.email.content.C2UploadedEmailContentProvider;
 import uk.gov.hmcts.reform.fpl.service.email.content.CafcassEmailContentProvider;
 import uk.gov.hmcts.reform.fpl.service.email.content.CafcassEmailContentProviderSDOIssued;
 import uk.gov.hmcts.reform.fpl.service.email.content.GatekeeperEmailContentProvider;
+import uk.gov.hmcts.reform.fpl.service.email.content.GeneratedOrderEmailContentProvider;
 import uk.gov.hmcts.reform.fpl.service.email.content.HmctsEmailContentProvider;
 import uk.gov.hmcts.reform.fpl.service.email.content.LocalAuthorityEmailContentProvider;
 import uk.gov.hmcts.reform.idam.client.IdamApi;
@@ -30,11 +30,11 @@ import uk.gov.service.notify.NotificationClientException;
 import java.util.List;
 import java.util.Map;
 
-import static uk.gov.hmcts.reform.fpl.NotifyTemplates.C21_ORDER_NOTIFICATION_TEMPLATE;
 import static uk.gov.hmcts.reform.fpl.NotifyTemplates.C2_UPLOAD_NOTIFICATION_TEMPLATE;
 import static uk.gov.hmcts.reform.fpl.NotifyTemplates.CAFCASS_SUBMISSION_TEMPLATE;
 import static uk.gov.hmcts.reform.fpl.NotifyTemplates.GATEKEEPER_SUBMISSION_TEMPLATE;
 import static uk.gov.hmcts.reform.fpl.NotifyTemplates.HMCTS_COURT_SUBMISSION_TEMPLATE;
+import static uk.gov.hmcts.reform.fpl.NotifyTemplates.ORDER_NOTIFICATION_TEMPLATE;
 import static uk.gov.hmcts.reform.fpl.NotifyTemplates.STANDARD_DIRECTION_ORDER_ISSUED_TEMPLATE;
 
 @Slf4j
@@ -52,7 +52,7 @@ public class NotificationHandler {
     private final CafcassEmailContentProviderSDOIssued cafcassEmailContentProviderSDOIssued;
     private final GatekeeperEmailContentProvider gatekeeperEmailContentProvider;
     private final C2UploadedEmailContentProvider c2UploadedEmailContentProvider;
-    private final C21OrderEmailContentProvider c21OrderEmailContentProvider;
+    private final GeneratedOrderEmailContentProvider orderEmailContentProvider;
     private final LocalAuthorityEmailContentProvider localAuthorityEmailContentProvider;
     private final LocalAuthorityEmailLookupConfiguration localAuthorityEmailLookupConfiguration;
     private final NotificationClient notificationClient;
@@ -89,12 +89,13 @@ public class NotificationHandler {
     }
 
     @EventListener
-    public void sendNotificationForC21Order(final C21OrderEvent event) {
+    public void sendNotificationForOrder(final GeneratedOrderEvent event) {
         CaseDetails caseDetails = event.getCallbackRequest().getCaseDetails();
         String localAuthorityCode = (String) caseDetails.getData().get(CASE_LOCAL_AUTHORITY_PROPERTY_NAME);
 
-        sendC21NotificationForLocalAuthority(caseDetails, localAuthorityCode, event.getMostRecentUploadedDocumentUrl());
-        sendC21NotificationForCafcass(caseDetails, localAuthorityCode, event.getMostRecentUploadedDocumentUrl());
+        sendOrderNotificationForLocalAuthority(caseDetails, localAuthorityCode,
+            event.getMostRecentUploadedDocumentUrl());
+        sendOrderNotificationForCafcass(caseDetails, localAuthorityCode, event.getMostRecentUploadedDocumentUrl());
     }
 
     @EventListener
@@ -152,26 +153,26 @@ public class NotificationHandler {
         }
     }
 
-    private void sendC21NotificationForCafcass(final CaseDetails caseDetails, final String localAuthorityCode,
-                                               final String mostRecentUploadedDocumentUrl) {
+    private void sendOrderNotificationForCafcass(final CaseDetails caseDetails, final String localAuthorityCode,
+                                                 final String mostRecentUploadedDocumentUrl) {
         Map<String, Object> cafCassParameters =
-            c21OrderEmailContentProvider.buildC21OrderNotificationParametersForCafcass(
+            orderEmailContentProvider.buildOrderNotificationParametersForCafcass(
                 caseDetails, localAuthorityCode, mostRecentUploadedDocumentUrl);
         String cafcassEmail = cafcassLookupConfiguration.getCafcass(localAuthorityCode).getEmail();
-        sendNotification(C21_ORDER_NOTIFICATION_TEMPLATE, cafcassEmail, cafCassParameters,
+        sendNotification(ORDER_NOTIFICATION_TEMPLATE, cafcassEmail, cafCassParameters,
             Long.toString(caseDetails.getId()));
     }
 
-    private void sendC21NotificationForLocalAuthority(final CaseDetails caseDetails, final String localAuthorityCode,
-                                                      final String mostRecentUploadedDocumentUrl) {
+    private void sendOrderNotificationForLocalAuthority(final CaseDetails caseDetails, final String localAuthorityCode,
+                                                        final String mostRecentUploadedDocumentUrl) {
         Map<String, Object> localAuthorityParameters =
-            c21OrderEmailContentProvider.buildC21OrderNotificationParametersForLocalAuthority(
+            orderEmailContentProvider.buildOrderNotificationParametersForLocalAuthority(
                 caseDetails, localAuthorityCode, mostRecentUploadedDocumentUrl);
         String localAuthorityEmail = localAuthorityEmailLookupConfiguration
             .getLocalAuthority(localAuthorityCode)
             .map(LocalAuthorityEmailLookupConfiguration.LocalAuthority::getEmail)
             .orElseThrow(() -> new NullPointerException("Local authority '" + localAuthorityCode + "' not found"));
-        sendNotification(C21_ORDER_NOTIFICATION_TEMPLATE, localAuthorityEmail, localAuthorityParameters,
+        sendNotification(ORDER_NOTIFICATION_TEMPLATE, localAuthorityEmail, localAuthorityParameters,
             Long.toString(caseDetails.getId()));
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/CaseData.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/CaseData.java
@@ -13,7 +13,7 @@ import uk.gov.hmcts.reform.fpl.model.common.JudgeAndLegalAdvisor;
 import uk.gov.hmcts.reform.fpl.validation.groups.EPOGroup;
 import uk.gov.hmcts.reform.fpl.validation.groups.NoticeOfProceedingsGroup;
 import uk.gov.hmcts.reform.fpl.validation.groups.UploadDocumentsGroup;
-import uk.gov.hmcts.reform.fpl.validation.groups.ValidateCaseNumberGroup;
+import uk.gov.hmcts.reform.fpl.validation.groups.ValidateFamilyManCaseNumberGroup;
 import uk.gov.hmcts.reform.fpl.validation.interfaces.HasDocumentsIncludedInSwet;
 
 import java.time.LocalDate;
@@ -120,7 +120,7 @@ public class CaseData {
     @Valid
     private final List<@NotNull(message = "You need to add details to children") Element<Child>> children1;
     @NotBlank(message = "Enter Familyman case number", groups = {NoticeOfProceedingsGroup.class,
-        ValidateCaseNumberGroup.class})
+        ValidateFamilyManCaseNumberGroup.class})
     private final String familyManCaseNumber;
     private final NoticeOfProceedings noticeOfProceedings;
 
@@ -142,10 +142,10 @@ public class CaseData {
     private final C2DocumentBundle temporaryC2Document;
     private final List<Element<C2DocumentBundle>> c2DocumentBundle;
     private final GeneratedOrder order;
-    private final List<Element<GeneratedOrder>> generatedOrders;
+    private final List<Element<GeneratedOrder>> orderCollection;
 
     public List<Element<GeneratedOrder>> getGeneratedOrders() {
-        return defaultIfNull(generatedOrders, new ArrayList<>());
+        return defaultIfNull(orderCollection, new ArrayList<>());
     }
 
     private final CaseManagementOrder caseManagementOrder;

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/CaseData.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/CaseData.java
@@ -10,11 +10,10 @@ import uk.gov.hmcts.reform.fpl.model.common.DocumentBundle;
 import uk.gov.hmcts.reform.fpl.model.common.DocumentSocialWorkOther;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
 import uk.gov.hmcts.reform.fpl.model.common.JudgeAndLegalAdvisor;
-import uk.gov.hmcts.reform.fpl.validation.groups.C21CaseOrderGroup;
 import uk.gov.hmcts.reform.fpl.validation.groups.EPOGroup;
 import uk.gov.hmcts.reform.fpl.validation.groups.NoticeOfProceedingsGroup;
-import uk.gov.hmcts.reform.fpl.validation.groups.NotifyGatekeeperGroup;
 import uk.gov.hmcts.reform.fpl.validation.groups.UploadDocumentsGroup;
+import uk.gov.hmcts.reform.fpl.validation.groups.ValidateCaseNumberGroup;
 import uk.gov.hmcts.reform.fpl.validation.interfaces.HasDocumentsIncludedInSwet;
 
 import java.time.LocalDate;
@@ -121,7 +120,7 @@ public class CaseData {
     @Valid
     private final List<@NotNull(message = "You need to add details to children") Element<Child>> children1;
     @NotBlank(message = "Enter Familyman case number", groups = {NoticeOfProceedingsGroup.class,
-        C21CaseOrderGroup.class, NotifyGatekeeperGroup.class})
+        ValidateCaseNumberGroup.class})
     private final String familyManCaseNumber;
     private final NoticeOfProceedings noticeOfProceedings;
 
@@ -142,11 +141,11 @@ public class CaseData {
     private final JudgeAndLegalAdvisor judgeAndLegalAdvisor;
     private final C2DocumentBundle temporaryC2Document;
     private final List<Element<C2DocumentBundle>> c2DocumentBundle;
-    private final C21Order c21Order;
-    private final List<Element<C21Order>> c21Orders;
+    private final GeneratedOrder order;
+    private final List<Element<GeneratedOrder>> generatedOrders;
 
-    public List<Element<C21Order>> getC21Orders() {
-        return defaultIfNull(c21Orders, new ArrayList<>());
+    public List<Element<GeneratedOrder>> getGeneratedOrders() {
+        return defaultIfNull(generatedOrders, new ArrayList<>());
     }
 
     private final CaseManagementOrder caseManagementOrder;

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/GeneratedOrder.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/GeneratedOrder.java
@@ -7,7 +7,7 @@ import uk.gov.hmcts.reform.fpl.model.common.JudgeAndLegalAdvisor;
 
 @Data
 @Builder(toBuilder = true)
-public class C21Order {
+public class GeneratedOrder {
     private final String orderTitle;
     private final String orderDetails;
     private final DocumentReference document;

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/GeneratedOrderService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/GeneratedOrderService.java
@@ -5,9 +5,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.document.domain.Document;
 import uk.gov.hmcts.reform.fpl.config.HmctsCourtLookupConfiguration;
-import uk.gov.hmcts.reform.fpl.model.C21Order;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.Child;
+import uk.gov.hmcts.reform.fpl.model.GeneratedOrder;
 import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
 import uk.gov.hmcts.reform.fpl.model.common.JudgeAndLegalAdvisor;
@@ -27,12 +27,12 @@ import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
 
 @Slf4j
 @Service
-public class CreateC21OrderService {
+public class GeneratedOrderService {
     private final DateFormatterService dateFormatterService;
     private final HmctsCourtLookupConfiguration hmctsCourtLookupConfiguration;
     private final Time time;
 
-    public CreateC21OrderService(DateFormatterService dateFormatterService,
+    public GeneratedOrderService(DateFormatterService dateFormatterService,
                                  HmctsCourtLookupConfiguration hmctsCourtLookupConfiguration,
                                  Time time) {
         this.dateFormatterService = dateFormatterService;
@@ -40,8 +40,8 @@ public class CreateC21OrderService {
         this.time = time;
     }
 
-    public C21Order addDocumentToC21(C21Order c21Order, Document document) {
-        return c21Order.toBuilder()
+    public GeneratedOrder addDocumentToOrder(GeneratedOrder order, Document document) {
+        return order.toBuilder()
             .document(DocumentReference.builder()
                 .url(document.links.self.href)
                 .binaryUrl(document.links.binary.href)
@@ -53,16 +53,17 @@ public class CreateC21OrderService {
     /**
      * Method to format title of order, add {@link JudgeAndLegalAdvisor} object and a formatted order date.
      *
-     * @param c21Order             this value will contain fixed details and document values as well as customisable
+     * @param order                this value will contain fixed details and document values as well as customisable
      *                             values.
      * @param judgeAndLegalAdvisor the judge and legal advisor for the order.
-     * @return Element containing randomUUID and a fully populated C21Order.
+     * @return Element containing randomUUID and a fully populated order.
      */
-    public Element<C21Order> addCustomValuesToC21Order(C21Order c21Order, JudgeAndLegalAdvisor judgeAndLegalAdvisor) {
-        return Element.<C21Order>builder()
+    public Element<GeneratedOrder> addCustomValuesToOrder(GeneratedOrder order,
+                                                          JudgeAndLegalAdvisor judgeAndLegalAdvisor) {
+        return Element.<GeneratedOrder>builder()
             .id(randomUUID())
-            .value(c21Order.toBuilder()
-                .orderTitle(defaultIfBlank(c21Order.getOrderTitle(), "Order"))
+            .value(order.toBuilder()
+                .orderTitle(defaultIfBlank(order.getOrderTitle(), "Order"))
                 .judgeAndLegalAdvisor(judgeAndLegalAdvisor)
                 .orderDate(dateFormatterService.formatLocalDateTimeBaseUsingFormat(time.now(),
                     "h:mma, d MMMM yyyy"))
@@ -70,12 +71,12 @@ public class CreateC21OrderService {
             .build();
     }
 
-    public Map<String, Object> getC21OrderTemplateData(CaseData caseData) {
+    public Map<String, Object> getOrderTemplateData(CaseData caseData) {
         return ImmutableMap.<String, Object>builder()
             .put("familyManCaseNumber", caseData.getFamilyManCaseNumber())
             .put("courtName", getCourtName(caseData.getCaseLocalAuthority()))
-            .put("orderTitle", defaultIfNull(caseData.getC21Order().getOrderTitle(), "Order"))
-            .put("orderDetails", caseData.getC21Order().getOrderDetails())
+            .put("orderTitle", defaultIfNull(caseData.getOrder().getOrderTitle(), "Order"))
+            .put("orderDetails", caseData.getOrder().getOrderDetails())
             .put("todaysDate", dateFormatterService.formatLocalDateTimeBaseUsingFormat(time.now(), "d MMMM yyyy"))
             .put("judgeTitleAndName", JudgeAndLegalAdvisorHelper.formatJudgeTitleAndName(
                 caseData.getJudgeAndLegalAdvisor()))
@@ -101,8 +102,8 @@ public class CreateC21OrderService {
             .collect(toList());
     }
 
-    public String mostRecentUploadedC21DocumentUrl(final List<Element<C21Order>> c21Orders) {
-        return getLast(c21Orders.stream()
+    public String mostRecentUploadedOrderDocumentUrl(final List<Element<GeneratedOrder>> orders) {
+        return getLast(orders.stream()
             .filter(Objects::nonNull)
             .map(Element::getValue)
             .filter(Objects::nonNull)

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/GeneratedOrderService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/GeneratedOrderService.java
@@ -53,8 +53,7 @@ public class GeneratedOrderService {
     /**
      * Method to format title of order, add {@link JudgeAndLegalAdvisor} object and a formatted order date.
      *
-     * @param order                this value will contain fixed details and document values as well as customisable
-     *                             values.
+     * @param order                this value will contain order title and order details
      * @param judgeAndLegalAdvisor the judge and legal advisor for the order.
      * @return Element containing randomUUID and a fully populated order.
      */

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/email/content/GeneratedOrderEmailContentProvider.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/email/content/GeneratedOrderEmailContentProvider.java
@@ -23,39 +23,37 @@ import static uk.gov.hmcts.reform.fpl.CaseDefinitionConstants.JURISDICTION;
 import static uk.gov.hmcts.reform.fpl.utils.EmailNotificationHelper.buildSubjectLine;
 
 @Service
-public class C21OrderEmailContentProvider extends AbstractEmailContentProvider {
+public class GeneratedOrderEmailContentProvider extends AbstractEmailContentProvider {
 
     private final LocalAuthorityNameLookupConfiguration localAuthorityNameLookupConfiguration;
     private final CafcassLookupConfiguration cafcassLookupConfiguration;
     private final ObjectMapper objectMapper;
 
-    public C21OrderEmailContentProvider(@Value("${ccd.ui.base.url}")String uiBaseUrl,
-                                           ObjectMapper objectMapper,
-                                           HearingBookingService hearingBookingService,
-                                           LocalAuthorityNameLookupConfiguration
-                                               localAuthorityNameLookupConfiguration,
-                                           DateFormatterService dateFormatterService,
-                                           CafcassLookupConfiguration cafcassLookupConfiguration) {
+    public GeneratedOrderEmailContentProvider(@Value("${ccd.ui.base.url}") String uiBaseUrl,
+                                              ObjectMapper objectMapper,
+                                              HearingBookingService hearingBookingService,
+                                              LocalAuthorityNameLookupConfiguration
+                                                  localAuthorityNameLookupConfiguration,
+                                              DateFormatterService dateFormatterService,
+                                              CafcassLookupConfiguration cafcassLookupConfiguration) {
         super(uiBaseUrl, dateFormatterService, hearingBookingService);
         this.objectMapper = objectMapper;
         this.localAuthorityNameLookupConfiguration = localAuthorityNameLookupConfiguration;
         this.cafcassLookupConfiguration = cafcassLookupConfiguration;
     }
 
-    public Map<String, Object> buildC21OrderNotificationParametersForCafcass(final CaseDetails caseDetails,
-                                                                             final String localAuthorityCode,
-                                                                          final String mostRecentUploadedDocumentUrl) {
+    public Map<String, Object> buildOrderNotificationParametersForCafcass(
+        final CaseDetails caseDetails, final String localAuthorityCode, final String mostRecentUploadedDocumentUrl) {
         return ImmutableMap.<String, Object>builder()
-            .putAll(commonC21NotificationParameters(caseDetails, mostRecentUploadedDocumentUrl))
+            .putAll(commonOrderNotificationParameters(caseDetails, mostRecentUploadedDocumentUrl))
             .put("localAuthorityOrCafcass", cafcassLookupConfiguration.getCafcass(localAuthorityCode).getName())
             .build();
     }
 
-    public Map<String, Object> buildC21OrderNotificationParametersForLocalAuthority(final CaseDetails caseDetails,
-                                                                                    final String localAuthorityCode,
-                                                                          final String mostRecentUploadedDocumentUrl) {
+    public Map<String, Object> buildOrderNotificationParametersForLocalAuthority(
+        final CaseDetails caseDetails, final String localAuthorityCode, final String mostRecentUploadedDocumentUrl) {
         return ImmutableMap.<String, Object>builder()
-            .putAll(commonC21NotificationParameters(caseDetails, mostRecentUploadedDocumentUrl))
+            .putAll(commonOrderNotificationParameters(caseDetails, mostRecentUploadedDocumentUrl))
             .put("localAuthorityOrCafcass",
                 localAuthorityNameLookupConfiguration.getLocalAuthorityName(localAuthorityCode))
             .build();
@@ -73,8 +71,8 @@ public class C21OrderEmailContentProvider extends AbstractEmailContentProvider {
             .collect(joining(","));
     }
 
-    private Map<String, Object> commonC21NotificationParameters(final CaseDetails caseDetails,
-                                                                final String linkToDocument) {
+    private Map<String, Object> commonOrderNotificationParameters(final CaseDetails caseDetails,
+                                                                  final String linkToDocument) {
         CaseData caseData = objectMapper.convertValue(caseDetails.getData(), CaseData.class);
         final String subjectLine = buildSubjectLine(caseData);
         return ImmutableMap.of(

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/utils/CaseDataGeneratorHelper.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/utils/CaseDataGeneratorHelper.java
@@ -8,10 +8,10 @@ import uk.gov.hmcts.reform.fpl.enums.OrderStatus;
 import uk.gov.hmcts.reform.fpl.model.Address;
 import uk.gov.hmcts.reform.fpl.model.Applicant;
 import uk.gov.hmcts.reform.fpl.model.ApplicantParty;
-import uk.gov.hmcts.reform.fpl.model.C21Order;
 import uk.gov.hmcts.reform.fpl.model.Child;
 import uk.gov.hmcts.reform.fpl.model.ChildParty;
 import uk.gov.hmcts.reform.fpl.model.Direction;
+import uk.gov.hmcts.reform.fpl.model.GeneratedOrder;
 import uk.gov.hmcts.reform.fpl.model.HearingBooking;
 import uk.gov.hmcts.reform.fpl.model.Order;
 import uk.gov.hmcts.reform.fpl.model.Other;
@@ -256,10 +256,10 @@ public class CaseDataGeneratorHelper {
             )).build();
     }
 
-    public static List<Element<C21Order>> createC21Orders() {
+    public static List<Element<GeneratedOrder>> createOrders() {
         return ImmutableList.of(
-            Element.<C21Order>builder()
-                .value(C21Order.builder()
+            Element.<GeneratedOrder>builder()
+                .value(GeneratedOrder.builder()
                     .orderTitle("Example Order")
                     .orderDetails(
                         "Example order details here - Lorem ipsum dolor sit amet, consectetur adipiscing elit")
@@ -269,9 +269,9 @@ public class CaseDataGeneratorHelper {
                         "Judy", null, HER_HONOUR_JUDGE))
                     .build())
                 .build(),
-            Element.<C21Order>builder()
+            Element.<GeneratedOrder>builder()
                 .id(UUID.randomUUID())
-                .value(C21Order.builder()
+                .value(GeneratedOrder.builder()
                     .orderTitle("Winter is here")
                     .orderDetails("Westeros")
                     .orderDate(DATE_FORMATTER_SERVICE.formatLocalDateTimeBaseUsingFormat(
@@ -281,9 +281,9 @@ public class CaseDataGeneratorHelper {
                     .document(createDocumentReference(randomUUID().toString()))
                     .build())
                 .build(),
-            Element.<C21Order>builder()
+            Element.<GeneratedOrder>builder()
                 .id(UUID.randomUUID())
-                .value(C21Order.builder()
+                .value(GeneratedOrder.builder()
                     .orderTitle("Black Sails")
                     .orderDetails("Long John Silver")
                     .orderDate(DATE_FORMATTER_SERVICE.formatLocalDateTimeBaseUsingFormat(

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/validation/groups/NotifyGatekeeperGroup.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/validation/groups/NotifyGatekeeperGroup.java
@@ -1,5 +1,0 @@
-package uk.gov.hmcts.reform.fpl.validation.groups;
-
-// JSR Validation interface used to validate the send to gatekeeper event
-public @interface NotifyGatekeeperGroup {
-}

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/validation/groups/ValidateCaseNumberGroup.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/validation/groups/ValidateCaseNumberGroup.java
@@ -1,5 +1,5 @@
 package uk.gov.hmcts.reform.fpl.validation.groups;
 
 // JSR Validation interface used to validate the C21 Group
-public @interface C21CaseOrderGroup {
+public @interface ValidateCaseNumberGroup {
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/validation/groups/ValidateCaseNumberGroup.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/validation/groups/ValidateCaseNumberGroup.java
@@ -1,5 +1,0 @@
-package uk.gov.hmcts.reform.fpl.validation.groups;
-
-// JSR Validation interface used to validate the C21 Group
-public @interface ValidateCaseNumberGroup {
-}

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/validation/groups/ValidateFamilyManCaseNumberGroup.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/validation/groups/ValidateFamilyManCaseNumberGroup.java
@@ -1,0 +1,5 @@
+package uk.gov.hmcts.reform.fpl.validation.groups;
+
+// JSR Validation interface used to validate existence of familyman case number
+public @interface ValidateFamilyManCaseNumberGroup {
+}

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -17,6 +17,9 @@ idam:
   s2s-auth:
     microservice: fpl_case_service
 
+fpl:
+  local_authority_codes_forbidden_case_submission:
+
 ---
 
 spring:
@@ -57,6 +60,7 @@ ccd:
       url: http://fake-url
 
 fpl:
+  local_authority_codes_forbidden_case_submission: FPLA
   local_authority_email_to_code:
     mapping: 'example.gov.uk=>example'
   local_authority_code_to_name:

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -117,7 +117,7 @@ gateway:
   url: http://localhost:3453
 
 notify:
-  api_key: pretends-12f756df-f01d-4a32-a405-e1ea8a494fbb-21670ef3-5abb-4f05-9208-a72e41b4a01c
+  api_key: fake-key
 
 ccd:
   ui:

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -117,7 +117,7 @@ gateway:
   url: http://localhost:3453
 
 notify:
-  api_key: fake-key
+  api_key: pretends-12f756df-f01d-4a32-a405-e1ea8a494fbb-21670ef3-5abb-4f05-9208-a72e41b4a01c
 
 ccd:
   ui:

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/GeneratedOrderServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/GeneratedOrderServiceTest.java
@@ -8,10 +8,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.document.domain.Document;
 import uk.gov.hmcts.reform.fpl.config.HmctsCourtLookupConfiguration;
-import uk.gov.hmcts.reform.fpl.model.C21Order;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.Child;
 import uk.gov.hmcts.reform.fpl.model.ChildParty;
+import uk.gov.hmcts.reform.fpl.model.GeneratedOrder;
 import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
 import uk.gov.hmcts.reform.fpl.model.common.JudgeAndLegalAdvisor;
@@ -25,11 +25,11 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.reform.fpl.enums.JudgeOrMagistrateTitle.HER_HONOUR_JUDGE;
-import static uk.gov.hmcts.reform.fpl.utils.CaseDataGeneratorHelper.createC21Orders;
+import static uk.gov.hmcts.reform.fpl.utils.CaseDataGeneratorHelper.createOrders;
 import static uk.gov.hmcts.reform.fpl.utils.DocumentManagementStoreLoader.document;
 
 @ExtendWith(SpringExtension.class)
-class CreateC21OrderServiceTest {
+class GeneratedOrderServiceTest {
     private static final String LOCAL_AUTHORITY_CODE = "example";
     private static final String COURT_NAME = "Example Court";
     private static final String COURT_EMAIL = "example@court.com";
@@ -41,18 +41,18 @@ class CreateC21OrderServiceTest {
     private DateFormatterService dateFormatterService = new DateFormatterService();
     private HmctsCourtLookupConfiguration hmctsCourtLookupConfiguration = new HmctsCourtLookupConfiguration(CONFIG);
 
-    private CreateC21OrderService service;
+    private GeneratedOrderService service;
 
     @BeforeEach
     void setup() {
-        this.service = new CreateC21OrderService(dateFormatterService, hmctsCourtLookupConfiguration, time);
+        this.service = new GeneratedOrderService(dateFormatterService, hmctsCourtLookupConfiguration, time);
     }
 
     @Test
-    void shouldAddDocumentToEmptyC21WhenDocumentExists() throws IOException {
+    void shouldAddDocumentToEmptyOrderWhenDocumentExists() throws IOException {
         Document document = document();
 
-        C21Order returnedOrder = service.addDocumentToC21(C21Order.builder().build(), document);
+        GeneratedOrder returnedOrder = service.addDocumentToOrder(GeneratedOrder.builder().build(), document);
 
         assertThat(returnedOrder).hasFieldOrPropertyWithValue("document", DocumentReference.builder()
             .binaryUrl(document.links.binary.href)
@@ -62,13 +62,13 @@ class CreateC21OrderServiceTest {
     }
 
     @Test
-    void shouldAddDocumentToPopulatedC21WhenDocumentExists() throws IOException {
+    void shouldAddDocumentToPopulatedOrderWhenDocumentExists() throws IOException {
         Document document = document();
-        C21Order.C21OrderBuilder order = C21Order.builder()
+        GeneratedOrder.GeneratedOrderBuilder order = GeneratedOrder.builder()
             .orderTitle("Order")
             .orderDetails("Some details");
 
-        C21Order returnedOrder = service.addDocumentToC21(order.build(), document);
+        GeneratedOrder returnedOrder = service.addDocumentToOrder(order.build(), document);
 
         assertThat(returnedOrder).isEqualTo(order.document(DocumentReference.builder()
             .binaryUrl(document.links.binary.href)
@@ -78,14 +78,14 @@ class CreateC21OrderServiceTest {
     }
 
     @Test
-    void shouldReturnExpectedC21OrderWhenOrderTitleIsNull() {
-        C21Order c21Order = C21Order.builder()
+    void shouldReturnExpectedOrderWhenOrderTitleIsNull() {
+        GeneratedOrder order = GeneratedOrder.builder()
             .orderTitle(null)
             .orderDetails("Some details")
             .document(DocumentReference.builder().build())
             .build();
 
-        Element<C21Order> returnedElement = service.addCustomValuesToC21Order(c21Order,
+        Element<GeneratedOrder> returnedElement = service.addCustomValuesToOrder(order,
             JudgeAndLegalAdvisor.builder().build());
 
         assertThat(returnedElement.getValue().getOrderTitle()).isEqualTo("Order");
@@ -97,14 +97,14 @@ class CreateC21OrderServiceTest {
     }
 
     @Test
-    void shouldReturnExpectedC21OrderWhenOrderTitleIsEmptyString() {
-        C21Order c21Order = C21Order.builder()
+    void shouldReturnExpectedOrderWhenOrderTitleIsEmptyString() {
+        GeneratedOrder order = GeneratedOrder.builder()
             .orderTitle("")
             .orderDetails("Some details")
             .document(DocumentReference.builder().build())
             .build();
 
-        Element<C21Order> returnedElement = service.addCustomValuesToC21Order(c21Order,
+        Element<GeneratedOrder> returnedElement = service.addCustomValuesToOrder(order,
             JudgeAndLegalAdvisor.builder().build());
 
         assertThat(returnedElement.getValue().getOrderTitle()).isEqualTo("Order");
@@ -116,14 +116,14 @@ class CreateC21OrderServiceTest {
     }
 
     @Test
-    void shouldReturnExpectedC21OrderWhenOrderTitleIsStringWithSpaceCharacter() {
-        C21Order c21Order = C21Order.builder()
+    void shouldReturnExpectedOrderWhenOrderTitleIsStringWithSpaceCharacter() {
+        GeneratedOrder order = GeneratedOrder.builder()
             .orderTitle(" ")
             .orderDetails("Some details")
             .document(DocumentReference.builder().build())
             .build();
 
-        Element<C21Order> returnedElement = service.addCustomValuesToC21Order(c21Order,
+        Element<GeneratedOrder> returnedElement = service.addCustomValuesToOrder(order,
             JudgeAndLegalAdvisor.builder().build());
 
         assertThat(returnedElement.getValue().getOrderTitle()).isEqualTo("Order");
@@ -135,14 +135,14 @@ class CreateC21OrderServiceTest {
     }
 
     @Test
-    void shouldReturnExpectedC21OrderWhenOrderTitlePresent() {
-        C21Order c21Order = C21Order.builder()
+    void shouldReturnExpectedOrderWhenOrderTitlePresent() {
+        GeneratedOrder order = GeneratedOrder.builder()
             .orderTitle("Example Title")
             .orderDetails("Some details")
             .document(DocumentReference.builder().build())
             .build();
 
-        Element<C21Order> returnedElement = service.addCustomValuesToC21Order(c21Order,
+        Element<GeneratedOrder> returnedElement = service.addCustomValuesToOrder(order,
             JudgeAndLegalAdvisor.builder().build());
 
         assertThat(returnedElement.getValue().getOrderTitle()).isEqualTo("Example Title");
@@ -154,14 +154,14 @@ class CreateC21OrderServiceTest {
     }
 
     @Test
-    void shouldReturnExpectedC21OrderWhenJudgeAndLegalAdvisorFullyPopulated() {
-        C21Order c21Order = C21Order.builder()
+    void shouldReturnExpectedOrderWhenJudgeAndLegalAdvisorFullyPopulated() {
+        GeneratedOrder order = GeneratedOrder.builder()
             .orderTitle("Example Title")
             .orderDetails("Some details")
             .document(DocumentReference.builder().build())
             .build();
 
-        Element<C21Order> returnedElement = service.addCustomValuesToC21Order(c21Order, JudgeAndLegalAdvisor.builder()
+        Element<GeneratedOrder> returnedElement = service.addCustomValuesToOrder(order, JudgeAndLegalAdvisor.builder()
             .judgeTitle(HER_HONOUR_JUDGE)
             .judgeLastName("Judy")
             .legalAdvisorName("Peter Parker")
@@ -185,18 +185,20 @@ class CreateC21OrderServiceTest {
         CaseData caseData = populatedCaseData(localDate);
 
         Map<String, Object> expectedMap = expectedData(date);
-        Map<String, Object> templateData = service.getC21OrderTemplateData(caseData);
+        Map<String, Object> templateData = service.getOrderTemplateData(caseData);
 
         assertThat(templateData).isEqualTo(expectedMap);
     }
 
     @Test
-    void shouldReturnMostRecentUploadedC21DocumentUrl() {
-        final String expectedMostRecentUploadedC21DocumentUrl = "http://dm-store:8080/documents/79ec80ec-7be6-493b-b4e6-f002f05b7079/binary";
-        final String returnedMostRecentUploadedC21DocumentUrl = service.mostRecentUploadedC21DocumentUrl(
-            createC21Orders());
+    void shouldReturnMostRecentUploadedOrderDocumentUrl() {
+        final String expectedMostRecentUploadedOrderDocumentUrl =
+            "http://dm-store:8080/documents/79ec80ec-7be6-493b-b4e6-f002f05b7079/binary";
+        final String returnedMostRecentUploadedOrderDocumentUrl = service.mostRecentUploadedOrderDocumentUrl(
+            createOrders());
 
-        assertThat(expectedMostRecentUploadedC21DocumentUrl).isEqualTo(returnedMostRecentUploadedC21DocumentUrl);
+        assertThat(expectedMostRecentUploadedOrderDocumentUrl).isEqualTo(
+            returnedMostRecentUploadedOrderDocumentUrl);
     }
 
     @SuppressWarnings("unchecked")
@@ -223,7 +225,7 @@ class CreateC21OrderServiceTest {
         return CaseData.builder()
             .familyManCaseNumber("123")
             .caseLocalAuthority("example")
-            .c21Order(C21Order.builder()
+            .order(GeneratedOrder.builder()
                 .orderTitle("Example Title")
                 .orderDetails("Example details")
                 .build())

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ValidateGroupServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ValidateGroupServiceTest.java
@@ -9,7 +9,7 @@ import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.HearingBooking;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
 import uk.gov.hmcts.reform.fpl.validation.groups.NoticeOfProceedingsGroup;
-import uk.gov.hmcts.reform.fpl.validation.groups.ValidateCaseNumberGroup;
+import uk.gov.hmcts.reform.fpl.validation.groups.ValidateFamilyManCaseNumberGroup;
 
 import java.util.List;
 import java.util.UUID;
@@ -31,7 +31,7 @@ class ValidateGroupServiceTest {
     @Test
     void shouldReturnAnErrorWhenFamilyManCaseNumberIsNotPopulated() {
         List<String> errors = validateGroupService.validateGroup(CaseData.builder().build(),
-            ValidateCaseNumberGroup.class);
+            ValidateFamilyManCaseNumberGroup.class);
 
         assertThat(errors).containsExactly("Enter Familyman case number");
     }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ValidateGroupServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ValidateGroupServiceTest.java
@@ -8,8 +8,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.HearingBooking;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
-import uk.gov.hmcts.reform.fpl.validation.groups.C21CaseOrderGroup;
 import uk.gov.hmcts.reform.fpl.validation.groups.NoticeOfProceedingsGroup;
+import uk.gov.hmcts.reform.fpl.validation.groups.ValidateCaseNumberGroup;
 
 import java.util.List;
 import java.util.UUID;
@@ -30,7 +30,8 @@ class ValidateGroupServiceTest {
 
     @Test
     void shouldReturnAnErrorWhenFamilyManCaseNumberIsNotPopulated() {
-        List<String> errors = validateGroupService.validateGroup(CaseData.builder().build(), C21CaseOrderGroup.class);
+        List<String> errors = validateGroupService.validateGroup(CaseData.builder().build(),
+            ValidateCaseNumberGroup.class);
 
         assertThat(errors).containsExactly("Enter Familyman case number");
     }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/email/GeneratedOrderEmailContentProviderTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/email/GeneratedOrderEmailContentProviderTest.java
@@ -122,7 +122,7 @@ class GeneratedOrderEmailContentProviderTest {
         return CaseDetails.builder()
             .id(167888L)
             .data(ImmutableMap.of("hearingDetails", createHearingBookings(now, now.plusDays(1)),
-                "generatedOrders", ImmutableList.of(
+                "orderCollection", ImmutableList.of(
                     Element.<GeneratedOrder>builder()
                         .value(GeneratedOrder.builder()
                             .orderTitle("Example Order")

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/email/GeneratedOrderEmailContentProviderTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/email/GeneratedOrderEmailContentProviderTest.java
@@ -15,11 +15,11 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.config.CafcassLookupConfiguration;
 import uk.gov.hmcts.reform.fpl.config.LocalAuthorityNameLookupConfiguration;
-import uk.gov.hmcts.reform.fpl.model.C21Order;
+import uk.gov.hmcts.reform.fpl.model.GeneratedOrder;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
 import uk.gov.hmcts.reform.fpl.service.DateFormatterService;
 import uk.gov.hmcts.reform.fpl.service.HearingBookingService;
-import uk.gov.hmcts.reform.fpl.service.email.content.C21OrderEmailContentProvider;
+import uk.gov.hmcts.reform.fpl.service.email.content.GeneratedOrderEmailContentProvider;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -39,10 +39,10 @@ import static uk.gov.hmcts.reform.fpl.utils.CaseDataGeneratorHelper.createJudgeA
 import static uk.gov.hmcts.reform.fpl.utils.CaseDataGeneratorHelper.createRespondents;
 
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = {JacksonAutoConfiguration.class, C21OrderEmailContentProvider.class,
+@ContextConfiguration(classes = {JacksonAutoConfiguration.class, GeneratedOrderEmailContentProvider.class,
     HearingBookingService.class, LocalAuthorityNameLookupConfiguration.class, DateFormatterService.class,
     CafcassLookupConfiguration.class})
-class C21OrderEmailContentProviderTest {
+class GeneratedOrderEmailContentProviderTest {
     private final LocalDate today = LocalDate.now();
     private final DateFormatterService dateFormatterService = new DateFormatterService();
     private final HearingBookingService hearingBookingService = new HearingBookingService();
@@ -60,7 +60,7 @@ class C21OrderEmailContentProviderTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    private C21OrderEmailContentProvider c21OrderEmailContentProvider;
+    private GeneratedOrderEmailContentProvider orderEmailContentProvider;
 
     private String familyManCaseNumber;
     private UUID documentId;
@@ -68,7 +68,7 @@ class C21OrderEmailContentProviderTest {
 
     @BeforeEach
     void setup() {
-        this.c21OrderEmailContentProvider = new C21OrderEmailContentProvider("",
+        this.orderEmailContentProvider = new GeneratedOrderEmailContentProvider("",
             objectMapper, hearingBookingService, localAuthorityNameLookupConfiguration, dateFormatterService,
             cafcassLookupConfiguration);
 
@@ -84,12 +84,12 @@ class C21OrderEmailContentProviderTest {
     }
 
     @Test
-    void shouldReturnExactC21CafcassNotificationParametersWithUploadedDocumentUrl() {
+    void shouldReturnExactOrderCafcassNotificationParametersWithUploadedDocumentUrl() {
         final String documentUrl = "http://dm-store:8080/documents/" + documentId + "/binary";
-        CaseDetails caseDetails = createCaseDetailsWithSingleC21Element();
+        CaseDetails caseDetails = createCaseDetailsWithSingleOrderElement();
 
         Map<String, Object> returnedCafcassParameters =
-            c21OrderEmailContentProvider.buildC21OrderNotificationParametersForCafcass(
+            orderEmailContentProvider.buildOrderNotificationParametersForCafcass(
                 caseDetails, LOCAL_AUTHORITY_CODE, documentUrl);
 
         assertThat(returnedCafcassParameters)
@@ -101,12 +101,12 @@ class C21OrderEmailContentProviderTest {
     }
 
     @Test
-    void shouldReturnExactC21LocalAuthorityNotificationParametersWithUploadedDocumentUrl() {
+    void shouldReturnExactOrderLocalAuthorityNotificationParametersWithUploadedDocumentUrl() {
         final String documentUrl = "http://dm-store:8080/documents/" + documentId + "/binary";
-        CaseDetails caseDetails = createCaseDetailsWithSingleC21Element();
+        CaseDetails caseDetails = createCaseDetailsWithSingleOrderElement();
 
         Map<String, Object> returnedLocalAuthorityParameters =
-            c21OrderEmailContentProvider.buildC21OrderNotificationParametersForLocalAuthority(
+            orderEmailContentProvider.buildOrderNotificationParametersForLocalAuthority(
                 caseDetails, LOCAL_AUTHORITY_CODE, documentUrl);
 
         assertThat(returnedLocalAuthorityParameters)
@@ -117,14 +117,14 @@ class C21OrderEmailContentProviderTest {
                 documentUrl, "167888", "/case/" + JURISDICTION + "/" + CASE_TYPE + "/167888");
     }
 
-    private CaseDetails createCaseDetailsWithSingleC21Element() {
+    private CaseDetails createCaseDetailsWithSingleOrderElement() {
         final LocalDateTime now = LocalDateTime.now();
         return CaseDetails.builder()
             .id(167888L)
             .data(ImmutableMap.of("hearingDetails", createHearingBookings(now, now.plusDays(1)),
-                "c21Orders", ImmutableList.of(
-                    Element.<C21Order>builder()
-                        .value(C21Order.builder()
+                "generatedOrders", ImmutableList.of(
+                    Element.<GeneratedOrder>builder()
+                        .value(GeneratedOrder.builder()
                             .orderTitle("Example Order")
                             .orderDetails(
                                 "Example order details here - Lorem ipsum dolor sit amet, consectetur adipiscing elit")

--- a/service/src/test/resources/core-case-data-store-api/callback-request.json
+++ b/service/src/test/resources/core-case-data-store-api/callback-request.json
@@ -478,7 +478,7 @@
         "judgeLastName": "Judy",
         "legalAdvisorName": "Peter Parker"
       },
-      "c21Order": {
+      "order": {
         "orderTitle": "Example Order",
         "orderDetails": "Example order details here - Lorem ipsum dolor sit amet, consectetur adipiscing elit"
       },


### PR DESCRIPTION
### JIRA link (if applicable) ###


### Change description ###

- [X] Get devops to run query to check for existing C21s
- [X] Decide on name for the model: GeneratedOrder

No functionality/UI changes. This refactor is required to make the system scalable for future orders (important for FPLA-716 final care orders #689). This should be reviewed/merged before #689.

- Change 'createC21Order' to 'createOrder' and 'c21Order' to 'order' (where possible)

- Change 'C21Order' model to 'GeneratedOrder' model (this name can be easily changed)

- Updated e2e tests to be easily scalable with future orders (i.e test all orders in one scenario)

- Combined two identical validation groups (NotifyGatekeeper / C21Order) into one: ValidateFamilyManCaseNumberGroup

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
