### PR TITLE
fix: hide nested field in children event if initial question set to 'No' (FPLA-1095)

### DIFF
--- a/ccd-definition/ComplexTypes/2_ChildParty.json
+++ b/ccd-definition/ComplexTypes/2_ChildParty.json
@@ -169,7 +169,7 @@
     "ListElementCode": "placementCourt",
     "FieldType": "TextArea",
     "ElementLabel": "Which court are you applying to?",
-    "FieldShowCondition": "placementOrderApplication=\"Yes\"",
+    "FieldShowCondition": "placementOrderApplication=\"Yes\" AND adoption=\"Yes\"",
     "SecurityClassification": "Public"
   },
   {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FPLA-1095

### Change description ###

Hide the 'Which court are you applying to question?' field if the initial question 'Are you considering adoption at this stage?' is set to 'No'. The field we are hiding is nested and currently shows regardless for both yes/no responses on the initial question.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```