### PR TITLE
fix: configure custom thread pool task executor so that async executi…

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -238,6 +238,7 @@ dependencies {
 
   testCompile group: 'org.mockito', name :'mockito-core', version: '3.0.0'
   testCompile group: 'org.apache.pdfbox', name: 'pdfbox', version: '2.0.19'
+  testCompile group: 'org.apache.commons', name: 'commons-text', version: '1.8'
 
   testCompile group: 'org.springframework.security', name: 'spring-security-test'
 

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/CaseInitiationControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/CaseInitiationControllerTest.java
@@ -11,18 +11,26 @@ import uk.gov.hmcts.reform.authorisation.ServiceAuthorisationApi;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.ccd.client.CaseUserApi;
 import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse;
+import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.CaseUser;
+import uk.gov.hmcts.reform.fpl.config.LocalAuthorityUserLookupConfiguration;
 import uk.gov.hmcts.reform.fpl.config.SystemUpdateUserConfiguration;
 import uk.gov.hmcts.reform.fpl.exceptions.GrantCaseAccessException;
+import uk.gov.hmcts.reform.fpl.exceptions.UnknownLocalAuthorityCodeException;
 import uk.gov.hmcts.reform.idam.client.IdamApi;
 import uk.gov.hmcts.reform.idam.client.IdamClient;
 import uk.gov.hmcts.reform.idam.client.models.UserInfo;
+import uk.gov.hmcts.reform.rd.client.OrganisationApi;
+import uk.gov.hmcts.reform.rd.model.OrganisationUser;
+import uk.gov.hmcts.reform.rd.model.OrganisationUsers;
+import uk.gov.hmcts.reform.rd.model.Status;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -42,12 +50,26 @@ import static uk.gov.hmcts.reform.fpl.utils.assertions.ExceptionAssertion.assert
 @OverrideAutoConfiguration(enabled = true)
 class CaseInitiationControllerTest extends AbstractControllerTest {
 
-    private static final String LA_CALLER_ID = USER_ID;
-    private static final String LA_USER_2_ID = "2";
-    private static final String LA_USER_3_ID = "3";
-    private static final String[] LA_USER_IDS = {LA_CALLER_ID, LA_USER_2_ID, LA_USER_3_ID};
+    private static final String CALLER_ID = USER_ID;
+
+    private static final String LA_1_CODE = "LA_1";
+    private static final String LA_1_USER_1_ID = "LA_1-1";
+    private static final String LA_1_USER_2_ID = "LA_1-2";
+    private static final List<String> LA_1_USER_IDS = List.of(CALLER_ID, LA_1_USER_1_ID, LA_1_USER_2_ID);
+
+    private static final String LA_2_CODE = "LA_2";
+    private static final String LA_2_USER_1_ID = "LA_2-1";
+    private static final String LA_2_USER_2_ID = "LA_2-2";
+    private static final List<String> LA_2_USER_IDS = List.of(CALLER_ID, LA_2_USER_1_ID, LA_2_USER_2_ID);
+
     private static final String CASE_ID = "12345";
     private static final Set<String> CASE_ROLES = Set.of("[LASOLICITOR]", "[CREATOR]");
+
+    @MockBean
+    private LocalAuthorityUserLookupConfiguration localAuthorityUserLookupConfiguration;
+
+    @MockBean(name = "uk.gov.hmcts.reform.rd.client.OrganisationApi")
+    private OrganisationApi organisationApi;
 
     @MockBean(name = "uk.gov.hmcts.reform.authorisation.ServiceAuthorisationApi")
     private ServiceAuthorisationApi serviceAuthorisationApi;
@@ -82,6 +104,15 @@ class CaseInitiationControllerTest extends AbstractControllerTest {
 
         given(idamApi.retrieveUserInfo(USER_AUTH_TOKEN)).willReturn(
             UserInfo.builder().sub("user@example.gov.uk").build());
+
+        given(localAuthorityUserLookupConfiguration.getUserIds(LA_1_CODE))
+            .willReturn(LA_1_USER_IDS);
+
+        given(localAuthorityUserLookupConfiguration.getUserIds(LA_2_CODE))
+            .willThrow(new UnknownLocalAuthorityCodeException(LA_2_CODE));
+
+        given(organisationApi.findUsersByOrganisation(USER_AUTH_TOKEN, SERVICE_AUTH_TOKEN, Status.ACTIVE))
+            .willReturn(organisation(LA_2_USER_IDS));
     }
 
     @Test
@@ -113,46 +144,66 @@ class CaseInitiationControllerTest extends AbstractControllerTest {
     }
 
     @Test
-    void updateCaseRolesShouldBeCalledOnceForEachUser() {
-        postSubmittedEvent(callbackRequest());
+    void updateCaseRolesShouldBeCalledOnceForEachUserFetchedFromPRD() {
+        postSubmittedEvent(getCase(LA_2_CODE));
 
-        verifyUpdateCaseRolesWasCalledOnceForEachUser();
+        verifyCaseRoleGrantedToEachUser(LA_2_USER_IDS);
+    }
+
+    @Test
+    void updateCaseRolesShouldBeCalledOnceForEachUser() {
+        postSubmittedEvent(getCase(LA_1_CODE));
+
+        verifyCaseRoleGrantedToEachUser(LA_1_USER_IDS);
     }
 
     @Test
     void shouldGrantCaseAccessToOtherUsersAndThrowExceptionWhenCallerAccessNotGranted() {
         doThrow(RuntimeException.class)
-            .when(caseUserApi).updateCaseRolesForUser(any(), any(), any(), eq(LA_CALLER_ID), any());
+            .when(caseUserApi).updateCaseRolesForUser(any(), any(), any(), eq(CALLER_ID), any());
 
-        final Exception exception = assertThrows(Exception.class, () -> postSubmittedEvent(callbackRequest()));
+        final Exception exception = assertThrows(Exception.class, () -> postSubmittedEvent(getCase(LA_1_CODE)));
 
         assertException(exception)
             .isCausedBy(new GrantCaseAccessException(CASE_ID, Set.of(USER_ID), Set.of(CREATOR, LASOLICITOR)));
 
-        verifyUpdateCaseRolesWasCalledOnceForEachUser();
+        verifyCaseRoleGrantedToEachUser(LA_1_USER_IDS);
     }
 
     @Test
     void shouldAttemptGrantAccessToAllLocalAuthorityUsersWhenGrantAccessFailsForSomeOfThem() {
         doThrow(RuntimeException.class)
-            .when(caseUserApi).updateCaseRolesForUser(any(), any(), any(), eq(LA_USER_2_ID), any());
+            .when(caseUserApi).updateCaseRolesForUser(any(), any(), any(), eq(LA_1_USER_1_ID), any());
 
-        postSubmittedEvent(callbackRequest());
+        postSubmittedEvent(getCase(LA_1_CODE));
 
-        verifyUpdateCaseRolesWasCalledOnceForEachUser();
+        verifyCaseRoleGrantedToEachUser(LA_1_USER_IDS);
     }
 
-    private void verifyUpdateCaseRolesWasCalledOnceForEachUser() {
+
+    private void verifyCaseRoleGrantedToEachUser(List<String> users) {
         verify(caseUserApi).updateCaseRolesForUser(
-            USER_AUTH_TOKEN, SERVICE_AUTH_TOKEN, CASE_ID, LA_USER_IDS[0],
-            new CaseUser(LA_USER_IDS[0], CASE_ROLES));
+            USER_AUTH_TOKEN, SERVICE_AUTH_TOKEN, CASE_ID, CALLER_ID,
+            new CaseUser(CALLER_ID, CASE_ROLES));
 
-        verify(caseUserApi, timeout(1000)).updateCaseRolesForUser(
-            USER_AUTH_TOKEN, SERVICE_AUTH_TOKEN, CASE_ID, LA_USER_IDS[1],
-            new CaseUser(LA_USER_IDS[1], CASE_ROLES));
-
-        verify(caseUserApi, timeout(1000)).updateCaseRolesForUser(
-            USER_AUTH_TOKEN, SERVICE_AUTH_TOKEN, CASE_ID, LA_USER_IDS[2],
-            new CaseUser(LA_USER_IDS[2], CASE_ROLES));
+        users.stream()
+            .filter(userId -> !CALLER_ID.equals(userId))
+            .forEach(userId ->
+                verify(caseUserApi, timeout(1000)).updateCaseRolesForUser(
+                    USER_AUTH_TOKEN, SERVICE_AUTH_TOKEN, CASE_ID, userId,
+                    new CaseUser(userId, CASE_ROLES)));
     }
+
+    private static OrganisationUsers organisation(List<String> userIds) {
+        List<OrganisationUser> users = userIds.stream()
+            .map(id -> OrganisationUser.builder().userIdentifier(id).build())
+            .collect(toList());
+
+        return OrganisationUsers.builder().users(users).build();
+    }
+
+    private static CallbackRequest getCase(String localAuthority) {
+        return callbackRequest(Map.of("localAuthority", localAuthority));
+    }
+
 }

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/CaseSubmissionControllerMidEventTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/CaseSubmissionControllerMidEventTest.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.reform.fpl.utils.CoreCaseDataStoreLoader.callbackRequest;
 
 @ActiveProfiles("integration-test")
 @WebMvcTest(CaseSubmissionController.class)
@@ -51,8 +52,7 @@ class CaseSubmissionControllerMidEventTest extends AbstractControllerTest {
 
     @Test
     void shouldReturnNoErrorsWhenMandatoryFieldsAreProvidedInCaseData() {
-        AboutToStartOrSubmitCallbackResponse callbackResponse = postMidEvent(
-            "core-case-data-store-api/callback-request.json");
+        AboutToStartOrSubmitCallbackResponse callbackResponse = postMidEvent(callbackRequest());
 
         assertThat(callbackResponse.getErrors()).isEmpty();
     }

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/CaseSubmissionControllerSubmittedTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/CaseSubmissionControllerSubmittedTest.java
@@ -50,6 +50,7 @@ import static uk.gov.hmcts.reform.fpl.enums.State.OPEN;
 import static uk.gov.hmcts.reform.fpl.enums.State.RETURNED;
 import static uk.gov.hmcts.reform.fpl.enums.YesNo.NO;
 import static uk.gov.hmcts.reform.fpl.enums.YesNo.YES;
+import static uk.gov.hmcts.reform.fpl.utils.CoreCaseDataStoreLoader.callbackRequest;
 
 @ActiveProfiles("integration-test")
 @WebMvcTest(CaseSubmissionController.class)
@@ -90,7 +91,7 @@ class CaseSubmissionControllerSubmittedTest extends AbstractControllerTest {
         Map<String, Object> expectedHmctsParameters = getExpectedHmctsParameters(true);
         Map<String, Object> completeCafcassParameters = getExpectedCafcassParameters(true);
 
-        postSubmittedEvent("core-case-data-store-api/callback-request.json");
+        postSubmittedEvent(callbackRequest());
 
         verify(notificationClient).sendEmail(
             HMCTS_COURT_SUBMISSION_TEMPLATE,

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/config/AsyncConfiguration.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/config/AsyncConfiguration.java
@@ -2,10 +2,17 @@ package uk.gov.hmcts.reform.fpl.config;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskDecorator;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
 
 import java.lang.reflect.Method;
+import java.util.concurrent.Executor;
+import javax.annotation.Nonnull;
 
 @Slf4j
 @Configuration
@@ -24,4 +31,26 @@ public class AsyncConfiguration implements AsyncConfigurer {
         }
     }
 
+    @Override
+    @Bean
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
+        taskExecutor.setTaskDecorator(new AsyncTaskDecorator());
+        return taskExecutor;
+    }
+
+    static class AsyncTaskDecorator implements TaskDecorator {
+        @Override
+        public Runnable decorate(@Nonnull Runnable task) {
+            RequestAttributes context = RequestContextHolder.currentRequestAttributes();
+            return () -> {
+                try {
+                    RequestContextHolder.setRequestAttributes(context);
+                    task.run();
+                } finally {
+                    RequestContextHolder.resetRequestAttributes();
+                }
+            };
+        }
+    }
 }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/utils/CoreCaseDataStoreLoader.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/utils/CoreCaseDataStoreLoader.java
@@ -1,11 +1,15 @@
 package uk.gov.hmcts.reform.fpl.utils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.text.StringSubstitutor;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
 
 public class CoreCaseDataStoreLoader {
 
@@ -16,21 +20,37 @@ public class CoreCaseDataStoreLoader {
     }
 
     public static CaseDetails emptyCaseDetails() {
-        String response = ResourceReader.readString("core-case-data-store-api/empty-case-details.json");
-        return read(response, CaseDetails.class);
+        return emptyCaseDetails(emptyMap());
+    }
+
+    public static CaseDetails emptyCaseDetails(Map<String, Object> placeholders) {
+        String file = readFile("core-case-data-store-api/empty-case-details.json", placeholders);
+        return convert(file, CaseDetails.class);
     }
 
     public static CaseDetails populatedCaseDetails() {
-        String response = ResourceReader.readString("core-case-data-store-api/populated-case-details.json");
-        return read(response, CaseDetails.class);
+        return populatedCaseDetails(emptyMap());
+    }
+
+    public static CaseDetails populatedCaseDetails(Map<String, Object> placeholders) {
+        String file = readFile("core-case-data-store-api/populated-case-details.json", placeholders);
+        return convert(file, CaseDetails.class);
     }
 
     public static CallbackRequest callbackRequest() {
-        String response = ResourceReader.readString("core-case-data-store-api/callback-request.json");
-        return read(response, CallbackRequest.class);
+        return callbackRequest(emptyMap());
     }
 
-    private static <T> T read(String json, Class<T> clazz) {
+    public static CallbackRequest callbackRequest(Map<String, Object> placeholders) {
+        String file = readFile("core-case-data-store-api/callback-request.json", placeholders);
+        return convert(file, CallbackRequest.class);
+    }
+
+    private static String readFile(String file, Map<String, Object> placeholders) {
+        return StringSubstitutor.replace(ResourceReader.readString(file), placeholders);
+    }
+
+    private static <T> T convert(String json, Class<T> clazz) {
         try {
             return mapper.readValue(json, clazz);
         } catch (IOException e) {

--- a/service/src/test/resources/core-case-data-store-api/callback-request.json
+++ b/service/src/test/resources/core-case-data-store-api/callback-request.json
@@ -1,6 +1,6 @@
 {
   "case_details": {
-    "id": 12345,
+    "id": "${id:-12345}",
     "jurisdiction": "PUBLICLAW",
     "state": "Open",
     "case_type_id": "CARE_SUPERVISION_EPO",
@@ -26,7 +26,7 @@
           }
         }
       ],
-      "caseLocalAuthority": "example",
+      "caseLocalAuthority": "${localAuthority:-example}",
       "risks": {
         "neglect": "Yes",
         "sexualAbuse": "Yes",


### PR DESCRIPTION
fix for issue introduced in 
https://tools.hmcts.net/jira/browse/FPLA-1758
services invoked from new threads dont have access to request scoped components (RequestData)

based on:
https://stackoverflow.com/questions/23732089/how-to-enable-request-scope-in-async-task-executor