### PR TITLE
fix: added future date check on hearing bookings (FPLA-1768)

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/utils/EmailNotificationHelper.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/utils/EmailNotificationHelper.java
@@ -38,11 +38,11 @@ public class EmailNotificationHelper {
     }
 
     public String buildSubjectLineWithHearingBookingDateSuffix(final CaseData caseData,
-                                                                      final List<Element<HearingBooking>>
-                                                                          hearingBookings) {
+                                                               final List<Element<HearingBooking>> hearingBookings) {
         String subjectLine = buildSubjectLine(caseData);
         String hearingDateText = "";
-        if (isNotEmpty(hearingBookings)) {
+
+        if (hasFutureHearing(hearingBookings)) {
             hearingDateText = buildHearingDateText(hearingBookings);
         }
 
@@ -58,6 +58,11 @@ public class EmailNotificationHelper {
     public static String formatCaseUrl(String uiBaseUrl, Long caseId, String tab) {
         String caseUrl = formatCaseUrl(uiBaseUrl, caseId);
         return isBlank(tab) ? caseUrl : String.format("%s#%s", caseUrl, tab);
+    }
+
+    private boolean hasFutureHearing(List<Element<HearingBooking>> hearingBookings) {
+        return isNotEmpty(hearingBookings) && hearingBookings.stream()
+            .anyMatch(hearing -> hearing.getValue().startsAfterToday());
     }
 
     private String buildHearingDateText(final List<Element<HearingBooking>> hearingBookings) {

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/utils/EmailNotificationHelperTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/utils/EmailNotificationHelperTest.java
@@ -33,11 +33,11 @@ class EmailNotificationHelperTest {
     private Time time;
 
     @Autowired
-    private EmailNotificationHelper emailNotificationHelper;
+    private EmailNotificationHelper helper;
 
     @Test
     void subjectLineShouldBeEmptyWhenNoRespondentOrCaseNumberEmpty() {
-        String subjectLine = emailNotificationHelper.buildSubjectLine(CaseData.builder().build());
+        String subjectLine = helper.buildSubjectLine(CaseData.builder().build());
         assertThat(subjectLine).isEmpty();
     }
 
@@ -49,7 +49,7 @@ class EmailNotificationHelperTest {
             .build();
 
         String expectedSubjectLine = "Jones, FamilyManCaseNumber";
-        String subjectLine = emailNotificationHelper.buildSubjectLine(caseData);
+        String subjectLine = helper.buildSubjectLine(caseData);
         assertThat(subjectLine).isEqualTo(expectedSubjectLine);
     }
 
@@ -60,7 +60,7 @@ class EmailNotificationHelperTest {
             .build();
 
         String expectedSubjectLine = "Jones";
-        String subjectLine = emailNotificationHelper.buildSubjectLine(caseData);
+        String subjectLine = helper.buildSubjectLine(caseData);
         assertThat(subjectLine).isEqualTo(expectedSubjectLine);
     }
 
@@ -105,7 +105,7 @@ class EmailNotificationHelperTest {
             .build();
 
         String expectedSubjectLine = "FamilyManCaseNumber-With-Empty-Lastname";
-        String subjectLine = emailNotificationHelper.buildSubjectLine(caseData);
+        String subjectLine = helper.buildSubjectLine(caseData);
         assertThat(subjectLine).isEqualTo(expectedSubjectLine);
     }
 
@@ -122,7 +122,7 @@ class EmailNotificationHelperTest {
 
         String expectedSubjectLine = "Jones, FamilyManCaseNumber, hearing "
             + formatLocalDateTimeBaseUsingFormat(dateInTenMonths, "d MMM yyyy");
-        String returnedSubjectLine = emailNotificationHelper.buildSubjectLineWithHearingBookingDateSuffix(caseData,
+        String returnedSubjectLine = helper.buildSubjectLineWithHearingBookingDateSuffix(caseData,
             caseData.getHearingDetails());
         assertThat(returnedSubjectLine).isEqualTo(expectedSubjectLine);
     }
@@ -136,9 +136,25 @@ class EmailNotificationHelperTest {
             .build();
 
         String expectedSubjectLine = "Jones, FamilyManCaseNumber";
-        String returnedSubjectLine = emailNotificationHelper.buildSubjectLineWithHearingBookingDateSuffix(caseData,
+        String returnedSubjectLine = helper.buildSubjectLineWithHearingBookingDateSuffix(caseData,
             caseData.getHearingDetails());
         assertThat(returnedSubjectLine).isEqualTo(expectedSubjectLine);
+    }
+
+    @Test
+    void shouldNotAddHearingDateWhenNoFutureHearings() {
+        LocalDateTime pastDate = time.now().minusYears(10);
+        List<Element<HearingBooking>> hearingBookings = createHearingBookingsFromInitialDate(pastDate);
+        CaseData caseData = CaseData.builder()
+            .respondents1(createRespondents())
+            .hearingDetails(hearingBookings)
+            .familyManCaseNumber("FamilyManCaseNumber")
+            .build();
+
+        String expected = "Jones, FamilyManCaseNumber";
+        String actual = helper.buildSubjectLineWithHearingBookingDateSuffix(caseData, caseData.getHearingDetails());
+
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FPLA-1768

### Change description ###

Added the following matcher to the if statement checking whether hearing booking should be populated or not.
```
hearingBookings.stream().anyMatch(hearing -> hearing.getValue().startsAfterToday())

```
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
