### PR TITLE
Fix representative e2e test

### DIFF
--- a/e2e/pages/events/enterRepresentativesEvent.page.js
+++ b/e2e/pages/events/enterRepresentativesEvent.page.js
@@ -42,7 +42,7 @@ module.exports = {
       });
     }
     if(representative.servingPreferences) {
-      this.setServingPreferences(representative.servingPreferences.toLowerCase());
+      await this.setServingPreferences(representative.servingPreferences.toLowerCase());
     }
     if(representative.role) {
       I.selectOption(this.fields(elementIndex).representative.role, representative.role);


### PR DESCRIPTION
Serving preferences is currently clicked after continue button is pressed. Works due to backend validation and retries on clicking continue 