### PR TITLE
fix: past hearings persisted when adding new one (FPLA-1701)

### DIFF
--- a/ccd-definition/CaseEvent/Gatekeeping.json
+++ b/ccd-definition/CaseEvent/Gatekeeping.json
@@ -27,6 +27,7 @@
     "PostConditionState": "Gatekeeping",
     "SecurityClassification": "Public",
     "CallBackURLAboutToStartEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/add-hearing-bookings/about-to-start",
+    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/add-hearing-bookings/about-to-submit",
     "ShowSummary": "Y",
     "EndButtonLabel": "Save and continue"
   },

--- a/ccd-definition/CaseEvent/PREPARE_FOR_HEARING.json
+++ b/ccd-definition/CaseEvent/PREPARE_FOR_HEARING.json
@@ -10,6 +10,7 @@
     "PostConditionState": "PREPARE_FOR_HEARING",
     "SecurityClassification": "Public",
     "CallBackURLAboutToStartEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/add-hearing-bookings/about-to-start",
+    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/add-hearing-bookings/about-to-submit",
     "ShowSummary": "Y",
     "EndButtonLabel": "Save and continue"
   },


### PR DESCRIPTION
### JIRA link (if applicable) ###

FPLA-1701

### Change description ###

Past hearings were deleted when adding new hearing details. This was due to about-to-submit callback not being triggered in all states for that particular event. 

```
  {
    "LiveFrom": "01/01/2017",
    "CaseTypeID": "CARE_SUPERVISION_EPO",
    "ID": "hearingBookingDetails",
    "Name": "Add hearing details",
    "Description": "Add hearing booking details to a case",
    "DisplayOrder": 2,
    "PreConditionState(s)": "Submitted",
    "PostConditionState": "Submitted",
    "SecurityClassification": "Public",
    "CallBackURLAboutToStartEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/add-hearing-bookings/about-to-start",
    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/add-hearing-bookings/about-to-submit",
    "ShowSummary": "Y",
    "EndButtonLabel": "Save and continue"
  },
```
Above is original for submitted. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
