### PR TITLE
refactor: add additional path structure to create order mid event

### DIFF
--- a/ccd-definition/CaseEventToFields/createOrder-PREPARE_FOR_HEARING.json
+++ b/ccd-definition/CaseEventToFields/createOrder-PREPARE_FOR_HEARING.json
@@ -139,7 +139,7 @@
     "PageDisplayOrder": 7,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "Y",
-    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/create-order/mid-event"
+    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/create-order/generate-document/mid-event"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -154,6 +154,6 @@
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "Y",
     "PageShowCondition": "orderTypeAndDocument.type!=\"BLANK_ORDER\"",
-    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/create-order/mid-event"
+    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/create-order/generate-document/mid-event"
   }
 ]

--- a/ccd-definition/CaseEventToFields/createOrder.json
+++ b/ccd-definition/CaseEventToFields/createOrder.json
@@ -139,7 +139,7 @@
     "PageDisplayOrder": 7,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "Y",
-    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/create-order/mid-event"
+    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/create-order/generate-document/mid-event"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -154,6 +154,6 @@
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "Y",
     "PageShowCondition": "orderTypeAndDocument.type!=\"BLANK_ORDER\"",
-    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/create-order/mid-event"
+    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/create-order/generate-document/mid-event"
   }
 ]

--- a/ccd-definition/CaseEventToFields/createOrderGatekeeping.json
+++ b/ccd-definition/CaseEventToFields/createOrderGatekeeping.json
@@ -139,7 +139,7 @@
     "PageDisplayOrder": 7,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "Y",
-    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/create-order/mid-event"
+    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/create-order/generate-document/mid-event"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -154,6 +154,6 @@
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "Y",
     "PageShowCondition": "orderTypeAndDocument.type!=\"BLANK_ORDER\"",
-    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/create-order/mid-event"
+    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/create-order/generate-document/mid-event"
   }
 ]

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/GeneratedOrderControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/GeneratedOrderControllerTest.java
@@ -311,7 +311,8 @@ class GeneratedOrderControllerTest extends AbstractControllerTest {
         void shouldGenerateDocumentWithCorrectNameWhenOrderTypeIsValid(CaseDetails caseDetails,
                                                                        String fileName,
                                                                        DocmosisTemplates templateName) {
-            final AboutToStartOrSubmitCallbackResponse callbackResponse = postMidEvent(caseDetails);
+            final AboutToStartOrSubmitCallbackResponse callbackResponse = postMidEvent(
+                caseDetails, "generate-document");
 
             verify(docmosisDocumentGeneratorService).generateDocmosisDocument(any(), eq(templateName));
             verify(uploadDocumentService).uploadPDF(userId, userAuthToken, pdf, fileName);
@@ -323,7 +324,7 @@ class GeneratedOrderControllerTest extends AbstractControllerTest {
 
         @Test
         void shouldNotGenerateOrderDocumentWhenOrderTypeIsCareOrderWithNoFurtherDirections() {
-            postMidEvent(generateCareOrderCaseDetailsWithoutFurtherDirections());
+            postMidEvent(generateCareOrderCaseDetailsWithoutFurtherDirections(), "generate-document");
 
             verify(docmosisDocumentGeneratorService, never()).generateDocmosisDocument(any(), any());
             verify(uploadDocumentService, never()).uploadPDF(any(), any(), any(), any());

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/GeneratedOrderController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/GeneratedOrderController.java
@@ -80,7 +80,7 @@ public class GeneratedOrderController {
             .build();
     }
 
-    @PostMapping("/mid-event")
+    @PostMapping("/generate-document/mid-event")
     public AboutToStartOrSubmitCallbackResponse handleMidEvent(
         @RequestHeader(value = "authorization") String authorization,
         @RequestHeader(value = "user-id") String userId,


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Added an additional path structure for the mid event in the create order event.
This is to reduce the size/number of changes in #857.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
