### PR TITLE
refactor/fix: update 'others to be given notice' event to be consistent with similar events

### DIFF
--- a/ccd-definition/AuthorisationCaseField/la-solicitor.json
+++ b/ccd-definition/AuthorisationCaseField/la-solicitor.json
@@ -221,7 +221,7 @@
     "CaseTypeID": "CARE_SUPERVISION_EPO",
     "CaseFieldID": "others",
     "UserRole": "caseworker-publiclaw-solicitor",
-    "CRUD": "CRU"
+    "CRUD": "CRUD"
   },
   {
     "LiveFrom": "01/01/2017",

--- a/ccd-definition/CaseEvent/Gatekeeping.json
+++ b/ccd-definition/CaseEvent/Gatekeeping.json
@@ -72,6 +72,8 @@
     "PreConditionState(s)": "Gatekeeping",
     "PostConditionState": "Gatekeeping",
     "SecurityClassification": "Public",
+    "CallBackURLAboutToStartEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/enter-others/about-to-start",
+    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/enter-others/about-to-submit",
     "ShowSummary": "N",
     "ShowEventNotes": "Y",
     "EndButtonLabel": "Save and continue"

--- a/ccd-definition/CaseEvent/Open.json
+++ b/ccd-definition/CaseEvent/Open.json
@@ -103,6 +103,8 @@
     "PreConditionState(s)": "Open",
     "PostConditionState": "Open",
     "SecurityClassification": "Public",
+    "CallBackURLAboutToStartEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/enter-others/about-to-start",
+    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/enter-others/about-to-submit",
     "ShowSummary": "N",
     "ShowEventNotes": "N",
     "EndButtonLabel": "Save and continue"

--- a/ccd-definition/CaseEvent/PREPARE_FOR_HEARING.json
+++ b/ccd-definition/CaseEvent/PREPARE_FOR_HEARING.json
@@ -55,6 +55,8 @@
     "PreConditionState(s)": "PREPARE_FOR_HEARING",
     "PostConditionState": "PREPARE_FOR_HEARING",
     "SecurityClassification": "Public",
+    "CallBackURLAboutToStartEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/enter-others/about-to-start",
+    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/enter-others/about-to-submit",
     "ShowSummary": "N",
     "ShowEventNotes": "Y",
     "EndButtonLabel": "Save and continue"

--- a/ccd-definition/CaseEvent/Submitted.json
+++ b/ccd-definition/CaseEvent/Submitted.json
@@ -127,6 +127,8 @@
     "PreConditionState(s)": "Submitted",
     "PostConditionState": "Submitted",
     "SecurityClassification": "Public",
+    "CallBackURLAboutToStartEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/enter-others/about-to-start",
+    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/enter-others/about-to-submit",
     "ShowSummary": "N",
     "ShowEventNotes": "Y",
     "EndButtonLabel": "Save and continue"

--- a/ccd-definition/ComplexTypes/Person.json
+++ b/ccd-definition/ComplexTypes/Person.json
@@ -5,6 +5,7 @@
     "ListElementCode": "firstOther",
     "FieldType": "Others",
     "ElementLabel": "Person 1",
+    "FieldShowCondition": "firstOther=\"DO_NOT_SHOW\"",
     "SecurityClassification": "Public"
   },
   {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/OthersController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/OthersController.java
@@ -1,0 +1,57 @@
+package uk.gov.hmcts.reform.fpl.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.annotations.Api;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse;
+import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.fpl.model.CaseData;
+import uk.gov.hmcts.reform.fpl.service.OthersService;
+
+@Api
+@RestController
+@RequestMapping("/callback/enter-others")
+public class OthersController {
+
+    private final ObjectMapper mapper;
+    private final OthersService othersService;
+
+    @Autowired
+    public OthersController(ObjectMapper mapper, OthersService othersService) {
+        this.mapper = mapper;
+        this.othersService = othersService;
+    }
+
+    @PostMapping("/about-to-start")
+    public AboutToStartOrSubmitCallbackResponse handleAboutToStart(@RequestBody CallbackRequest callbackrequest) {
+        CaseDetails caseDetails = callbackrequest.getCaseDetails();
+        CaseData caseData = mapper.convertValue(caseDetails.getData(), CaseData.class);
+
+        caseDetails.getData().put("others", othersService.expandOthersCollection(caseData));
+
+        return AboutToStartOrSubmitCallbackResponse.builder()
+            .data(caseDetails.getData())
+            .build();
+    }
+
+    @PostMapping("/about-to-submit")
+    public AboutToStartOrSubmitCallbackResponse handleAboutToSubmit(@RequestBody CallbackRequest callbackRequest) {
+        CaseDetails caseDetails = callbackRequest.getCaseDetails();
+        CaseData caseData = mapper.convertValue(caseDetails.getData(), CaseData.class);
+
+        if (othersService.expandedCollectionNotEmpty(caseData.getOthers().getAdditionalOthers())) {
+            caseDetails.getData().put("others", othersService.handleFirstOther(caseData));
+        } else {
+            caseDetails.getData().remove("others");
+        }
+
+        return AboutToStartOrSubmitCallbackResponse.builder()
+            .data(caseDetails.getData())
+            .build();
+    }
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/Other.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/Other.java
@@ -4,18 +4,23 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
+import java.time.LocalDate;
+
 @Data
 @Builder
 @AllArgsConstructor
 public class Other {
     @SuppressWarnings("membername")
-    private final String DOB;
+    private final LocalDate DOB;        //date not persisting - please investigate
     private final String name;
     private final String gender;
     private final Address address;
     private final String telephone;
-    private final String birthplace;
+    private final String birthPlace;
     private final String childInformation;
+    private final String detailsHidden;
+    private final String detailsHiddenReason;
     private final String litigationIssues;
+    private final String litigationIssuesDetails;
     private final String genderIdentification;
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/OthersService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/OthersService.java
@@ -1,29 +1,79 @@
 package uk.gov.hmcts.reform.fpl.service;
 
 import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.fpl.model.Address;
+import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.Other;
 import uk.gov.hmcts.reform.fpl.model.Others;
+import uk.gov.hmcts.reform.fpl.model.common.Element;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static net.logstash.logback.encoder.org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+import static net.logstash.logback.encoder.org.apache.commons.lang3.ObjectUtils.isNotEmpty;
 
 @Service
 public class OthersService {
 
+    public Others expandOthersCollection(CaseData caseData) {
+        List<Element<Other>> others = new ArrayList<>();
+
+        if (caseData.getOthers() == null) {
+            others.add(Element.<Other>builder()
+                .value(Other.builder()
+                    .build())
+                .build());
+        } else {
+            //Maintain existing cases where a firstOther exists
+            if (isNotEmpty(caseData.getOthers().getFirstOther())
+                && !caseData.getOthers().getFirstOther().equals(Other.builder().build())) {
+                others.add(Element.<Other>builder().value(caseData.getOthers().getFirstOther()).build());
+            }
+
+            if (isNotEmpty(caseData.getOthers().getAdditionalOthers())) {
+                others.addAll(caseData.getOthers().getAdditionalOthers());
+            }
+        }
+
+        return Others.builder()
+            .additionalOthers(others)
+            .build();
+    }
+
+    public Others handleFirstOther(CaseData caseData) {
+        List<Element<Other>> others = caseData.getOthers().getAdditionalOthers();
+
+        if (isNotEmpty(caseData.getOthers().getFirstOther())) {
+            others.add(0, Element.<Other>builder().value(caseData.getOthers().getFirstOther()).build());
+        }
+
+        return Others.builder()
+            .additionalOthers(others)
+            .build();
+    }
+
     public String buildOthersLabel(Others others) {
         StringBuilder sb = new StringBuilder();
-
+        //Handles old cases where firstOther exists (others event not re-submitted) and new cases with no firstOther
         if (otherExists(others)) {
-            if (others.getFirstOther() != null) {
+            int othersListStartIndex = 1;
+            if (isNotEmpty(others.getFirstOther())) {
                 sb.append(String.format("Person 1 - %s", getName(others.getFirstOther()))).append("\n");
-            }
-
-            if (others.getAdditionalOthers() != null) {
-                for (int i = 0; i < others.getAdditionalOthers().size(); i++) {
-                    Other other = others.getAdditionalOthers().get(i).getValue();
-
-                    sb.append(String.format("Other person %d - %s", i + 1, getName(other))).append("\n");
+                if (isNotEmpty(others.getAdditionalOthers())) {
+                    othersListStartIndex = 0;
                 }
+            } else if (isNotEmpty(others.getAdditionalOthers())) {
+                sb.append(String.format("Person 1 - %s", getName(others.getAdditionalOthers().get(0).getValue())))
+                    .append("\n");
             }
+
+            for (int i = othersListStartIndex; i < others.getAdditionalOthers().size(); i++) {
+                Other other = others.getAdditionalOthers().get(i).getValue();
+
+                sb.append(String.format("Other person %d - %s", i + 1, getName(other))).append("\n");
+            }
+
         } else {
             sb.append("No others on the case");
         }
@@ -39,4 +89,9 @@ public class OthersService {
         return others != null && (others.getFirstOther() != null || others.getAdditionalOthers() != null);
     }
 
+    public boolean expandedCollectionNotEmpty(List<Element<Other>> additionalOthers) {
+        return (isNotEmpty(additionalOthers)
+            && !additionalOthers.get(0).getValue().equals(
+            Other.builder().address(Address.builder().build()).build()));
+    }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/utils/CaseDataGeneratorHelper.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/utils/CaseDataGeneratorHelper.java
@@ -241,9 +241,9 @@ public class CaseDataGeneratorHelper {
     public static Others createOthers() {
         return Others.builder()
             .firstOther(Other.builder()
-                .birthplace("Newry")
+                .birthPlace("Newry")
                 .childInformation("Child suffers from ADD")
-                .DOB("02/02/05")
+                .DOB(LocalDate.now())
                 .gender("Male")
                 .name("Kyle Stafford")
                 .telephone("02838882404")
@@ -259,8 +259,8 @@ public class CaseDataGeneratorHelper {
             .additionalOthers(ImmutableList.of(
                 Element.<Other>builder()
                     .value(Other.builder()
-                        .birthplace("Craigavon")
-                        .DOB("02/02/05")
+                        .birthPlace("Craigavon")
+                        .DOB(LocalDate.now())
                         .gender("Female")
                         .name("Sarah Simpson")
                         .telephone("02838882404")


### PR DESCRIPTION
Will need QA:

- to check that 'others to be given notice' event still works as intended (for LA and admin, who can amend)
- to confirm CMO and SDO "others_label" is still correct

TODO:

- fix DOB not persisting (Others.java, 2_Others.json)
- integration tests for new Others controller (this controller is necessary for upcoming confidentiality story anyway)
- unit tests for new OthersService methods

### Change description ###

Update the 'Other to be given notice' event to just use a collection instead of a 'firstOther' followed by a collection. The old functionality was presumably before 'about-to-start' to expand collections was discovered. We now know how to do this, so we should be consistent with the other two similar events: 'Children' and 'Respondents'. Not only should we be consistent, but as the existing 'firstOther' is not part of a collection, it displays vastly different in the tab view, and users cannot actually delete the first other they have entered.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
