### PR TITLE
fix: Comply on behalf - use correct id when checking if party is repr…

### DIFF
--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ComplyOnBehalfControllerAboutToStartTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ComplyOnBehalfControllerAboutToStartTest.java
@@ -180,9 +180,8 @@ class ComplyOnBehalfControllerAboutToStartTest extends AbstractControllerTest {
     }
 
     private List<Element<Representative>> representativeServedByPost() {
-        return List.of(ElementUtils.element(
+        return List.of(ElementUtils.element(ComplyOnBehalfControllerAboutToStartTest.REPRESENTATIVE_ID,
             Representative.builder()
-                .idamId(ComplyOnBehalfControllerAboutToStartTest.REPRESENTATIVE_ID.toString())
                 .servingPreferences(POST)
                 .build()));
     }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/DirectionHelperService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/DirectionHelperService.java
@@ -275,11 +275,10 @@ public class DirectionHelperService {
     }
 
     // if representative left in list, where serving pref = DIGITAL_SERVICE -> keep direction.
-    // could be improved with a call to idam? return directions that belong to representative??
     private boolean isDirectionForUnrepresentedParty(List<Element<Representative>> representatives,
                                                      List<Element<UUID>> finalIds) {
         return representatives.stream()
-            .filter(x -> unwrapElements(finalIds).contains(UUID.fromString(x.getValue().getIdamId())))
+            .filter(x -> unwrapElements(finalIds).contains(x.getId()))
             .anyMatch(x -> x.getValue().getServingPreferences() != DIGITAL_SERVICE);
     }
 

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/DirectionHelperServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/DirectionHelperServiceTest.java
@@ -1666,8 +1666,7 @@ class DirectionHelperServiceTest {
         }
 
         private List<Element<Representative>> representativeWithServingPreference(RepresentativeServingPreferences x) {
-            return List.of(ElementUtils.element(Representative.builder()
-                .idamId(representativeId.toString())
+            return List.of(ElementUtils.element(representativeId, Representative.builder()
                 .servingPreferences(x)
                 .build()));
         }


### PR DESCRIPTION
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
