### PR TITLE
impr: update deprecated assertions

### DIFF
--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/CommonDirectionServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/CommonDirectionServiceTest.java
@@ -235,8 +235,10 @@ class CommonDirectionServiceTest {
             service.addEmptyDirectionsForAssigneeNotInMap(map);
 
             assertThat(map).containsOnlyKeys(DirectionAssignee.values());
-            assertThat(map).extracting(ALL_PARTIES, PARENTS_AND_RESPONDENTS, COURT, OTHERS).containsOnly(emptyList());
-            assertThat(map).extracting(LOCAL_AUTHORITY, CAFCASS).containsOnly(emptyListOfElement());
+            assertThat(map).extractingByKeys(ALL_PARTIES, PARENTS_AND_RESPONDENTS, COURT, OTHERS)
+                .allMatch(List::isEmpty);
+            assertThat(map).extractingByKeys(LOCAL_AUTHORITY, CAFCASS)
+                .allMatch(list -> list.equals(emptyListOfElement()));
         }
 
         private List<Element<Direction>> emptyListOfElement() {


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

As of [AssertJ core 3.14.0](https://assertj.github.io/doc/#assertj-core-3-14-0-release-notes) the `extracting()` method has been deprecated.
Replaced `extracting` with `extractingByKeys`. With a simple switch to this the compiler would then generate the following warning for the `containsOnly()` method
```
Unchecked generics array creation for varargs parameter
```
so to remove this warning the assertions were updated as well. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
