### PR TITLE
chore: remove deprecated jenkins call

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -82,7 +82,6 @@ withPipeline(type, product, component) {
   disableLegacyDeployment()
 
   enableAksStagingDeployment()
-  installCharts()
   enableSlackNotifications('#fpla-tech')
 
   env.PROXY_SERVER = "proxyout.reform.hmcts.net:8080"


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

installCharts() was deprecated yesterday and now does nothing as it's behaviour is default

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
