### PR TITLE
fix: allow only all party directions to be valid in cmo compliance (FPLA-NA)

### DIFF
--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ComplyWithDirectionsControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ComplyWithDirectionsControllerTest.java
@@ -69,6 +69,27 @@ class ComplyWithDirectionsControllerTest {
         assertThat(collectionsContainDirectionsForRoleAndAllParties(caseData));
     }
 
+    @Test
+    void aboutToStartCallbackShouldReturnAllPartiesDirectionsWhenNoSpecificRoleDirections() throws Exception {
+        Direction direction = Direction.builder().assignee(ALL_PARTIES).build();
+        Order sdo = Order.builder().directions(buildDirections(direction)).build();
+
+        CallbackRequest request = CallbackRequest.builder()
+            .caseDetails(CaseDetails.builder()
+                .data(ImmutableMap.of("standardDirectionOrder", sdo))
+                .build())
+            .build();
+
+        CaseData caseData = makeRequest(request, "about-to-start");
+
+        assertThat(caseData.getAllParties()).isNull();
+        assertThat(caseData.getLocalAuthorityDirections()).containsAll(sdo.getDirections());
+        assertThat(caseData.getCafcassDirections()).containsAll(sdo.getDirections());
+        assertThat(caseData.getRespondentDirections()).containsAll(sdo.getDirections());
+        assertThat(caseData.getOtherPartiesDirections()).containsAll(sdo.getDirections());
+        assertThat(caseData.getCourtDirectionsCustom()).containsAll(sdo.getDirections());
+    }
+
     @SuppressWarnings("unchecked")
     @Test
     void aboutToSubmitShouldAddResponseToStandardDirectionOrderWhenEmptyServedCaseManagementOrders() throws Exception {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/ComplyWithDirectionsController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/ComplyWithDirectionsController.java
@@ -46,6 +46,8 @@ public class ComplyWithDirectionsController {
         Map<DirectionAssignee, List<Element<Direction>>> sortedDirections =
             directionHelperService.sortDirectionsByAssignee(directionsToComplyWith);
 
+        directionHelperService.addEmptyDirectionsForAssigneeNotInMap(sortedDirections);
+
         sortedDirections.forEach((assignee, directions) -> {
             if (!assignee.equals(ALL_PARTIES)) {
                 directions.addAll(sortedDirections.get(ALL_PARTIES));

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/DirectionHelperService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/DirectionHelperService.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static java.util.Arrays.stream;
 import static java.util.Collections.emptyList;
 import static java.util.Objects.isNull;
 import static java.util.UUID.randomUUID;
@@ -402,6 +403,15 @@ public class DirectionHelperService {
         List<Element<Direction>> directions) {
         return directions.stream()
             .collect(groupingBy(directionElement -> directionElement.getValue().getAssignee()));
+    }
+
+    /**
+     * Adds any {@link DirectionAssignee} not present to a map with an empty list of directions.
+     *
+     * @param map assignee, directions key value pairs.
+     */
+    public void addEmptyDirectionsForAssigneeNotInMap(Map<DirectionAssignee, List<Element<Direction>>> map) {
+        stream(DirectionAssignee.values()).forEach(assignee -> map.putIfAbsent(assignee, new ArrayList<>()));
     }
 
     /**

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/DirectionHelperServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/DirectionHelperServiceTest.java
@@ -753,6 +753,36 @@ class DirectionHelperServiceTest {
     }
 
     @Nested
+    class AddEmptyDirectionsForAssigneeNotInMap {
+
+        @Test
+        void shouldAddEmptyListValueWhenKeyNotPresentInMap() {
+            Map<DirectionAssignee, List<Element<Direction>>> map = new HashMap<>();
+
+            service.addEmptyDirectionsForAssigneeNotInMap(map);
+
+            assertThat(map).containsOnlyKeys(DirectionAssignee.values());
+        }
+
+        @Test
+        void shouldAddEmptyListValueToNewKeysWhenSomeKeysAreAlreadyPresent() {
+            Map<DirectionAssignee, List<Element<Direction>>> map = new HashMap<>();
+            map.put(LOCAL_AUTHORITY, emptyListOfElement());
+            map.put(CAFCASS, emptyListOfElement());
+
+            service.addEmptyDirectionsForAssigneeNotInMap(map);
+
+            assertThat(map).containsOnlyKeys(DirectionAssignee.values());
+            assertThat(map).extracting(ALL_PARTIES, PARENTS_AND_RESPONDENTS, COURT, OTHERS).containsOnly(emptyList());
+            assertThat(map).extracting(LOCAL_AUTHORITY, CAFCASS).containsOnly(emptyListOfElement());
+        }
+
+        private ImmutableList<Element<Direction>> emptyListOfElement() {
+            return ImmutableList.of(Element.<Direction>builder().build());
+        }
+    }
+
+    @Nested
     class RemoveCustomDirections {
 
         @Test

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/DirectionHelperServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/DirectionHelperServiceTest.java
@@ -761,7 +761,8 @@ class DirectionHelperServiceTest {
 
             service.addEmptyDirectionsForAssigneeNotInMap(map);
 
-            assertThat(map).containsOnlyKeys(DirectionAssignee.values());
+            Stream.of(DirectionAssignee.values())
+                .forEach(assignee -> assertThat(map.get(assignee)).isEqualTo(emptyList()));
         }
 
         @Test


### PR DESCRIPTION
### Change description ###

new method in DirectionHelperService to add empty values for DirectionAssignee not present.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
