### PR TITLE
imp: use IDAM on preview when AAT idam is down

### DIFF
--- a/bin/configurer/utils/generate-preview-user-mappings.sh
+++ b/bin/configurer/utils/generate-preview-user-mappings.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -eu
+
+function get_user_ids() {
+  kubectl exec service/shared-db -- psql --username openidm --tuples-only --command "SELECT string_agg(fullobject->>'_id',',') FROM managedObjects WHERE fullobject->>'userName' LIKE '%$1%';" openidm
+}
+
+swansea_user_ids=$(echo $(get_user_ids swansea) | tr -d ' ')
+hillingdon_user_ids=$(echo $(get_user_ids hillingdon) | tr -d ' ')
+
+echo "FPLA=>0;SA=>${swansea_user_ids};HN=>${hillingdon_user_ids}"

--- a/bin/configurer/utils/idam-lease-user-token.sh
+++ b/bin/configurer/utils/idam-lease-user-token.sh
@@ -2,11 +2,10 @@
 
 set -eu
 
-username=${1}
-password=${2}
-clientSecret=${CCD_API_GATEWAY_IDAM_CLIENT_SECRET:-ccd_gateway_secret}
-redirectUri=${CCD_IDAM_REDIRECT_URL:-http://localhost:3451/oauth2redirect}
+username=ccd.docker.default@hmcts.net
+password=Password12
+redirectUri=${CCD_IDAM_REDIRECT_URL:-http://localhost:3451/oauth2redirect }
 
 code=$(curl --insecure --fail --show-error --silent -X POST --user "${username}:${password}" "${IDAM_API_BASE_URL:-http://localhost:5000}/oauth2/authorize?redirect_uri=${redirectUri}&response_type=code&client_id=ccd_gateway" -d "" | docker run --rm --interactive stedolan/jq -r .code)
 
-curl --insecure --fail --show-error --silent -X POST -H "Content-Type: application/x-www-form-urlencoded" --user "ccd_gateway:${clientSecret}" "${IDAM_API_BASE_URL:-http://localhost:5000}/oauth2/token?code=${code}&redirect_uri=${redirectUri}&grant_type=authorization_code" -d "" | docker run --rm --interactive stedolan/jq -r .access_token
+curl --insecure --fail --show-error --silent -X POST -H "Content-Type: application/x-www-form-urlencoded" --user "ccd_gateway:ccd_gateway_secret" "${IDAM_API_BASE_URL:-http://localhost:5000}/oauth2/token?code=${code}&redirect_uri=${redirectUri}&grant_type=authorization_code" -d "" | docker run --rm --interactive stedolan/jq -r .access_token

--- a/bin/variables/load-preview-environment-variables.sh
+++ b/bin/variables/load-preview-environment-variables.sh
@@ -8,9 +8,14 @@ echo 'export ENVIRONMENT=preview'
 
 # urls
 echo "export SERVICE_AUTH_PROVIDER_API_BASE_URL=http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
-echo "export IDAM_API_BASE_URL=https://idam-api.aat.platform.hmcts.net"
-echo "export CCD_IDAM_REDIRECT_URL=https://ccd-case-management-web-aat.service.core-compute-aat.internal/oauth2redirect"
-echo "export CCD_DEFINITION_STORE_API_BASE_URL=https://definition-store-api-fpl-case-service-pr-${pr}.service.core-compute-preview.internal"
+echo "export IDAM_API_BASE_URL=http://api-idam-fpl.service.core-compute-preview.internal"
+echo "export CCD_IDAM_REDIRECT_URL=https://case-management-web-fpl-case-service-pr-${pr}.service.core-compute-preview.internal/oauth2redirect"
+echo "export CCD_DEFINITION_STORE_API_BASE_URL=http://definition-store-api-fpl-case-service-pr-${pr}.service.core-compute-preview.internal"
 
 # definition placeholders
 echo "export CCD_DEF_CASE_SERVICE_BASE_URL=http://fpl-case-service-pr-${pr}.service.core-compute-preview.internal"
+
+# secrets - unset to fallback to defaults
+unset CCD_API_GATEWAY_IDAM_CLIENT_SECRET
+unset CCD_CONFIGURER_IMPORTER_USERNAME
+unset CCD_CONFIGURER_IMPORTER_PASSWORD

--- a/charts/fpl-case-service/values.preview.template.yaml
+++ b/charts/fpl-case-service/values.preview.template.yaml
@@ -7,13 +7,14 @@ java:
   ingressHost: ${SERVICE_FQDN}
   livenessDelay: 50
   environment:
+    IDAM_API_URL: http://api-idam-fpl.service.core-compute-preview.internal
     CORE_CASE_DATA_API_URL: http://${SERVICE_NAME}-data-store-api
     IDAM_CLIENT_ID: fpl_case_service
-    IDAM_CLIENT_REDIRECT_URI: https://fpl-case-service-*.service.core-compute-aat.internal/oauth2/callback
+    IDAM_CLIENT_REDIRECT_URI: https://localhost:9000/oauth2/callback
     RD_PROFESSIONAL_API_URL: http://fpl-prd-mock-service
     SPRING_SECURITY_ENABLED: true
-    SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUERURI: https://forgerock-am.service.core-compute-idam-aat.internal:8443/openam/oauth2/hmcts
-    SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWKSETURI: https://idam-api.aat.platform.hmcts.net/o/jwks
+    SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUERURI: http://fr-am:8080/openam/oauth2/hmcts
+    SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWKSETURI: http://api-idam-fpl.service.core-compute-preview.internal/o/jwks
     GATEWAY_URL: https://gateway-${SERVICE_FQDN}
   keyVaults:
     fpl:
@@ -22,7 +23,7 @@ java:
         - notify-api-key
         - docmosis-api-key
         - fpl-case-service-s2s-secret
-        - fpl-case-service-idam-client-secret
+        - fpl-case-service-idam-client-secret-preview
         - local-authority-email-to-code-mapping
         - local-authority-code-to-name-mapping
         - local-authority-user-mapping
@@ -38,8 +39,14 @@ ccd:
   ingressIP: ${INGRESS_IP}
   consulIP: ${CONSUL_LB_IP}
   cpuRequests: 250m
+  idamApiUrl: http://api-idam-fpl.service.core-compute-preview.internal
+  idamWebUrl: http://web-idam-fpl.service.core-compute-preview.internal
   idam-pr:
     releaseNameOverride: ${SERVICE_NAME}-ccd-idam-pr
+    api:
+      url: http://api-idam-fpl.service.core-compute-preview.internal
+    web_public:
+      url: http://web-idam-fpl.service.core-compute-preview.internal
     redirect_uris:
       CCD:
         - https://case-management-web-${SERVICE_FQDN}/oauth2redirect
@@ -57,7 +64,7 @@ ccd:
   apiGateway:
     s2sKey: ${CCD_API_GATEWAY_S2S_SECRET}
     idamClientSecret:
-      value: ${CCD_API_GATEWAY_IDAM_CLIENT_SECRET}
+      value: ccd_gateway_secret
     environment:
       PROXY_DOCUMENT_MANAGEMENT: http://dm-store-aat.service.core-compute-aat.internal
       ADDRESS_LOOKUP_TOKEN: ${ADDRESS_LOOKUP_TOKEN}

--- a/service/src/main/resources/bootstrap.yaml
+++ b/service/src/main/resources/bootstrap.yaml
@@ -7,7 +7,7 @@ spring:
         notify-api-key: notify.api_key
         docmosis-api-key: docmosis.tornado.key
         fpl-case-service-s2s-secret: idam.s2s-auth.totp_secret
-        fpl-case-service-idam-client-secret: idam.client.secret
+        fpl-case-service-idam-client-secret-preview: idam.client.secret
         local-authority-email-to-code-mapping: fpl.local_authority_email_to_code.mapping
         local-authority-code-to-name-mapping: fpl.local_authority_code_to_name.mapping
         local-authority-user-mapping: fpl.local_authority_user.mapping


### PR DESCRIPTION
### JIRA link (if applicable) ###

None

### Change description ###

This switches FPL preview environment to team IDAM instance that is deployed in AKS cluster. 

Team IDAM is deployed in preview and configured with all required services, roles and users.

In case switch is required the following steps are required:

1. merge this PR
2. run `bin/configurer/utils/generate-preview-user-mappings.sh` script and update `local-authority-user-mapping` Key Vault key with the result of the script to update user mappings
3. ~~set `fpl_case_service_secret` as value of `fpl-case-service-idam-client-secret` in Key Vault~~ (for now the code is using fpl-case-service-idam-client-secret-preview) seems a bit more elegant) 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
