### PR TITLE
fix for date formatting when `hearingTime` returns as 1 January but test returns 01 January

### DIFF
--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/CMODocmosisTemplateDataGenerationServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/CMODocmosisTemplateDataGenerationServiceTest.java
@@ -289,8 +289,8 @@ class CMODocmosisTemplateDataGenerationServiceTest {
 
     private String getHearingTime() {
         return String.format("%s - %s",
-            dateFormatterService.formatLocalDateTimeBaseUsingFormat(NOW, "dd MMMM, h:mma"),
-            dateFormatterService.formatLocalDateTimeBaseUsingFormat(NOW.plusDays(1), "dd MMMM, h:mma"));
+            dateFormatterService.formatLocalDateTimeBaseUsingFormat(NOW, "d MMMM, h:mma"),
+            dateFormatterService.formatLocalDateTimeBaseUsingFormat(NOW.plusDays(1), "d MMMM, h:mma"));
     }
 
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

### Change description ###
Update to `getHearingTime` method in `CMODocmosisTemplateDataGenerationServiceTest` to resolve the day formatting as `CMODocmosisTemplateDataGenerationService.getTemplateData` returns `hearingTime` as `d` not `dd`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
