### PR TITLE
fix: only validate edited and new hearing bookings (FPLA-1178)

### DIFF
--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/HearingBookingDetailsControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/HearingBookingDetailsControllerTest.java
@@ -6,13 +6,19 @@ import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.ActiveProfiles;
 import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse;
+import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.model.HearingBooking;
+import uk.gov.hmcts.reform.fpl.model.common.Element;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
+import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.element;
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.wrapElements;
 
 @ActiveProfiles("integration-test")
@@ -21,6 +27,7 @@ import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.wrapElements;
 class HearingBookingDetailsControllerTest extends AbstractControllerTest {
 
     private static final String ERROR_MESSAGE = "Enter a start date in the future";
+    private static final HearingBooking EMPTY_BOOKING = HearingBooking.builder().build();
 
     HearingBookingDetailsControllerTest() {
         super("add-hearing-bookings");
@@ -31,7 +38,7 @@ class HearingBookingDetailsControllerTest extends AbstractControllerTest {
         LocalDateTime yesterday = LocalDateTime.now().minusDays(1);
 
         AboutToStartOrSubmitCallbackResponse callbackResponse = makeRequest(createHearing(
-            yesterday, yesterday.plusDays(1)));
+            yesterday, yesterday.plusDays(1)), EMPTY_BOOKING);
 
         assertThat(callbackResponse.getErrors()).contains(ERROR_MESSAGE);
     }
@@ -41,7 +48,7 @@ class HearingBookingDetailsControllerTest extends AbstractControllerTest {
         LocalDateTime tomorrow = LocalDateTime.now().plusDays(1);
 
         AboutToStartOrSubmitCallbackResponse callbackResponse = makeRequest(createHearing(
-            tomorrow, tomorrow.plusDays(1)));
+            tomorrow, tomorrow.plusDays(1)), EMPTY_BOOKING);
 
         assertThat(callbackResponse.getErrors()).doesNotContain(ERROR_MESSAGE);
     }
@@ -50,7 +57,8 @@ class HearingBookingDetailsControllerTest extends AbstractControllerTest {
     void shouldReturnAnErrorWhenHearingDateIsSetToToday() throws Exception {
         LocalDateTime today = LocalDateTime.now();
 
-        AboutToStartOrSubmitCallbackResponse callbackResponse = makeRequest(createHearing(today, today.plusDays(1)));
+        AboutToStartOrSubmitCallbackResponse callbackResponse = makeRequest(createHearing(
+            today, today.plusDays(1)), EMPTY_BOOKING);
 
         assertThat(callbackResponse.getErrors()).contains(ERROR_MESSAGE);
     }
@@ -60,7 +68,7 @@ class HearingBookingDetailsControllerTest extends AbstractControllerTest {
         LocalDateTime distantPast = LocalDateTime.now().minusYears(10000);
 
         AboutToStartOrSubmitCallbackResponse callbackResponse = makeRequest(createHearing(
-            distantPast, distantPast.plusDays(1)));
+            distantPast, distantPast.plusDays(1)), EMPTY_BOOKING);
 
         assertThat(callbackResponse.getErrors()).contains(ERROR_MESSAGE);
     }
@@ -70,9 +78,43 @@ class HearingBookingDetailsControllerTest extends AbstractControllerTest {
         LocalDateTime distantFuture = LocalDateTime.now().plusYears(1000);
 
         AboutToStartOrSubmitCallbackResponse callbackResponse = makeRequest(createHearing(
-            distantFuture, distantFuture.plusDays(1)));
+            distantFuture, distantFuture.plusDays(1)), EMPTY_BOOKING);
 
         assertThat(callbackResponse.getErrors()).doesNotContain(ERROR_MESSAGE);
+    }
+
+    @Test
+    void shouldOnlyValidateNewBookingsWhenBookingAlreadyExists() throws Exception {
+        LocalDateTime distantFuture = LocalDateTime.now().plusYears(1000);
+        LocalDateTime distantPast = LocalDateTime.now().minusYears(10000);
+
+        AboutToStartOrSubmitCallbackResponse callbackResponse = makeRequest(createHearing(
+            distantFuture, distantFuture.plusDays(1)), createHearing(distantPast, distantPast.plusDays(1)));
+
+        assertThat(callbackResponse.getErrors()).doesNotContain(ERROR_MESSAGE);
+    }
+
+    @Test
+    void shouldErrorWhenExistingBookingIsUpdatedToPastDate() {
+        LocalDateTime futureDate = LocalDateTime.now().plusDays(5);
+        UUID hearingId = randomUUID();
+
+        CallbackRequest request = callbackRequestWithEditedBooking(futureDate, hearingId);
+
+        AboutToStartOrSubmitCallbackResponse callbackResponse = postMidEvent(request);
+
+        assertThat(callbackResponse.getErrors()).containsOnlyOnce(ERROR_MESSAGE);
+    }
+
+    private CallbackRequest callbackRequestWithEditedBooking(LocalDateTime futureDate, UUID hearingId) {
+        return CallbackRequest.builder()
+                .caseDetails(CaseDetails.builder()
+                    .data(Map.of("hearingDetails", listBookingWithStartDate(hearingId, futureDate.minusDays(10))))
+                    .build())
+                .caseDetailsBefore(CaseDetails.builder()
+                    .data(Map.of("hearingDetails", listBookingWithStartDate(hearingId, futureDate)))
+                    .build())
+                .build();
     }
 
     private HearingBooking createHearing(LocalDateTime startDate, LocalDateTime endDate) {
@@ -82,16 +124,30 @@ class HearingBookingDetailsControllerTest extends AbstractControllerTest {
             .build();
     }
 
-    private AboutToStartOrSubmitCallbackResponse makeRequest(HearingBooking hearingDetail) throws Exception {
-        Map<String, Object> map = mapper.readValue(mapper.writeValueAsString(hearingDetail),
+    private AboutToStartOrSubmitCallbackResponse makeRequest(HearingBooking after, HearingBooking before) throws Exception {
+        Map<String, Object> mapAfter = mapper.readValue(mapper.writeValueAsString(after),
             new TypeReference<>() {
             });
 
-        CaseDetails caseDetails = CaseDetails.builder()
-            .id(12345L)
-            .data(Map.of("hearingDetails", wrapElements(map)))
+        Map<String, Object> mapBefore = mapper.readValue(mapper.writeValueAsString(before),
+            new TypeReference<>() {
+            });
+
+        CallbackRequest request = CallbackRequest.builder()
+            .caseDetails(CaseDetails.builder()
+                .id(12345L)
+                .data(Map.of("hearingDetails", wrapElements(mapAfter)))
+                .build())
+            .caseDetailsBefore(CaseDetails.builder()
+                .id(12345L)
+                .data(Map.of("hearingDetails", wrapElements(mapBefore)))
+                .build())
             .build();
 
-        return postMidEvent(caseDetails);
+        return postMidEvent(request);
+    }
+
+    private List<Element<HearingBooking>> listBookingWithStartDate(UUID id, LocalDateTime date) {
+        return List.of(element(id, createHearing(date, date.plusDays(1))));
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/HearingBookingDetailsController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/HearingBookingDetailsController.java
@@ -21,6 +21,9 @@ import uk.gov.hmcts.reform.fpl.validation.groups.HearingBookingDetailsGroup;
 import java.util.ArrayList;
 import java.util.List;
 
+import static java.util.Collections.emptyList;
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+
 @Api
 @RestController
 @RequestMapping("/callback/add-hearing-bookings")
@@ -56,9 +59,16 @@ public class HearingBookingDetailsController {
     @PostMapping("/mid-event")
     public AboutToStartOrSubmitCallbackResponse handleMidEvent(@RequestBody CallbackRequest callbackrequest) {
         CaseDetails caseDetails = callbackrequest.getCaseDetails();
+        CaseDetails caseDetailsBefore = callbackrequest.getCaseDetailsBefore();
         CaseData caseData = mapper.convertValue(caseDetails.getData(), CaseData.class);
+        CaseData caseDataBefore = mapper.convertValue(caseDetailsBefore.getData(), CaseData.class);
+
+        List<Element<HearingBooking>> hearingDetailsBefore =
+            defaultIfNull(caseDataBefore.getHearingDetails(), emptyList());
 
         List<Element<HearingBooking>> hearingDetails = caseData.getHearingDetails();
+
+        hearingBookingService.filterPreviousHearings(hearingDetailsBefore, hearingDetails);
 
         final List<String> errors = validateHearingBookings(hearingDetails);
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/HearingBookingService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/HearingBookingService.java
@@ -59,4 +59,8 @@ public class HearingBookingService {
             .findFirst()
             .orElse(null);
     }
+
+    public void filterPreviousHearings(List<Element<HearingBooking>> before, List<Element<HearingBooking>> after) {
+        after.removeIf(before::contains);
+    }
 }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/HearingBookingServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/HearingBookingServiceTest.java
@@ -221,6 +221,24 @@ class HearingBookingServiceTest {
             assertThat(returnedHearings).isEqualTo(hearingBookings);
         }
 
+        @Test
+        void shouldReturnEmptyListWhenUpdatedHearingButStartDateIsNotChanged() {
+            HearingBooking.HearingBookingBuilder builder = HearingBooking.builder()
+                .startDate(date.plusDays(5));
+
+            List<Element<HearingBooking>> existingHearing = List.of(element(hearingId, builder.build()));
+
+            List<Element<HearingBooking>> newHearing = List.of(element(hearingId, builder
+                .endDate(date.plusDays(10))
+                .type("hearing type")
+                .venue("venue")
+                .build()));
+
+            List<Element<HearingBooking>> returnedHearings = service.getChangedHearings(existingHearing, newHearing);
+
+            assertThat(returnedHearings).isEmpty();
+        }
+
         private Element<HearingBooking> hearingBookingWithIdAndStartDate(UUID hearingId, int i) {
             return element(hearingId, HearingBooking.builder()
                 .startDate(date.plusDays(i))


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FPLA-1178

### Change description ###

Compare caseDetails before to see which hearing bookings are new or have been updated.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
