### PR TITLE
fix: added updated order to caseData for next hearing date in cmo (FPLA-1624)

### DIFF
--- a/e2e/tests/localAuthoritySubmitsApplication_test.js
+++ b/e2e/tests/localAuthoritySubmitsApplication_test.js
@@ -402,7 +402,7 @@ Scenario('local authority enters other proceedings', async (I, caseViewPage, ent
   I.seeInTab(['Additional proceedings 1', 'Is the same guardian needed?'], 'Yes');
 });
 
-Scenario('local authority enters allocation proposal', async (I, caseViewPage, enterAllocationProposalEventPage) => {
+Scenario('local authority enters allocation proposal @create-case-with-mandatory-sections-only', async (I, caseViewPage, enterAllocationProposalEventPage) => {
   await caseViewPage.goToNewActions(config.applicationActions.enterAllocationProposal);
   enterAllocationProposalEventPage.selectAllocationProposal('Magistrate');
   enterAllocationProposalEventPage.enterProposalReason('test');

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ActionCaseManagementOrderControllerAboutToSubmitTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ActionCaseManagementOrderControllerAboutToSubmitTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.fpl.controllers;
 
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -118,14 +117,6 @@ class ActionCaseManagementOrderControllerAboutToSubmitTest extends AbstractContr
         assertThat(caseData.getCaseManagementOrder()).isEqualTo(expectedCaseManagementOrder());
     }
 
-    private String expectedPreHearing() {
-        return formatLocalDateTimeBaseUsingFormat(NOW.minusHours(1), "h:mma");
-    }
-
-    private String expectedHearingTime() {
-        return formatLocalDateTimeBaseUsingFormat(NOW, "h:mma") + " - " + formatLocalDateTimeBaseUsingFormat(NOW, "h:mma");
-    }
-
     @Test
     void shouldErrorIfHearingDateInFutureWhenSendToAllParties() {
         Map<String, Object> data = Map.of(
@@ -233,5 +224,17 @@ class ActionCaseManagementOrderControllerAboutToSubmitTest extends AbstractContr
             .caseTypeId(CASE_TYPE)
             .data(data)
             .build();
+    }
+
+    private String expectedPreHearing() {
+        return getStringDate(NOW.minusHours(1));
+    }
+
+    private String expectedHearingTime() {
+        return getStringDate(NOW) + " - " + getStringDate(NOW);
+    }
+
+    private String getStringDate(LocalDateTime now) {
+        return formatLocalDateTimeBaseUsingFormat(now, "h:mma");
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/ActionCaseManagementOrderController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/ActionCaseManagementOrderController.java
@@ -143,7 +143,7 @@ public class ActionCaseManagementOrderController {
             order = caseManagementOrderService.addNextHearingToCMO(caseData.getNextHearingDateList(), order);
         }
 
-        Document document = getDocument(caseData, order.isDraft());
+        Document document = getDocument(caseData.toBuilder().caseManagementOrder(order).build(), order.isDraft());
 
         order = caseManagementOrderService.addDocument(order, document);
 


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FPLA-1624

### Change description ###

A different object was being updated with new values, but then not being sent to the template service for document generation. This change adds a toBuilder method on case data and adds the updated order object. 

This is not the cleanest fix, I would like to revist the cmo controllers in a wider refactoring. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
