### PR TITLE
impr: stop use of IdamClient.authenticateUser as this is now deprecated. Now using IdamClient.getAccessToken

### DIFF
--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/CaseInitiationControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/CaseInitiationControllerTest.java
@@ -64,7 +64,7 @@ class CaseInitiationControllerTest extends AbstractControllerTest {
 
     @BeforeEach
     void setup() {
-        given(client.authenticateUser(userConfig.getUserName(), userConfig.getPassword())).willReturn(userAuthToken);
+        given(client.getAccessToken(userConfig.getUserName(), userConfig.getPassword())).willReturn(userAuthToken);
 
         given(authTokenGenerator.generate()).willReturn(SERVICE_AUTH_TOKEN);
 
@@ -104,7 +104,7 @@ class CaseInitiationControllerTest extends AbstractControllerTest {
     }
 
     @Test
-    void updateCaseRolesShouldBeCalledOnceForEachUser() throws Exception {
+    void updateCaseRolesShouldBeCalledOnceForEachUser() throws InterruptedException {
         postSubmittedEvent(callbackRequest());
 
         Thread.sleep(3000);
@@ -113,7 +113,7 @@ class CaseInitiationControllerTest extends AbstractControllerTest {
     }
 
     @Test
-    void shouldContinueAddingCaseRolesToUsersAfterGrantAccessFailure() throws Exception {
+    void shouldContinueAddingCaseRolesToUsersAfterGrantAccessFailure() throws InterruptedException {
         doThrow(RuntimeException.class).when(caseUserApi).updateCaseRolesForUser(
             any(), any(), any(), any(), any());
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/PopulateStandardDirectionsHandler.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/PopulateStandardDirectionsHandler.java
@@ -50,7 +50,7 @@ public class PopulateStandardDirectionsHandler {
     @Async
     @EventListener
     public void populateStandardDirections(PopulateStandardDirectionsEvent event) throws IOException {
-        String userToken = idamClient.authenticateUser(userConfig.getUserName(), userConfig.getPassword());
+        String userToken = idamClient.getAccessToken(userConfig.getUserName(), userConfig.getPassword());
         String systemUpdateUserId = idamClient.getUserInfo(userToken).getUid();
 
         StartEventResponse startEventResponse = coreCaseDataApi.startEventForCaseWorker(

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/LocalAuthorityUserService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/LocalAuthorityUserService.java
@@ -47,7 +47,7 @@ public class LocalAuthorityUserService {
                                             String caseLocalAuthority) {
         List<String> userIds = findUserIds(caseLocalAuthority);
 
-        String authentication = client.authenticateUser(userConfig.getUserName(), userConfig.getPassword());
+        String authentication = client.getAccessToken(userConfig.getUserName(), userConfig.getPassword());
         Stream.concat(userIds.stream(), Stream.of(requestData.userId()))
             .distinct()
             .parallel()

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/ccd/CoreCaseDataService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/ccd/CoreCaseDataService.java
@@ -36,7 +36,7 @@ public class CoreCaseDataService {
                              Long caseId,
                              String eventName,
                              Map<String, Object> eventData) {
-        String userToken = idamClient.authenticateUser(userConfig.getUserName(), userConfig.getPassword());
+        String userToken = idamClient.getAccessToken(userConfig.getUserName(), userConfig.getPassword());
         String systemUpdateUserId = idamClient.getUserInfo(userToken).getUid();
 
         StartEventResponse startEventResponse = coreCaseDataApi.startEventForCaseWorker(
@@ -72,7 +72,7 @@ public class CoreCaseDataService {
     }
 
     public List<CaseDetails> searchCases(String caseType, String query) {
-        String userToken = idamClient.authenticateUser(userConfig.getUserName(), userConfig.getPassword());
+        String userToken = idamClient.getAccessToken(userConfig.getUserName(), userConfig.getPassword());
 
         return coreCaseDataApi.searchCases(userToken, authTokenGenerator.generate(), caseType, query)
             .getCases();

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/PopulateStandardDirectionsHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/PopulateStandardDirectionsHandlerTest.java
@@ -90,7 +90,7 @@ class PopulateStandardDirectionsHandlerTest {
         populateStandardDirectionsHandler = new PopulateStandardDirectionsHandler(objectMapper, ordersLookupService,
             coreCaseDataApi, authTokenGenerator, idamClient, userConfig, commonDirectionService, hearingBookingService);
 
-        given(idamClient.authenticateUser(userConfig.getUserName(), userConfig.getPassword())).willReturn(TOKEN);
+        given(idamClient.getAccessToken(userConfig.getUserName(), userConfig.getPassword())).willReturn(TOKEN);
 
         given(idamClient.getUserInfo(TOKEN)).willReturn(UserInfo.builder()
             .uid(USER_ID)

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/LocalAuthorityUserServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/LocalAuthorityUserServiceTest.java
@@ -71,7 +71,7 @@ class LocalAuthorityUserServiceTest {
             organisationService,
             authTokenGenerator, caseUserApi, client, userConfig, requestData);
 
-        given(client.authenticateUser(userConfig.getUserName(), userConfig.getPassword())).willReturn(AUTH_TOKEN);
+        given(client.getAccessToken(userConfig.getUserName(), userConfig.getPassword())).willReturn(AUTH_TOKEN);
 
         given(authTokenGenerator.generate()).willReturn(SERVICE_AUTH_TOKEN);
 
@@ -91,7 +91,7 @@ class LocalAuthorityUserServiceTest {
 
         verifyUpdateCaseRolesWasCalledThisManyTimesForEachUser(1, USER_IDS);
 
-        verify(client, times(1)).authenticateUser(anyString(), anyString());
+        verify(client, times(1)).getAccessToken(anyString(), anyString());
     }
 
     @Test

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ccd/CoreCaseDataServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ccd/CoreCaseDataServiceTest.java
@@ -67,7 +67,7 @@ class CoreCaseDataServiceTest {
         void setUp() {
             when(idamClient.getUserInfo(userAuthToken))
                 .thenReturn(UserInfo.builder().uid(userId).build());
-            when(idamClient.authenticateUser(userConfig.getUserName(), userConfig.getPassword()))
+            when(idamClient.getAccessToken(userConfig.getUserName(), userConfig.getPassword()))
                 .thenReturn(userAuthToken);
 
             when(coreCaseDataApi.startEventForCaseWorker(userAuthToken, serviceAuthToken, userId, JURISDICTION,
@@ -131,14 +131,14 @@ class CoreCaseDataServiceTest {
         List<CaseDetails> cases = List.of(CaseDetails.builder().id(RandomUtils.nextLong()).build());
         SearchResult searchResult = SearchResult.builder().cases(cases).build();
 
-        when(idamClient.authenticateUser(userConfig.getUserName(), userConfig.getPassword())).thenReturn(userAuthToken);
+        when(idamClient.getAccessToken(userConfig.getUserName(), userConfig.getPassword())).thenReturn(userAuthToken);
         when(coreCaseDataApi.searchCases(userAuthToken, serviceAuthToken, caseType, query)).thenReturn(searchResult);
 
         List<CaseDetails> casesFound = service.searchCases(caseType, query);
 
         assertThat(casesFound).isEqualTo(cases);
         verify(coreCaseDataApi).searchCases(userAuthToken, serviceAuthToken, caseType, query);
-        verify(idamClient).authenticateUser(userConfig.getUserName(), userConfig.getPassword());
+        verify(idamClient).getAccessToken(userConfig.getUserName(), userConfig.getPassword());
     }
 
     private StartEventResponse buildStartEventResponse(String eventId, String eventToken) {


### PR DESCRIPTION
### JIRA link (if applicable) ###


### Change description ###

Stop use of `IdamClient.authenticateUser` as this is now deprecated. Now using `IdamClient.getAccessToken`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
