### PR TITLE
fix: dates persisted for sdo direction marked not needed (FPLA-1790)

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/CommonDirectionService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/CommonDirectionService.java
@@ -190,25 +190,6 @@ public class CommonDirectionService {
     }
 
     /**
-     * Takes a direction from a configuration file and builds a CCD direction.
-     *
-     * @param direction  the direction taken from json config.
-     * @param completeBy the date to be completed by. Can be null.
-     * @return Direction to be stored in CCD.
-     */
-    public Element<Direction> constructDirectionForCCD(DirectionConfiguration direction, LocalDateTime completeBy) {
-        return element(Direction.builder()
-            .directionType(direction.getTitle())
-            .directionText(direction.getText())
-            .assignee(direction.getAssignee())
-            .directionNeeded(YES.getValue())
-            .directionRemovable(booleanToYesOrNo(direction.getDisplay().isDirectionRemovable()))
-            .readOnly(booleanToYesOrNo(direction.getDisplay().isShowDateOnly()))
-            .dateToBeCompletedBy(completeBy)
-            .build());
-    }
-
-    /**
      * Returns a list of directions to comply with.
      *
      * @param caseData case data with standard directions and case management order directions.

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/JsonOrdersLookupService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/JsonOrdersLookupService.java
@@ -1,26 +1,86 @@
 package uk.gov.hmcts.reform.fpl.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.fpl.model.Direction;
+import uk.gov.hmcts.reform.fpl.model.HearingBooking;
+import uk.gov.hmcts.reform.fpl.model.common.Element;
+import uk.gov.hmcts.reform.fpl.model.configuration.DirectionConfiguration;
+import uk.gov.hmcts.reform.fpl.model.configuration.Display;
 import uk.gov.hmcts.reform.fpl.model.configuration.OrderDefinition;
+import uk.gov.hmcts.reform.fpl.service.calendar.CalendarService;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
 
+import static java.lang.Integer.parseInt;
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.toList;
+import static uk.gov.hmcts.reform.fpl.enums.YesNo.YES;
+import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.element;
 import static uk.gov.hmcts.reform.fpl.utils.ResourceReader.readString;
 
 @Service
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class JsonOrdersLookupService implements OrdersLookupService {
     private final ObjectMapper objectMapper;
-
-    @Autowired
-    public JsonOrdersLookupService(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
+    private final CalendarService calendarService;
 
     public OrderDefinition getStandardDirectionOrder() throws IOException {
         String content = readString("ordersConfig.json");
 
         return this.objectMapper.readValue(content, OrderDefinition.class);
+    }
+
+    public List<Element<Direction>> getStandardDirections(HearingBooking hearingBooking) throws IOException {
+        LocalDateTime hearingStartDate = ofNullable(hearingBooking).map(HearingBooking::getStartDate).orElse(null);
+
+        return getStandardDirectionOrder().getDirections()
+            .stream()
+            .map(configuration -> constructDirectionForCCD(hearingStartDate, configuration))
+            .collect(toList());
+    }
+
+    private Element<Direction> constructDirectionForCCD(LocalDateTime hearingDate, DirectionConfiguration direction) {
+        LocalDateTime dateToBeCompletedBy = ofNullable(hearingDate)
+            .map(x -> getCompleteByDate(x, direction.getDisplay()))
+            .orElse(null);
+
+        return element(Direction.builder()
+            .directionType(direction.getTitle())
+            .directionText(direction.getText())
+            .assignee(direction.getAssignee())
+            .directionNeeded(YES.getValue())
+            .directionRemovable(booleanToYesOrNo(direction.getDisplay().isDirectionRemovable()))
+            .readOnly(booleanToYesOrNo(direction.getDisplay().isShowDateOnly()))
+            .dateToBeCompletedBy(dateToBeCompletedBy)
+            .build());
+    }
+
+    private LocalDateTime getCompleteByDate(LocalDateTime startDate, Display display) {
+        return ofNullable(display.getDelta())
+            .map(delta -> addDelta(startDate, parseInt(delta)))
+            .map(date -> getLocalDateTime(display.getTime(), date))
+            .orElse(null);
+    }
+
+    private LocalDateTime getLocalDateTime(String time, LocalDate date) {
+        return ofNullable(time).map(item -> LocalDateTime.of(date, LocalTime.parse(item))).orElse(date.atStartOfDay());
+    }
+
+    private LocalDate addDelta(LocalDateTime date, int delta) {
+        if (delta == 0) {
+            return date.toLocalDate();
+        }
+        return calendarService.getWorkingDayFrom(date.toLocalDate(), delta);
+    }
+
+    private String booleanToYesOrNo(boolean value) {
+        return value ? "Yes" : "No";
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/OrdersLookupService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/OrdersLookupService.java
@@ -1,9 +1,15 @@
 package uk.gov.hmcts.reform.fpl.service;
 
+import uk.gov.hmcts.reform.fpl.model.Direction;
+import uk.gov.hmcts.reform.fpl.model.HearingBooking;
+import uk.gov.hmcts.reform.fpl.model.common.Element;
 import uk.gov.hmcts.reform.fpl.model.configuration.OrderDefinition;
 
 import java.io.IOException;
+import java.util.List;
 
 public interface OrdersLookupService {
     OrderDefinition getStandardDirectionOrder() throws IOException;
+
+    List<Element<Direction>> getStandardDirections(HearingBooking hearingBooking) throws IOException;
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/PrepareDirectionsForDataStoreService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/PrepareDirectionsForDataStoreService.java
@@ -13,6 +13,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang.StringUtils.isEmpty;
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
@@ -51,13 +54,16 @@ public class PrepareDirectionsForDataStoreService {
                 .filter(element -> hasSameDirectionType(elementToAddValue, element))
                 .forEach(element -> {
                     Direction direction = elementToAddValue.getValue();
+                    Direction value = element.getValue();
 
-                    direction.setReadOnly(element.getValue().getReadOnly());
-                    direction.setDirectionRemovable(element.getValue().getDirectionRemovable());
-                    direction.setAssignee(defaultIfNull(direction.getAssignee(), element.getValue().getAssignee()));
+                    direction.setReadOnly(value.getReadOnly());
+                    direction.setDirectionRemovable(value.getDirectionRemovable());
+                    direction.setAssignee(defaultIfNull(direction.getAssignee(), value.getAssignee()));
+                    direction.setDateToBeCompletedBy(
+                        defaultIfNull(direction.getDateToBeCompletedBy(), value.getDateToBeCompletedBy()));
 
-                    if (!element.getValue().getReadOnly().equals("No")) {
-                        direction.setDirectionText(element.getValue().getDirectionText());
+                    if (!value.getReadOnly().equals("No")) {
+                        direction.setDirectionText(value.getDirectionText());
                     }
                 }));
     }


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FPLA-1790

### Change description ###

Moved date population logic to JsonLookUpService. Dates no populated on about to submit callback of draft sdo event. This refactor should make it fairly straight forward to populate standard directions with dates on other events.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
