### PR TITLE
increase default pupeteer timeout (30 sec)

### DIFF
--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -12,7 +12,7 @@ exports.config = {
       show: process.env.SHOW_BROWSER_WINDOW || false,
       restart: false,
       keepCookies: true,
-      waitForTimeout: 10000,
+      waitForTimeout: 30000,
       chrome: {
         ignoreHTTPSErrors: true,
         args: process.env.PROXY_SERVER ? [


### PR DESCRIPTION
current timeout of 10 sec is not enough, especially when log out/log in, and cause plenty of retries which do not help when application is slow