### PR TITLE
imp: add allocation proposal to tag creating case with mandatory fields

### DIFF
--- a/e2e/tests/localAuthoritySubmitsApplication_test.js
+++ b/e2e/tests/localAuthoritySubmitsApplication_test.js
@@ -425,7 +425,7 @@ Scenario('local authority enters other proceedings', async (I, caseViewPage, ent
   I.seeInTab(['Additional proceedings 1', 'Is the same guardian needed?'], 'Yes');
 });
 
-Scenario('local authority enters allocation proposal', async (I, caseViewPage, enterAllocationProposalEventPage) => {
+Scenario('local authority enters allocation proposal @create-case-with-mandatory-sections-only', async (I, caseViewPage, enterAllocationProposalEventPage) => {
   await caseViewPage.goToNewActions(config.applicationActions.enterAllocationProposal);
   enterAllocationProposalEventPage.selectAllocationProposal('Magistrate');
   enterAllocationProposalEventPage.enterProposalReason('test');


### PR DESCRIPTION
### Change description ###

As in title - allocation proposal is now set when using tag:
 yarn test --grep "@create-case-with-mandatory-sections-only"

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
