### PR TITLE
feat: Grant case access failure alert (FPLA-1758)

### DIFF
--- a/infrastructure/alerts.tf
+++ b/infrastructure/alerts.tf
@@ -1,0 +1,50 @@
+locals {
+  alert_resource_group_name = "${var.product}-${var.component}-${var.env}"
+}
+
+module "fpl-action-group" {
+  source                 = "git@github.com:hmcts/cnp-module-action-group"
+  location               = "global"
+  env                    = "${var.env}"
+  resourcegroup_name     = "${local.alert_resource_group_name}"
+  action_group_name      = "${var.product}-support"
+  short_name             = "${var.product}-support"
+  email_receiver_name    = "FPL Support Mailing List"
+  email_receiver_address = "${data.azurerm_key_vault_secret.fpl_support_email_secret.value}"
+}
+
+module "fpl-performance-alert" {
+  source                     = "git@github.com:hmcts/cnp-module-metric-alert"
+  location                   = "${var.appinsights_location}"
+  app_insights_name          = "${var.product}-${var.component}-appinsights-${var.env}"
+  alert_name                 = "${var.product}-performance-alert"
+  alert_desc                 = "Requests that took longer than 1 seconds to complete"
+  app_insights_query         = "requests | where url !contains '/health' and success == 'True' and duration > 1000 | project timestamp, name, operation_Id, duration | sort by duration nulls last"
+  custom_email_subject       = "Alert: performance errors"
+  frequency_in_minutes       = 5
+  time_window_in_minutes     = 5
+  severity_level             = "2"
+  action_group_name          = "${var.product}-support"
+  trigger_threshold_operator = "GreaterThan"
+  trigger_threshold          = 2
+  resourcegroup_name         = "${local.alert_resource_group_name}"
+  enabled                    = "${var.enable_alerts}"
+}
+
+module "fpl-grant-case-access-failure-alert" {
+  source                     = "git@github.com:hmcts/cnp-module-metric-alert"
+  location                   = "${var.appinsights_location}"
+  app_insights_name          = "${var.product}-${var.component}-appinsights-${var.env}"
+  alert_name                 = "${var.product}-grant-case-access-failure"
+  alert_desc                 = "Grant case access failure"
+  app_insights_query         = "exceptions | where type contains 'GrantCaseAccessException' | project timestamp , outerMessage"
+  custom_email_subject       = "Alert: Grant case access failed"
+  frequency_in_minutes       = 5
+  time_window_in_minutes     = 5
+  severity_level             = "1"
+  action_group_name          = "${var.product}-support"
+  trigger_threshold_operator = "GreaterThan"
+  trigger_threshold          = 0
+  resourcegroup_name         = "${local.alert_resource_group_name}"
+  enabled                    = "${var.env == "aat"}"
+}

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -2,10 +2,6 @@ provider "azurerm" {
   version = "=1.44.0"
 }
 
-locals {
-  alert_resource_group_name = "${var.product}-${var.component}-${var.env}"
-}
-
 resource "azurerm_resource_group" "rg" {
   name     = "${var.product}-${var.component}-${var.env}"
   location = "${var.location}"
@@ -61,37 +57,6 @@ module "fpl-scheduler-db" {
 data "azurerm_key_vault_secret" "fpl_support_email_secret" {
   name      = "${var.product}-support-email"
   vault_uri = "${module.key-vault.key_vault_uri}"
-}
-
-module "fpl-action-group" {
-  source                 = "git@github.com:hmcts/cnp-module-action-group"
-  location               = "global"
-  env                    = "${var.env}"
-  resourcegroup_name     = "${local.alert_resource_group_name}"
-  action_group_name      = "${var.product}-support"
-  short_name             = "${var.product}-support"
-  email_receiver_name    = "FPL Support Mailing List"
-  email_receiver_address = "${data.azurerm_key_vault_secret.fpl_support_email_secret.value}"
-}
-
-module "fpl-performance-alert" {
-  source                     = "git@github.com:hmcts/cnp-module-metric-alert"
-  location                   = "${var.appinsights_location}"
-
-  app_insights_name          = "${var.product}-${var.component}-appinsights-${var.env}"
-
-  alert_name                 = "${var.product}-performance-alert"
-  alert_desc                 = "Requests that took longer than 1 seconds to complete"
-  app_insights_query         = "requests | where url !contains '/health' and success == 'True' and duration > 1000 | project timestamp, name, operation_Id, duration | sort by duration nulls last"
-  custom_email_subject       = "Alert: performance errors"
-  frequency_in_minutes       = 5
-  time_window_in_minutes     = 5
-  severity_level             = "2"
-  action_group_name          = "${var.product}-support"
-  trigger_threshold_operator = "GreaterThan"
-  trigger_threshold          = 2
-  resourcegroup_name         = "${local.alert_resource_group_name}"
-  enabled                    = "${var.enable_alerts}"
 }
 
 resource "azurerm_key_vault_secret" "scheduler-db-password" {


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/FPLA-1758

Infrastructure delivered before actual code due to testing approach. 
Story will be tested on preview with mocked ccd calls that simulates grant access failures. The fpl-case-service on preview will be connected to aat app insight, thus need to have alerts configured in aat. Alert is configured to be created only on aat, will be changed to prod  after successful story test  

Related to https://github.com/hmcts/fpl-ccd-configuration/pull/1240