### PR TITLE
impr: cleanup events - remove RequestData as it is not used and  pass…

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/ActionCaseManagementOrderController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/ActionCaseManagementOrderController.java
@@ -19,7 +19,6 @@ import uk.gov.hmcts.reform.fpl.model.CaseManagementOrder;
 import uk.gov.hmcts.reform.fpl.model.HearingBooking;
 import uk.gov.hmcts.reform.fpl.model.OrderAction;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 import uk.gov.hmcts.reform.fpl.service.CaseManagementOrderService;
 import uk.gov.hmcts.reform.fpl.service.DocumentDownloadService;
 import uk.gov.hmcts.reform.fpl.service.HearingBookingService;
@@ -48,7 +47,6 @@ public class ActionCaseManagementOrderController {
     private final ApplicationEventPublisher applicationEventPublisher;
     private final CoreCaseDataService coreCaseDataService;
     private final DocumentDownloadService documentDownloadService;
-    private final RequestData requestData;
     private final HearingBookingService hearingBookingService;
 
     @PostMapping("/about-to-start")
@@ -164,8 +162,8 @@ public class ActionCaseManagementOrderController {
             final String actionCmoDocumentUrl = actionedCmo.getOrderDoc().getBinaryUrl();
             byte[] documentContents = documentDownloadService.downloadDocument(actionCmoDocumentUrl);
 
-            applicationEventPublisher.publishEvent(new CaseManagementOrderIssuedEvent(callbackRequest, requestData,
-                documentContents));
+            applicationEventPublisher.publishEvent(
+                new CaseManagementOrderIssuedEvent(callbackRequest, documentContents));
         }
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/AllocatedJudgeController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/AllocatedJudgeController.java
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.fpl.events.NotifyAllocatedJudgeEvent;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 
 @Api
 @RestController
@@ -18,10 +17,9 @@ import uk.gov.hmcts.reform.fpl.request.RequestData;
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class AllocatedJudgeController {
     private final ApplicationEventPublisher applicationEventPublisher;
-    private final RequestData requestData;
 
     @PostMapping("/submitted")
     public void handleSubmittedEvent(@RequestBody CallbackRequest callbackRequest) {
-        applicationEventPublisher.publishEvent(new NotifyAllocatedJudgeEvent(callbackRequest, requestData));
+        applicationEventPublisher.publishEvent(new NotifyAllocatedJudgeEvent(callbackRequest));
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/CaseSubmissionController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/CaseSubmissionController.java
@@ -23,7 +23,6 @@ import uk.gov.hmcts.reform.fpl.events.AmendedReturnedCaseEvent;
 import uk.gov.hmcts.reform.fpl.events.SubmittedCaseEvent;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.FeesData;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 import uk.gov.hmcts.reform.fpl.service.CaseValidatorService;
 import uk.gov.hmcts.reform.fpl.service.FeatureToggleService;
 import uk.gov.hmcts.reform.fpl.service.UserDetailsService;
@@ -63,7 +62,6 @@ public class CaseSubmissionController {
     private final FeeService feeService;
     private final FeatureToggleService featureToggleService;
     private final LocalAuthorityNameLookupConfiguration localAuthorityNameLookupConfiguration;
-    private final RequestData requestData;
 
     @PostMapping("/about-to-start")
     public AboutToStartOrSubmitCallbackResponse handleAboutToStartEvent(
@@ -156,10 +154,10 @@ public class CaseSubmissionController {
 
     @PostMapping("/submitted")
     public void handleSubmittedEvent(@RequestBody @NotNull CallbackRequest callbackRequest) {
-        applicationEventPublisher.publishEvent(new SubmittedCaseEvent(callbackRequest, requestData));
+        applicationEventPublisher.publishEvent(new SubmittedCaseEvent(callbackRequest));
 
         if (isInReturnedState(callbackRequest.getCaseDetailsBefore())) {
-            applicationEventPublisher.publishEvent(new AmendedReturnedCaseEvent(callbackRequest, requestData));
+            applicationEventPublisher.publishEvent(new AmendedReturnedCaseEvent(callbackRequest));
         }
     }
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/DraftOrdersController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/DraftOrdersController.java
@@ -24,7 +24,6 @@ import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
 import uk.gov.hmcts.reform.fpl.model.common.JudgeAndLegalAdvisor;
 import uk.gov.hmcts.reform.fpl.model.docmosis.DocmosisStandardDirectionOrder;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 import uk.gov.hmcts.reform.fpl.service.CommonDirectionService;
 import uk.gov.hmcts.reform.fpl.service.DocumentService;
 import uk.gov.hmcts.reform.fpl.service.HearingBookingService;
@@ -71,7 +70,6 @@ public class DraftOrdersController {
     private final OrderValidationService orderValidationService;
     private final HearingBookingService hearingBookingService;
     private final Time time;
-    private final RequestData requestData;
     private final ValidateGroupService validateGroupService;
     private final StandardDirectionsService standardDirectionsService;
 
@@ -253,8 +251,7 @@ public class DraftOrdersController {
                 "internal-change:SEND_DOCUMENT",
                 Map.of("documentToBeSent", standardDirectionOrder.getOrderDoc())
             );
-            applicationEventPublisher.publishEvent(new StandardDirectionsOrderIssuedEvent(callbackRequest,
-                requestData));
+            applicationEventPublisher.publishEvent(new StandardDirectionsOrderIssuedEvent(callbackRequest));
         }
     }
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/GeneratedOrderController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/GeneratedOrderController.java
@@ -31,7 +31,6 @@ import uk.gov.hmcts.reform.fpl.model.common.JudgeAndLegalAdvisor;
 import uk.gov.hmcts.reform.fpl.model.order.generated.FurtherDirections;
 import uk.gov.hmcts.reform.fpl.model.order.generated.GeneratedOrder;
 import uk.gov.hmcts.reform.fpl.model.order.selector.ChildSelector;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 import uk.gov.hmcts.reform.fpl.service.ChildrenService;
 import uk.gov.hmcts.reform.fpl.service.DocmosisDocumentGeneratorService;
 import uk.gov.hmcts.reform.fpl.service.DocumentDownloadService;
@@ -81,7 +80,6 @@ public class GeneratedOrderController {
     private final ChildrenService childrenService;
     private final DocumentDownloadService documentDownloadService;
     private final FeatureToggleService featureToggleService;
-    private final RequestData requestData;
     private final Time time;
 
     @PostMapping("/about-to-start")
@@ -243,7 +241,6 @@ public class GeneratedOrderController {
             Map.of("documentToBeSent", mostRecentUploadedDocument)
         );
         applicationEventPublisher.publishEvent(new GeneratedOrderEvent(callbackRequest,
-            requestData,
             concatGatewayConfigurationUrlAndMostRecentUploadedOrderDocumentPath(
                 mostRecentUploadedDocument.getBinaryUrl()),
             documentDownloadService.downloadDocument(mostRecentUploadedDocument.getBinaryUrl())));

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/HearingBookingDetailsController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/HearingBookingDetailsController.java
@@ -17,7 +17,6 @@ import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.HearingBooking;
 import uk.gov.hmcts.reform.fpl.model.Judge;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 import uk.gov.hmcts.reform.fpl.service.HearingBookingService;
 import uk.gov.hmcts.reform.fpl.service.HearingBookingValidatorService;
 import uk.gov.hmcts.reform.fpl.service.StandardDirectionsService;
@@ -37,7 +36,6 @@ public class HearingBookingDetailsController {
     private final HearingBookingValidatorService validationService;
     private final ObjectMapper mapper;
     private final ApplicationEventPublisher applicationEventPublisher;
-    private final RequestData requestData;
     private final StandardDirectionsService standardDirectionsService;
 
     @PostMapping("/about-to-start")
@@ -106,8 +104,7 @@ public class HearingBookingDetailsController {
     public void handleSubmittedEvent(@RequestBody CallbackRequest callbackRequest) {
         CaseData caseData = mapper.convertValue(callbackRequest.getCaseDetails().getData(), CaseData.class);
         if (standardDirectionsService.hasEmptyDates(caseData)) {
-            applicationEventPublisher.publishEvent(new PopulateStandardDirectionsOrderDatesEvent(callbackRequest,
-                requestData));
+            applicationEventPublisher.publishEvent(new PopulateStandardDirectionsOrderDatesEvent(callbackRequest));
         }
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/NotifyGatekeeperController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/NotifyGatekeeperController.java
@@ -17,7 +17,6 @@ import uk.gov.hmcts.reform.fpl.events.PopulateStandardDirectionsEvent;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
 import uk.gov.hmcts.reform.fpl.model.common.EmailAddress;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 import uk.gov.hmcts.reform.fpl.service.ValidateGroupService;
 import uk.gov.hmcts.reform.fpl.validation.groups.ValidateFamilyManCaseNumberGroup;
 
@@ -37,7 +36,6 @@ public class NotifyGatekeeperController {
     private final ObjectMapper mapper;
     private final ValidateGroupService validateGroupService;
     private final ApplicationEventPublisher applicationEventPublisher;
-    private final RequestData requestData;
 
     //TODO: can we validate a hearing has been added at this point? Saves some nasty exceptions in the case of
     // no hearing being present when populating standard directions FPLA-1516
@@ -63,9 +61,9 @@ public class NotifyGatekeeperController {
     @PostMapping("/submitted")
     public void handleSubmittedEvent(@RequestBody CallbackRequest callbackRequest) {
         if (SUBMITTED.getValue().equals(callbackRequest.getCaseDetails().getState())) {
-            applicationEventPublisher.publishEvent(new PopulateStandardDirectionsEvent(callbackRequest, requestData));
+            applicationEventPublisher.publishEvent(new PopulateStandardDirectionsEvent(callbackRequest));
         }
-        applicationEventPublisher.publishEvent(new NotifyGatekeepersEvent(callbackRequest, requestData));
+        applicationEventPublisher.publishEvent(new NotifyGatekeepersEvent(callbackRequest));
     }
 
     private List<Element<EmailAddress>> resetGateKeeperEmailCollection() {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/PlacementController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/PlacementController.java
@@ -21,7 +21,6 @@ import uk.gov.hmcts.reform.fpl.model.Placement;
 import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
 import uk.gov.hmcts.reform.fpl.model.common.dynamic.DynamicList;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 import uk.gov.hmcts.reform.fpl.service.DocumentDownloadService;
 import uk.gov.hmcts.reform.fpl.service.PlacementService;
 import uk.gov.hmcts.reform.fpl.service.ccd.CoreCaseDataService;
@@ -47,7 +46,6 @@ public class PlacementController {
     private final ApplicationEventPublisher applicationEventPublisher;
     private final ObjectMapper mapper;
     private final PlacementService placementService;
-    private final RequestData requestData;
     private final CoreCaseDataService coreCaseDataService;
     private final DocumentDownloadService documentDownloadService;
 
@@ -153,8 +151,7 @@ public class PlacementController {
             .stream()
             .map(DocumentReference::getBinaryUrl)
             .map(documentDownloadService::downloadDocument)
-            .map(documentContents -> new NoticeOfPlacementOrderUploadedEvent(
-            callbackRequest, requestData, documentContents))
+            .map(documentContents -> new NoticeOfPlacementOrderUploadedEvent(callbackRequest, documentContents))
             .forEach(applicationEventPublisher::publishEvent);
     }
 
@@ -185,7 +182,7 @@ public class PlacementController {
 
     private void publishPlacementApplicationUploadEvent(CallbackRequest callbackRequest) {
         applicationEventPublisher.publishEvent(
-            new PlacementApplicationEvent(callbackRequest, requestData));
+            new PlacementApplicationEvent(callbackRequest));
     }
 
     private boolean isUpdatedPlacement(Placement previousPlacement, Placement newPlacement) {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/RepresentativesController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/RepresentativesController.java
@@ -15,7 +15,6 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.events.PartyAddedToCaseEvent;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.Others;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 import uk.gov.hmcts.reform.fpl.service.OthersService;
 import uk.gov.hmcts.reform.fpl.service.RepresentativeService;
 import uk.gov.hmcts.reform.fpl.service.RespondentService;
@@ -35,7 +34,6 @@ public class RepresentativesController {
     private final RespondentService respondentService;
     private final OthersService othersService;
     private final ApplicationEventPublisher applicationEventPublisher;
-    private final RequestData requestData;
 
     @PostMapping("/about-to-start")
     public AboutToStartOrSubmitCallbackResponse handleAboutToStart(@RequestBody CallbackRequest callbackRequest) {
@@ -84,8 +82,7 @@ public class RepresentativesController {
 
     @PostMapping("/submitted")
     public void handleSubmittedEvent(@RequestBody CallbackRequest callbackRequest) {
-        applicationEventPublisher.publishEvent(new PartyAddedToCaseEvent(
-            callbackRequest, requestData));
+        applicationEventPublisher.publishEvent(new PartyAddedToCaseEvent(callbackRequest));
     }
 
     private String getRespondentsLabel(CaseData caseData) {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/ReturnApplicationController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/ReturnApplicationController.java
@@ -15,7 +15,6 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.events.ReturnedCaseEvent;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 import uk.gov.hmcts.reform.fpl.service.ReturnApplicationService;
 
 @Api
@@ -27,7 +26,6 @@ public class ReturnApplicationController {
     private final ObjectMapper mapper;
     private final ReturnApplicationService returnApplicationService;
     private final ApplicationEventPublisher applicationEventPublisher;
-    private final RequestData requestData;
 
     @PostMapping("/about-to-start")
     public AboutToStartOrSubmitCallbackResponse handleAboutToStart(@RequestBody CallbackRequest callbackrequest) {
@@ -62,6 +60,6 @@ public class ReturnApplicationController {
 
     @PostMapping("/submitted")
     public void handleSubmittedEvent(@RequestBody CallbackRequest callbackRequest) {
-        applicationEventPublisher.publishEvent(new ReturnedCaseEvent(callbackRequest, requestData));
+        applicationEventPublisher.publishEvent(new ReturnedCaseEvent(callbackRequest));
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/UploadC2DocumentsController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/UploadC2DocumentsController.java
@@ -125,23 +125,21 @@ public class UploadC2DocumentsController {
                 try {
                     paymentService.makePaymentForC2(caseDetails.getId(), caseData);
                 } catch (FeeRegisterException | PaymentsApiException ignore) {
-                    applicationEventPublisher.publishEvent(new FailedPBAPaymentEvent(callbackRequest,
-                        requestData, C2_APPLICATION));
+                    applicationEventPublisher.publishEvent(new FailedPBAPaymentEvent(callbackRequest, C2_APPLICATION));
                 }
             }
 
             if (NO.getValue().equals(caseDetails.getData().get(DISPLAY_AMOUNT_TO_PAY))) {
-                applicationEventPublisher.publishEvent(new FailedPBAPaymentEvent(callbackRequest, requestData,
-                    C2_APPLICATION));
+                applicationEventPublisher.publishEvent(new FailedPBAPaymentEvent(callbackRequest, C2_APPLICATION));
             }
         }
 
-        applicationEventPublisher.publishEvent(new C2UploadedEvent(callbackRequest, requestData));
+        applicationEventPublisher.publishEvent(new C2UploadedEvent(callbackRequest));
 
         C2DocumentBundle c2DocumentBundle = caseData.getLastC2DocumentBundle();
 
         if (isNotPaidByPba(c2DocumentBundle)) {
-            applicationEventPublisher.publishEvent(new C2PbaPaymentNotTakenEvent(callbackRequest, requestData));
+            applicationEventPublisher.publishEvent(new C2PbaPaymentNotTakenEvent(callbackRequest));
         }
     }
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/events/AmendedReturnedCaseEvent.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/events/AmendedReturnedCaseEvent.java
@@ -1,10 +1,9 @@
 package uk.gov.hmcts.reform.fpl.events;
 
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 
 public class AmendedReturnedCaseEvent extends CallbackEvent {
-    public AmendedReturnedCaseEvent(CallbackRequest callbackRequest, RequestData requestData) {
-        super(callbackRequest, requestData);
+    public AmendedReturnedCaseEvent(CallbackRequest callbackRequest) {
+        super(callbackRequest);
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/events/C2PbaPaymentNotTakenEvent.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/events/C2PbaPaymentNotTakenEvent.java
@@ -1,11 +1,10 @@
 package uk.gov.hmcts.reform.fpl.events;
 
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 
 public class C2PbaPaymentNotTakenEvent extends CallbackEvent {
 
-    public C2PbaPaymentNotTakenEvent(CallbackRequest callbackRequest, RequestData requestData) {
-        super(callbackRequest, requestData);
+    public C2PbaPaymentNotTakenEvent(CallbackRequest callbackRequest) {
+        super(callbackRequest);
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/events/C2UploadedEvent.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/events/C2UploadedEvent.java
@@ -1,11 +1,10 @@
 package uk.gov.hmcts.reform.fpl.events;
 
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 
 public class C2UploadedEvent extends CallbackEvent {
 
-    public C2UploadedEvent(CallbackRequest callbackRequest, RequestData requestData) {
-        super(callbackRequest, requestData);
+    public C2UploadedEvent(CallbackRequest callbackRequest) {
+        super(callbackRequest);
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/events/CallbackEvent.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/events/CallbackEvent.java
@@ -2,36 +2,22 @@ package uk.gov.hmcts.reform.fpl.events;
 
 import lombok.EqualsAndHashCode;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 
 @EqualsAndHashCode
 public class CallbackEvent {
 
     private final CallbackRequest callbackRequest;
-    private final String authorisation;
-    private final String userId;
 
-    CallbackEvent(CallbackRequest callbackRequest, RequestData requestData) {
+    CallbackEvent(CallbackRequest callbackRequest) {
         this.callbackRequest = callbackRequest;
-        this.authorisation = requestData.authorisation();
-        this.userId = requestData.userId();
     }
 
     CallbackEvent(CallbackEvent callbackEvent) {
         this.callbackRequest = callbackEvent.callbackRequest;
-        this.authorisation = callbackEvent.authorisation;
-        this.userId = callbackEvent.userId;
     }
 
     public CallbackRequest getCallbackRequest() {
         return callbackRequest;
     }
 
-    public String getAuthorization() {
-        return authorisation;
-    }
-
-    public String getUserId() {
-        return userId;
-    }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/events/CaseManagementOrderIssuedEvent.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/events/CaseManagementOrderIssuedEvent.java
@@ -3,16 +3,14 @@ package uk.gov.hmcts.reform.fpl.events;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
 public class CaseManagementOrderIssuedEvent extends CallbackEvent {
     private final byte[] documentContents;
 
-    public CaseManagementOrderIssuedEvent(CallbackRequest callbackRequest, RequestData requestData,
-                    byte[] documentContents) {
-        super(callbackRequest, requestData);
+    public CaseManagementOrderIssuedEvent(CallbackRequest callbackRequest, byte[] documentContents) {
+        super(callbackRequest);
         this.documentContents = documentContents;
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/events/CaseManagementOrderReadyForJudgeReviewEvent.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/events/CaseManagementOrderReadyForJudgeReviewEvent.java
@@ -1,10 +1,9 @@
 package uk.gov.hmcts.reform.fpl.events;
 
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 
 public class CaseManagementOrderReadyForJudgeReviewEvent extends CallbackEvent {
-    public CaseManagementOrderReadyForJudgeReviewEvent(CallbackRequest callbackRequest, RequestData requestData) {
-        super(callbackRequest, requestData);
+    public CaseManagementOrderReadyForJudgeReviewEvent(CallbackRequest callbackRequest) {
+        super(callbackRequest);
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/events/CaseManagementOrderReadyForPartyReviewEvent.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/events/CaseManagementOrderReadyForPartyReviewEvent.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.fpl.events;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
@@ -11,10 +10,8 @@ public class CaseManagementOrderReadyForPartyReviewEvent extends CallbackEvent {
 
     byte[] documentContents;
 
-    public CaseManagementOrderReadyForPartyReviewEvent(CallbackRequest callbackRequest,
-                                                       RequestData requestData,
-                                                       byte[] documentContents) {
-        super(callbackRequest, requestData);
+    public CaseManagementOrderReadyForPartyReviewEvent(CallbackRequest callbackRequest, byte[] documentContents) {
+        super(callbackRequest);
         this.documentContents = documentContents;
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/events/CaseManagementOrderRejectedEvent.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/events/CaseManagementOrderRejectedEvent.java
@@ -4,13 +4,12 @@ import lombok.EqualsAndHashCode;
 import lombok.Generated;
 import lombok.Value;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 
 @Value
 @Generated
 @EqualsAndHashCode(callSuper = true)
 public class CaseManagementOrderRejectedEvent extends CallbackEvent {
-    public CaseManagementOrderRejectedEvent(CallbackRequest callbackRequest, RequestData requestData) {
-        super(callbackRequest, requestData);
+    public CaseManagementOrderRejectedEvent(CallbackRequest callbackRequest) {
+        super(callbackRequest);
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/events/FailedPBAPaymentEvent.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/events/FailedPBAPaymentEvent.java
@@ -4,7 +4,6 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.fpl.enums.ApplicationType;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
@@ -12,9 +11,8 @@ public class FailedPBAPaymentEvent extends CallbackEvent {
 
     private final ApplicationType applicationType;
 
-    public FailedPBAPaymentEvent(CallbackRequest callbackRequest, RequestData requestData,
-                                 ApplicationType applicationType) {
-        super(callbackRequest, requestData);
+    public FailedPBAPaymentEvent(CallbackRequest callbackRequest, ApplicationType applicationType) {
+        super(callbackRequest);
         this.applicationType = applicationType;
     }
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/events/GeneratedOrderEvent.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/events/GeneratedOrderEvent.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.fpl.events;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
@@ -12,9 +11,9 @@ public class GeneratedOrderEvent extends CallbackEvent {
     private final String mostRecentUploadedDocumentUrl;
     private final byte[] documentContents;
 
-    public GeneratedOrderEvent(CallbackRequest callbackRequest, RequestData requestData,
-                         String mostRecentUploadedDocumentUrl, byte[] documentContents) {
-        super(callbackRequest, requestData);
+    public GeneratedOrderEvent(CallbackRequest callbackRequest, String mostRecentUploadedDocumentUrl,
+                               byte[] documentContents) {
+        super(callbackRequest);
         this.mostRecentUploadedDocumentUrl = mostRecentUploadedDocumentUrl;
         this.documentContents = documentContents;
     }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/events/NoticeOfPlacementOrderUploadedEvent.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/events/NoticeOfPlacementOrderUploadedEvent.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.fpl.events;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
@@ -11,10 +10,8 @@ public class NoticeOfPlacementOrderUploadedEvent extends CallbackEvent {
 
     private final byte[] documentContents;
 
-    public NoticeOfPlacementOrderUploadedEvent(CallbackRequest callbackRequest,
-                                               RequestData requestData,
-                                               byte[] documentContents) {
-        super(callbackRequest, requestData);
+    public NoticeOfPlacementOrderUploadedEvent(CallbackRequest callbackRequest, byte[] documentContents) {
+        super(callbackRequest);
         this.documentContents = documentContents;
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/events/NotifyAllocatedJudgeEvent.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/events/NotifyAllocatedJudgeEvent.java
@@ -1,11 +1,10 @@
 package uk.gov.hmcts.reform.fpl.events;
 
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 
 public class NotifyAllocatedJudgeEvent extends CallbackEvent {
 
-    public NotifyAllocatedJudgeEvent(CallbackRequest callbackRequest, RequestData requestData) {
-        super(callbackRequest, requestData);
+    public NotifyAllocatedJudgeEvent(CallbackRequest callbackRequest) {
+        super(callbackRequest);
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/events/NotifyGatekeepersEvent.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/events/NotifyGatekeepersEvent.java
@@ -1,11 +1,10 @@
 package uk.gov.hmcts.reform.fpl.events;
 
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 
 public class NotifyGatekeepersEvent extends CallbackEvent {
 
-    public NotifyGatekeepersEvent(CallbackRequest callbackRequest, RequestData requestData) {
-        super(callbackRequest, requestData);
+    public NotifyGatekeepersEvent(CallbackRequest callbackRequest) {
+        super(callbackRequest);
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/events/PartyAddedToCaseEvent.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/events/PartyAddedToCaseEvent.java
@@ -3,13 +3,12 @@ package uk.gov.hmcts.reform.fpl.events;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
 public class PartyAddedToCaseEvent extends CallbackEvent {
 
-    public PartyAddedToCaseEvent(CallbackRequest callbackRequest, RequestData requestData) {
-        super(callbackRequest, requestData);
+    public PartyAddedToCaseEvent(CallbackRequest callbackRequest) {
+        super(callbackRequest);
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/events/PlacementApplicationEvent.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/events/PlacementApplicationEvent.java
@@ -1,10 +1,9 @@
 package uk.gov.hmcts.reform.fpl.events;
 
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 
 public class PlacementApplicationEvent extends CallbackEvent {
-    public PlacementApplicationEvent(CallbackRequest callbackRequest, RequestData requestData) {
-        super(callbackRequest, requestData);
+    public PlacementApplicationEvent(CallbackRequest callbackRequest) {
+        super(callbackRequest);
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/events/PopulateStandardDirectionsEvent.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/events/PopulateStandardDirectionsEvent.java
@@ -1,11 +1,10 @@
 package uk.gov.hmcts.reform.fpl.events;
 
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 
 public class PopulateStandardDirectionsEvent extends CallbackEvent {
 
-    public PopulateStandardDirectionsEvent(CallbackRequest callbackRequest, RequestData requestData) {
-        super(callbackRequest, requestData);
+    public PopulateStandardDirectionsEvent(CallbackRequest callbackRequest) {
+        super(callbackRequest);
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/events/PopulateStandardDirectionsOrderDatesEvent.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/events/PopulateStandardDirectionsOrderDatesEvent.java
@@ -1,11 +1,10 @@
 package uk.gov.hmcts.reform.fpl.events;
 
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 
 public class PopulateStandardDirectionsOrderDatesEvent extends CallbackEvent {
 
-    public PopulateStandardDirectionsOrderDatesEvent(CallbackRequest callbackRequest, RequestData requestData) {
-        super(callbackRequest, requestData);
+    public PopulateStandardDirectionsOrderDatesEvent(CallbackRequest callbackRequest) {
+        super(callbackRequest);
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/events/ReturnedCaseEvent.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/events/ReturnedCaseEvent.java
@@ -1,10 +1,9 @@
 package uk.gov.hmcts.reform.fpl.events;
 
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 
 public class ReturnedCaseEvent extends CallbackEvent {
-    public ReturnedCaseEvent(CallbackRequest callbackRequest, RequestData requestData) {
-        super(callbackRequest, requestData);
+    public ReturnedCaseEvent(CallbackRequest callbackRequest) {
+        super(callbackRequest);
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/events/StandardDirectionsOrderIssuedEvent.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/events/StandardDirectionsOrderIssuedEvent.java
@@ -1,11 +1,10 @@
 package uk.gov.hmcts.reform.fpl.events;
 
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 
 public class StandardDirectionsOrderIssuedEvent extends CallbackEvent {
 
-    public StandardDirectionsOrderIssuedEvent(CallbackRequest callbackRequest, RequestData requestData) {
-        super(callbackRequest, requestData);
+    public StandardDirectionsOrderIssuedEvent(CallbackRequest callbackRequest) {
+        super(callbackRequest);
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/events/SubmittedCaseEvent.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/events/SubmittedCaseEvent.java
@@ -1,11 +1,10 @@
 package uk.gov.hmcts.reform.fpl.events;
 
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 
 public class SubmittedCaseEvent extends CallbackEvent {
 
-    public SubmittedCaseEvent(CallbackRequest callbackRequest, RequestData requestData) {
-        super(callbackRequest, requestData);
+    public SubmittedCaseEvent(CallbackRequest callbackRequest) {
+        super(callbackRequest);
     }
 }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/events/CallbackEventTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/events/CallbackEventTest.java
@@ -3,23 +3,13 @@ package uk.gov.hmcts.reform.fpl.events;
 import org.apache.commons.lang.RandomStringUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 class CallbackEventTest {
-
-    private static final String AUTH_TOKEN = randomAlphanumeric(10);
-    private static final String USER_ID = randomAlphanumeric(10);
-
-    @Mock
-    private RequestData requestData;
 
     @Test
     void shouldCarryDataAndRequestContextInformation() {
@@ -27,13 +17,8 @@ class CallbackEventTest {
             .eventId(RandomStringUtils.randomAlphanumeric(10))
             .build();
 
-        when(requestData.authorisation()).thenReturn(AUTH_TOKEN);
-        when(requestData.userId()).thenReturn(USER_ID);
-
-        CallbackEvent callbackEvent = new CallbackEvent(callbackRequest, requestData);
+        CallbackEvent callbackEvent = new CallbackEvent(callbackRequest);
 
         assertThat(callbackEvent.getCallbackRequest()).isEqualTo(callbackRequest);
-        assertThat(callbackEvent.getAuthorization()).isEqualTo(AUTH_TOKEN);
-        assertThat(callbackEvent.getUserId()).isEqualTo(USER_ID);
     }
 }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/AmendedReturnedCaseEventHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/AmendedReturnedCaseEventHandlerTest.java
@@ -9,7 +9,6 @@ import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.fpl.events.AmendedReturnedCaseEvent;
 import uk.gov.hmcts.reform.fpl.model.event.EventData;
 import uk.gov.hmcts.reform.fpl.model.notify.returnedcase.ReturnedCaseTemplate;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 import uk.gov.hmcts.reform.fpl.service.email.NotificationService;
 import uk.gov.hmcts.reform.fpl.service.email.content.ReturnedCaseContentProvider;
 
@@ -22,9 +21,6 @@ import static uk.gov.hmcts.reform.fpl.utils.assertions.AnnotationAssertion.asser
 
 @ExtendWith(SpringExtension.class)
 class AmendedReturnedCaseEventHandlerTest {
-
-    @Mock
-    private RequestData requestData;
 
     @Mock
     private NotificationService notificationService;
@@ -48,7 +44,7 @@ class AmendedReturnedCaseEventHandlerTest {
         final String expectedEmail = "test@test.com";
         final CallbackRequest request = callbackRequest();
         final ReturnedCaseTemplate expectedTemplate = new ReturnedCaseTemplate();
-        final AmendedReturnedCaseEvent amendedReturnedCaseEvent = new AmendedReturnedCaseEvent(request, requestData);
+        final AmendedReturnedCaseEvent amendedReturnedCaseEvent = new AmendedReturnedCaseEvent(request);
 
         when(adminNotificationHandler.getHmctsAdminEmail(new EventData(amendedReturnedCaseEvent)))
             .thenReturn(expectedEmail);

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/C2PbaPaymentNotTakenEventHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/C2PbaPaymentNotTakenEventHandlerTest.java
@@ -10,7 +10,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.events.C2PbaPaymentNotTakenEvent;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 import uk.gov.hmcts.reform.fpl.service.InboxLookupService;
 import uk.gov.hmcts.reform.fpl.service.config.LookupTestConfig;
 import uk.gov.hmcts.reform.fpl.service.email.NotificationService;
@@ -45,9 +44,6 @@ public class C2PbaPaymentNotTakenEventHandlerTest {
     private IdamApi idamApi;
 
     @MockBean
-    private RequestData requestData;
-
-    @MockBean
     private InboxLookupService inboxLookupService;
 
     @MockBean
@@ -66,8 +62,7 @@ public class C2PbaPaymentNotTakenEventHandlerTest {
         given(c2UploadedEmailContentProvider.buildC2UploadPbaPaymentNotTakenNotification(caseDetails))
             .willReturn(c2PaymentNotTakenParameters);
 
-        c2PbaPaymentNotTakenEventHandler.sendEmail(
-            new C2PbaPaymentNotTakenEvent(callbackRequest(), requestData));
+        c2PbaPaymentNotTakenEventHandler.sendEmail(new C2PbaPaymentNotTakenEvent(callbackRequest()));
 
         verify(notificationService).sendEmail(
             C2_UPLOAD_PBA_PAYMENT_NOT_TAKEN_TEMPLATE, "admin@family-court.com", c2PaymentNotTakenParameters,
@@ -88,8 +83,7 @@ public class C2PbaPaymentNotTakenEventHandlerTest {
         given(c2UploadedEmailContentProvider.buildC2UploadPbaPaymentNotTakenNotification(caseDetails))
             .willReturn(c2PaymentNotTakenParameters);
 
-        c2PbaPaymentNotTakenEventHandler.sendEmail(
-            new C2PbaPaymentNotTakenEvent(callbackRequest, requestData));
+        c2PbaPaymentNotTakenEventHandler.sendEmail(new C2PbaPaymentNotTakenEvent(callbackRequest));
 
         verify(notificationService).sendEmail(
             C2_UPLOAD_PBA_PAYMENT_NOT_TAKEN_TEMPLATE, CTSC_INBOX, c2PaymentNotTakenParameters, "12345");

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/C2UploadedEventHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/C2UploadedEventHandlerTest.java
@@ -99,7 +99,7 @@ public class C2UploadedEventHandlerTest {
                     COURT_CODE));
 
             c2UploadedEventHandler.sendNotifications(
-                new C2UploadedEvent(callbackRequest(), requestData));
+                new C2UploadedEvent(callbackRequest()));
 
             verify(notificationService).sendEmail(
                 C2_UPLOAD_NOTIFICATION_TEMPLATE, "hmcts-non-admin@test.com", c2Parameters, "12345");
@@ -120,7 +120,7 @@ public class C2UploadedEventHandlerTest {
                 .willReturn(c2Parameters);
 
             c2UploadedEventHandler.sendNotifications(
-                new C2UploadedEvent(callbackRequest, requestData));
+                new C2UploadedEvent(callbackRequest));
 
             verify(notificationService).sendEmail(
                 C2_UPLOAD_NOTIFICATION_TEMPLATE,
@@ -135,7 +135,7 @@ public class C2UploadedEventHandlerTest {
                 UserInfo.builder().sub("hmcts-admin@test.com").roles(HMCTS_ADMIN.getRoles()).build());
 
             c2UploadedEventHandler.sendNotifications(
-                new C2UploadedEvent(callbackRequest(), requestData));
+                new C2UploadedEvent(callbackRequest()));
 
             verify(notificationService, never())
                 .sendEmail(C2_UPLOAD_NOTIFICATION_TEMPLATE, "hmcts-admin@test.com",

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/CaseManagementOrderIssuedEventHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/CaseManagementOrderIssuedEventHandlerTest.java
@@ -11,7 +11,6 @@ import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.events.CaseManagementOrderIssuedEvent;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 import uk.gov.hmcts.reform.fpl.service.CaseUrlService;
 import uk.gov.hmcts.reform.fpl.service.HearingBookingService;
 import uk.gov.hmcts.reform.fpl.service.InboxLookupService;
@@ -52,8 +51,6 @@ import static uk.gov.hmcts.reform.fpl.utils.matchers.JsonMatcher.eqJson;
     CaseManagementOrderDocumentLinkNotificationHandler.class, IssuedOrderAdminNotificationHandler.class,
     HmctsAdminNotificationHandler.class, HearingBookingService.class, FixedTimeConfiguration.class})
 public class CaseManagementOrderIssuedEventHandlerTest {
-    @MockBean
-    private RequestData requestData;
 
     @MockBean
     private InboxLookupService inboxLookupService;
@@ -93,7 +90,7 @@ public class CaseManagementOrderIssuedEventHandlerTest {
             .willReturn(getExpectedCaseUrlParameters(CMO.getLabel(), true));
 
         caseManagementOrderIssuedEventHandler.sendEmailsForIssuedCaseManagementOrder(
-            new CaseManagementOrderIssuedEvent(callbackRequest, requestData, DOCUMENT_CONTENTS));
+            new CaseManagementOrderIssuedEvent(callbackRequest, DOCUMENT_CONTENTS));
 
         verify(notificationService).sendEmail(
             CMO_ORDER_ISSUED_CASE_LINK_NOTIFICATION_TEMPLATE,
@@ -122,7 +119,7 @@ public class CaseManagementOrderIssuedEventHandlerTest {
             .willReturn(getExpectedCaseUrlParameters(CMO.getLabel(), true));
 
         caseManagementOrderIssuedEventHandler.sendEmailsForIssuedCaseManagementOrder(
-            new CaseManagementOrderIssuedEvent(callbackRequest, requestData, DOCUMENT_CONTENTS));
+            new CaseManagementOrderIssuedEvent(callbackRequest, DOCUMENT_CONTENTS));
 
         verify(notificationService).sendEmail(
             eq(ORDER_ISSUED_NOTIFICATION_TEMPLATE_FOR_ADMIN),
@@ -147,7 +144,7 @@ public class CaseManagementOrderIssuedEventHandlerTest {
             .willReturn(getExpectedCMOIssuedCaseLinkNotificationParametersForRepresentative());
 
         caseManagementOrderIssuedEventHandler.sendEmailsForIssuedCaseManagementOrder(
-            new CaseManagementOrderIssuedEvent(callbackRequest, requestData, DOCUMENT_CONTENTS));
+            new CaseManagementOrderIssuedEvent(callbackRequest, DOCUMENT_CONTENTS));
 
         verify(notificationService).sendEmail(
             CMO_ORDER_ISSUED_CASE_LINK_NOTIFICATION_TEMPLATE,

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/CaseManagementOrderReadyForJudgeReviewEventHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/CaseManagementOrderReadyForJudgeReviewEventHandlerTest.java
@@ -10,7 +10,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.events.CaseManagementOrderReadyForJudgeReviewEvent;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 import uk.gov.hmcts.reform.fpl.service.config.LookupTestConfig;
 import uk.gov.hmcts.reform.fpl.service.email.NotificationService;
 import uk.gov.hmcts.reform.fpl.service.email.content.CaseManagementOrderEmailContentProvider;
@@ -28,8 +27,6 @@ import static uk.gov.hmcts.reform.fpl.utils.CoreCaseDataStoreLoader.callbackRequ
 @SpringBootTest(classes = {CaseManagementOrderReadyForJudgeReviewEventHandler.class, JacksonAutoConfiguration.class,
     LookupTestConfig.class, HmctsAdminNotificationHandler.class})
 public class CaseManagementOrderReadyForJudgeReviewEventHandlerTest {
-    @MockBean
-    private RequestData requestData;
 
     @MockBean
     private NotificationService notificationService;
@@ -50,7 +47,7 @@ public class CaseManagementOrderReadyForJudgeReviewEventHandlerTest {
             .willReturn(getCMOReadyForJudgeNotificationParameters());
 
         caseManagementOrderReadyForJudgeReviewEventHandler.sendEmailForCaseManagementOrderReadyForJudgeReview(
-            new CaseManagementOrderReadyForJudgeReviewEvent(callbackRequest, requestData));
+            new CaseManagementOrderReadyForJudgeReviewEvent(callbackRequest));
 
         verify(notificationService).sendEmail(
             CMO_READY_FOR_JUDGE_REVIEW_NOTIFICATION_TEMPLATE,
@@ -69,7 +66,7 @@ public class CaseManagementOrderReadyForJudgeReviewEventHandlerTest {
             .willReturn(getCMOReadyForJudgeNotificationParameters());
 
         caseManagementOrderReadyForJudgeReviewEventHandler.sendEmailForCaseManagementOrderReadyForJudgeReview(
-            new CaseManagementOrderReadyForJudgeReviewEvent(callbackRequest, requestData));
+            new CaseManagementOrderReadyForJudgeReviewEvent(callbackRequest));
 
         verify(notificationService).sendEmail(
             CMO_READY_FOR_JUDGE_REVIEW_NOTIFICATION_TEMPLATE,

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/CaseManagementOrderReadyForPartyReviewEventHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/CaseManagementOrderReadyForPartyReviewEventHandlerTest.java
@@ -16,7 +16,6 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.enums.RepresentativeServingPreferences;
 import uk.gov.hmcts.reform.fpl.events.CaseManagementOrderReadyForPartyReviewEvent;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 import uk.gov.hmcts.reform.fpl.service.HearingBookingService;
 import uk.gov.hmcts.reform.fpl.service.RepresentativeService;
 import uk.gov.hmcts.reform.fpl.service.config.LookupTestConfig;
@@ -46,8 +45,6 @@ import static uk.gov.hmcts.reform.fpl.utils.matchers.JsonMatcher.eqJson;
     LookupTestConfig.class, RepresentativeNotificationService.class, HearingBookingService.class,
     FixedTimeConfiguration.class})
 class CaseManagementOrderReadyForPartyReviewEventHandlerTest {
-    @MockBean
-    private RequestData requestData;
 
     @MockBean
     private NotificationService notificationService;
@@ -87,7 +84,7 @@ class CaseManagementOrderReadyForPartyReviewEventHandlerTest {
             .willReturn((getCMOReadyforReviewByPartiesNotificationParameters(EMAIL)));
 
         orderReadyForPartyReviewEventHandler.sendEmailForCaseManagementOrderReadyForPartyReview(
-            new CaseManagementOrderReadyForPartyReviewEvent(callbackRequest, requestData, DOCUMENT_CONTENTS));
+            new CaseManagementOrderReadyForPartyReviewEvent(callbackRequest, DOCUMENT_CONTENTS));
 
         verify(notificationService).sendEmail(
             eq(CMO_READY_FOR_PARTY_REVIEW_NOTIFICATION_TEMPLATE),

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/CaseManagementOrderRejectedEventHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/CaseManagementOrderRejectedEventHandlerTest.java
@@ -8,7 +8,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.events.CaseManagementOrderRejectedEvent;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 import uk.gov.hmcts.reform.fpl.service.InboxLookupService;
 import uk.gov.hmcts.reform.fpl.service.email.NotificationService;
 import uk.gov.hmcts.reform.fpl.service.email.content.CaseManagementOrderEmailContentProvider;
@@ -23,9 +22,6 @@ import static uk.gov.hmcts.reform.fpl.utils.CoreCaseDataStoreLoader.callbackRequ
 
 @ExtendWith(SpringExtension.class)
 public class CaseManagementOrderRejectedEventHandlerTest {
-
-    @Mock
-    private RequestData requestData;
 
     @Mock
     private InboxLookupService inboxLookupService;
@@ -51,7 +47,7 @@ public class CaseManagementOrderRejectedEventHandlerTest {
             .willReturn(getCMORejectedCaseLinkNotificationParameters());
 
         caseManagementOrderRejectedEventHandler.notifyLocalAuthorityOfRejectedCaseManagementOrder(
-            new CaseManagementOrderRejectedEvent(callbackRequest, requestData));
+            new CaseManagementOrderRejectedEvent(callbackRequest));
 
         verify(notificationService).sendEmail(
             CMO_REJECTED_BY_JUDGE_TEMPLATE,

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/FailedPBAPaymentEventHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/FailedPBAPaymentEventHandlerTest.java
@@ -67,7 +67,7 @@ public class FailedPBAPaymentEventHandlerTest {
             .willReturn(expectedParameters);
 
         failedPBAPaymentEventHandler.sendFailedPBAPaymentEmailToLocalAuthority(
-            new FailedPBAPaymentEvent(callbackRequest, requestData, C110A_APPLICATION));
+            new FailedPBAPaymentEvent(callbackRequest, C110A_APPLICATION));
 
         verify(notificationService).sendEmail(
             APPLICATION_PBA_PAYMENT_FAILED_TEMPLATE_FOR_LA,
@@ -85,7 +85,7 @@ public class FailedPBAPaymentEventHandlerTest {
             .getCaseDetails(), C2_APPLICATION)).willReturn(expectedParameters);
 
         failedPBAPaymentEventHandler.sendFailedPBAPaymentEmailToCTSC(
-            new FailedPBAPaymentEvent(callbackRequest, requestData, C2_APPLICATION));
+            new FailedPBAPaymentEvent(callbackRequest, C2_APPLICATION));
 
         verify(notificationService).sendEmail(
             APPLICATION_PBA_PAYMENT_FAILED_TEMPLATE_FOR_CTSC,

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/GeneratedOrderEventHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/GeneratedOrderEventHandlerTest.java
@@ -14,7 +14,6 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.events.GeneratedOrderEvent;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.Representative;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 import uk.gov.hmcts.reform.fpl.service.CaseUrlService;
 import uk.gov.hmcts.reform.fpl.service.HearingBookingService;
 import uk.gov.hmcts.reform.fpl.service.InboxLookupService;
@@ -56,9 +55,6 @@ class GeneratedOrderEventHandlerTest {
 
     final String mostRecentUploadedDocumentUrl =
         "http://fake-document-gateway/documents/79ec80ec-7be6-493b-b4e6-f002f05b7079/binary";
-
-    @MockBean
-    private RequestData requestData;
 
     @MockBean
     private OrderIssuedEmailContentProvider orderIssuedEmailContentProvider;
@@ -110,7 +106,7 @@ class GeneratedOrderEventHandlerTest {
             .willReturn(getExpectedDigitalServedRepresentativesForAddingPartiesToCase());
 
         generatedOrderEventHandler.sendEmailsForOrder(new GeneratedOrderEvent(callbackRequest(),
-            requestData, mostRecentUploadedDocumentUrl, DOCUMENT_CONTENTS));
+            mostRecentUploadedDocumentUrl, DOCUMENT_CONTENTS));
 
         verify(notificationService).sendEmail(
             eq(ORDER_ISSUED_NOTIFICATION_TEMPLATE_FOR_ADMIN),

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/NoticeOfPlacementOrderUploadedEventHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/NoticeOfPlacementOrderUploadedEventHandlerTest.java
@@ -66,7 +66,7 @@ public class NoticeOfPlacementOrderUploadedEventHandlerTest {
         final CallbackRequest caseData = callbackRequest();
         final CaseDetails caseDetails = caseData.getCaseDetails();
         final NoticeOfPlacementOrderUploadedEvent event = new NoticeOfPlacementOrderUploadedEvent(
-            caseData, requestData, DOCUMENT_CONTENTS);
+            caseData, DOCUMENT_CONTENTS);
         final EventData eventData = new EventData(event);
 
         given(inboxLookupService.getNotificationRecipientEmail(caseDetails, LOCAL_AUTHORITY_CODE))

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/NotifyAllocatedJudgeEventHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/NotifyAllocatedJudgeEventHandlerTest.java
@@ -11,7 +11,6 @@ import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.events.NotifyAllocatedJudgeEvent;
 import uk.gov.hmcts.reform.fpl.model.notify.AllocatedJudgeTemplate;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 import uk.gov.hmcts.reform.fpl.service.email.NotificationService;
 import uk.gov.hmcts.reform.fpl.service.email.content.AllocatedJudgeContentProvider;
 
@@ -25,9 +24,6 @@ import static uk.gov.hmcts.reform.fpl.utils.CoreCaseDataStoreLoader.callbackRequ
 @SpringBootTest(classes = {NotifyAllocatedJudgeEventHandler.class, JacksonAutoConfiguration.class})
 class NotifyAllocatedJudgeEventHandlerTest {
     private final String allocatedJudgeEmailAddress = "test@test.com";
-
-    @MockBean
-    private RequestData requestData;
 
     @MockBean
     private NotificationService notificationService;
@@ -48,8 +44,7 @@ class NotifyAllocatedJudgeEventHandlerTest {
         given(allocatedJudgeContentProvider.buildNotificationParameters(caseDetails))
             .willReturn(expectedParameters);
 
-        notifyAllocatedJudgeEventHandler.notifyAllocatedJudge(new NotifyAllocatedJudgeEvent(callbackRequest,
-            requestData));
+        notifyAllocatedJudgeEventHandler.notifyAllocatedJudge(new NotifyAllocatedJudgeEvent(callbackRequest));
 
         verify(notificationService).sendEmail(
             ALLOCATED_JUDGE_TEMPLATE,

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/NotifyGatekeeperEventHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/NotifyGatekeeperEventHandlerTest.java
@@ -13,7 +13,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.fpl.events.NotifyGatekeepersEvent;
 import uk.gov.hmcts.reform.fpl.model.notify.sendtogatekeeper.NotifyGatekeeperTemplate;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 import uk.gov.hmcts.reform.fpl.service.CaseUrlService;
 import uk.gov.hmcts.reform.fpl.service.config.LookupTestConfig;
 import uk.gov.hmcts.reform.fpl.service.email.NotificationService;
@@ -42,8 +41,6 @@ public class NotifyGatekeeperEventHandlerTest {
     @Captor
     private ArgumentCaptor<NotifyGatekeeperTemplate> captor;
     @MockBean
-    private RequestData requestData;
-    @MockBean
     private NotificationService notificationService;
     @Autowired
     private NotifyGatekeeperEventHandler notifyGatekeeperEventHandler;
@@ -59,7 +56,7 @@ public class NotifyGatekeeperEventHandlerTest {
     void shouldSendEmailToMultipleGatekeepers() {
         CallbackRequest request = callbackRequest();
 
-        notifyGatekeeperEventHandler.sendEmailToGatekeeper(new NotifyGatekeepersEvent(request, requestData));
+        notifyGatekeeperEventHandler.sendEmailToGatekeeper(new NotifyGatekeepersEvent(request));
 
         verify(notificationService).sendEmail(
             eq(GATEKEEPER_SUBMISSION_TEMPLATE), eq(GATEKEEPER_EMAIL_ADDRESS),

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/PartyAddedToCaseEventHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/PartyAddedToCaseEventHandlerTest.java
@@ -89,7 +89,7 @@ public class PartyAddedToCaseEventHandlerTest {
             callbackRequest().getCaseDetails(), DIGITAL_SERVICE)).willReturn(expectedDigitalParameters);
 
         partyAddedToCaseEventHandler.sendEmailToPartiesAddedToCase(
-            new PartyAddedToCaseEvent(callbackRequest(), requestData));
+            new PartyAddedToCaseEvent(callbackRequest()));
 
         verify(notificationService).sendEmail(
             PARTY_ADDED_TO_CASE_BY_EMAIL_NOTIFICATION_TEMPLATE,

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/PlacementApplicationEventHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/PlacementApplicationEventHandlerTest.java
@@ -11,7 +11,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.events.PlacementApplicationEvent;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 import uk.gov.hmcts.reform.fpl.service.config.LookupTestConfig;
 import uk.gov.hmcts.reform.fpl.service.email.NotificationService;
 import uk.gov.hmcts.reform.fpl.service.email.content.PlacementApplicationContentProvider;
@@ -32,8 +31,6 @@ import static uk.gov.hmcts.reform.fpl.utils.CoreCaseDataStoreLoader.callbackRequ
 @SpringBootTest(classes = {PlacementApplicationEventHandler.class, JacksonAutoConfiguration.class,
     LookupTestConfig.class, HmctsAdminNotificationHandler.class})
 public class PlacementApplicationEventHandlerTest {
-    @MockBean
-    private RequestData requestData;
 
     @MockBean
     private NotificationService notificationService;
@@ -55,7 +52,7 @@ public class PlacementApplicationEventHandlerTest {
             .willReturn(expectedParameters);
 
         placementApplicationEventHandler.notifyAdminOfPlacementApplicationUpload(
-            new PlacementApplicationEvent(callbackRequest, requestData));
+            new PlacementApplicationEvent(callbackRequest));
 
         verify(notificationService).sendEmail(
             NEW_PLACEMENT_APPLICATION_NOTIFICATION_TEMPLATE,
@@ -75,7 +72,7 @@ public class PlacementApplicationEventHandlerTest {
             .willReturn(expectedParameters);
 
         placementApplicationEventHandler.notifyAdminOfPlacementApplicationUpload(
-            new PlacementApplicationEvent(callbackRequest, requestData));
+            new PlacementApplicationEvent(callbackRequest));
 
         verify(notificationService).sendEmail(
             NEW_PLACEMENT_APPLICATION_NOTIFICATION_TEMPLATE,

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/PopulateStandardDirectionsHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/PopulateStandardDirectionsHandlerTest.java
@@ -17,7 +17,6 @@ import uk.gov.hmcts.reform.fpl.events.PopulateStandardDirectionsEvent;
 import uk.gov.hmcts.reform.fpl.model.Direction;
 import uk.gov.hmcts.reform.fpl.model.HearingBooking;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 import uk.gov.hmcts.reform.fpl.service.CommonDirectionService;
 import uk.gov.hmcts.reform.fpl.service.HearingBookingService;
 import uk.gov.hmcts.reform.fpl.service.StandardDirectionsService;
@@ -75,9 +74,6 @@ class PopulateStandardDirectionsHandlerTest {
     @MockBean
     private StandardDirectionsService standardDirectionsService;
 
-    @MockBean
-    private RequestData requestData;
-
     @Captor
     private ArgumentCaptor<Map<String, Object>> data;
 
@@ -94,7 +90,7 @@ class PopulateStandardDirectionsHandlerTest {
 
     @Test
     void shouldTriggerEventWithCorrectData() {
-        handler.populateStandardDirections(new PopulateStandardDirectionsEvent(callbackRequest, requestData));
+        handler.populateStandardDirections(new PopulateStandardDirectionsEvent(callbackRequest));
 
         verify(coreCaseDataService).triggerEvent(
             eq(JURISDICTION),
@@ -112,7 +108,7 @@ class PopulateStandardDirectionsHandlerTest {
     void shouldCallStandardDirectionsServiceWithNullIfNoFirstHearing() {
         given(hearingBookingService.getFirstHearing(any())).willReturn(Optional.empty());
 
-        handler.populateStandardDirections(new PopulateStandardDirectionsEvent(callbackRequest, requestData));
+        handler.populateStandardDirections(new PopulateStandardDirectionsEvent(callbackRequest));
 
         verify(coreCaseDataService).triggerEvent(
             eq(JURISDICTION),

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/PopulateStandardDirectionsOrderDatesHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/PopulateStandardDirectionsOrderDatesHandlerTest.java
@@ -17,7 +17,6 @@ import uk.gov.hmcts.reform.fpl.events.PopulateStandardDirectionsOrderDatesEvent;
 import uk.gov.hmcts.reform.fpl.model.Direction;
 import uk.gov.hmcts.reform.fpl.model.HearingBooking;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 import uk.gov.hmcts.reform.fpl.service.CommonDirectionService;
 import uk.gov.hmcts.reform.fpl.service.HearingBookingService;
 import uk.gov.hmcts.reform.fpl.service.StandardDirectionsService;
@@ -85,9 +84,6 @@ class PopulateStandardDirectionsOrderDatesHandlerTest {
     @MockBean
     private HearingBookingService hearingBookingService;
 
-    @MockBean
-    private RequestData requestData;
-
     @Captor
     private ArgumentCaptor<Map<String, Object>> data;
 
@@ -104,8 +100,7 @@ class PopulateStandardDirectionsOrderDatesHandlerTest {
 
     @Test
     void shouldTriggerEventWithCaseDataFilledWithDates() {
-        handler.populateDates(new PopulateStandardDirectionsOrderDatesEvent(callbackRequest,
-            requestData));
+        handler.populateDates(new PopulateStandardDirectionsOrderDatesEvent(callbackRequest));
 
         verify(hearingBookingService).getFirstHearing(HEARING_DETAILS);
         verify(standardDirectionsService).getDirections(FIRST_HEARING);
@@ -122,8 +117,7 @@ class PopulateStandardDirectionsOrderDatesHandlerTest {
     @Test
     void shouldFillCaseDataWithMissingDatesOnly() {
         callbackRequest.getCaseDetails().setData(getDataWithSomeDatesFilled());
-        handler.populateDates(new PopulateStandardDirectionsOrderDatesEvent(callbackRequest,
-            requestData));
+        handler.populateDates(new PopulateStandardDirectionsOrderDatesEvent(callbackRequest));
 
         verify(hearingBookingService).getFirstHearing(HEARING_DETAILS);
         verify(standardDirectionsService).getDirections(FIRST_HEARING);

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/StandardDirectionsOrderIssuedEventHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/StandardDirectionsOrderIssuedEventHandlerTest.java
@@ -11,7 +11,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.fpl.config.CafcassLookupConfiguration;
 import uk.gov.hmcts.reform.fpl.events.StandardDirectionsOrderIssuedEvent;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 import uk.gov.hmcts.reform.fpl.service.InboxLookupService;
 import uk.gov.hmcts.reform.fpl.service.config.LookupTestConfig;
 import uk.gov.hmcts.reform.fpl.service.email.NotificationService;
@@ -36,9 +35,6 @@ import static uk.gov.hmcts.reform.fpl.utils.CoreCaseDataStoreLoader.callbackRequ
     LookupTestConfig.class})
 public class StandardDirectionsOrderIssuedEventHandlerTest {
     private static CallbackRequest callbackRequest = callbackRequest();
-
-    @MockBean
-    private RequestData requestData;
 
     @MockBean
     private CafcassEmailContentProviderSDOIssued cafcassEmailContentProviderSDOIssued;
@@ -70,7 +66,7 @@ public class StandardDirectionsOrderIssuedEventHandlerTest {
             LOCAL_AUTHORITY_CODE)).willReturn(expectedParameters);
 
         standardDirectionsOrderIssuedEventHandler.notifyCafcassOfIssuedStandardDirectionsOrder(
-            new StandardDirectionsOrderIssuedEvent(callbackRequest, requestData));
+            new StandardDirectionsOrderIssuedEvent(callbackRequest));
 
         verify(notificationService).sendEmail(
             STANDARD_DIRECTION_ORDER_ISSUED_TEMPLATE,
@@ -92,7 +88,7 @@ public class StandardDirectionsOrderIssuedEventHandlerTest {
             .willReturn(LOCAL_AUTHORITY_EMAIL_ADDRESS);
 
         standardDirectionsOrderIssuedEventHandler.notifyLocalAuthorityOfIssuedStandardDirectionsOrder(
-            new StandardDirectionsOrderIssuedEvent(callbackRequest, requestData));
+            new StandardDirectionsOrderIssuedEvent(callbackRequest));
 
         verify(notificationService).sendEmail(
             STANDARD_DIRECTION_ORDER_ISSUED_TEMPLATE, LOCAL_AUTHORITY_EMAIL_ADDRESS, expectedParameters,

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/SubmittedCaseEventHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/SubmittedCaseEventHandlerTest.java
@@ -22,7 +22,6 @@ import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.event.EventData;
 import uk.gov.hmcts.reform.fpl.model.notify.submittedcase.SubmitCaseCafcassTemplate;
 import uk.gov.hmcts.reform.fpl.model.notify.submittedcase.SubmitCaseHmctsTemplate;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 import uk.gov.hmcts.reform.fpl.service.FeatureToggleService;
 import uk.gov.hmcts.reform.fpl.service.email.NotificationService;
 import uk.gov.hmcts.reform.fpl.service.email.content.CafcassEmailContentProvider;
@@ -52,9 +51,6 @@ class SubmittedCaseEventHandlerTest {
 
     @Mock
     private ObjectMapper mapper;
-
-    @Mock
-    private RequestData requestData;
 
     @Mock
     private NotificationService notificationService;
@@ -88,7 +84,7 @@ class SubmittedCaseEventHandlerTest {
         final String expectedEmail = "test@test.com";
         final CallbackRequest request = callbackRequest(OPEN);
         final SubmitCaseHmctsTemplate expectedTemplate = new SubmitCaseHmctsTemplate();
-        final SubmittedCaseEvent submittedCaseEvent = new SubmittedCaseEvent(request, requestData);
+        final SubmittedCaseEvent submittedCaseEvent = new SubmittedCaseEvent(request);
 
         when(adminNotificationHandler.getHmctsAdminEmail(new EventData(submittedCaseEvent))).thenReturn(expectedEmail);
         when(hmctsEmailContentProvider.buildHmctsSubmissionNotification(request.getCaseDetails(), LOCAL_AUTHORITY_CODE))
@@ -110,7 +106,7 @@ class SubmittedCaseEventHandlerTest {
         final CafcassLookupConfiguration.Cafcass cafcass =
             new CafcassLookupConfiguration.Cafcass(LOCAL_AUTHORITY_CODE, expectedEmail);
         final SubmitCaseCafcassTemplate expectedTemplate = new SubmitCaseCafcassTemplate();
-        final SubmittedCaseEvent submittedCaseEvent = new SubmittedCaseEvent(request, requestData);
+        final SubmittedCaseEvent submittedCaseEvent = new SubmittedCaseEvent(request);
 
         when(cafcassLookupConfiguration.getCafcass(LOCAL_AUTHORITY_CODE)).thenReturn(cafcass);
         when(cafcassEmailContentProvider.buildCafcassSubmissionNotification(request.getCaseDetails(),
@@ -139,7 +135,7 @@ class SubmittedCaseEventHandlerTest {
         void shouldNotPayIfPaymentIsToggledOff() {
             final CallbackRequest request = callbackRequest(OPEN);
 
-            final SubmittedCaseEvent submittedCaseEvent = new SubmittedCaseEvent(request, requestData);
+            final SubmittedCaseEvent submittedCaseEvent = new SubmittedCaseEvent(request);
 
             when(featureToggleService.isPaymentsEnabled()).thenReturn(false);
 
@@ -152,7 +148,7 @@ class SubmittedCaseEventHandlerTest {
         @EnumSource(value = State.class, mode = EXCLUDE, names = {"OPEN"})
         void shouldNotPayIfCaseStateIsDifferentThanOpen(State state) {
             final CallbackRequest request = callbackRequest(state);
-            final SubmittedCaseEvent submittedCaseEvent = new SubmittedCaseEvent(request, requestData);
+            final SubmittedCaseEvent submittedCaseEvent = new SubmittedCaseEvent(request);
 
             when(featureToggleService.isPaymentsEnabled()).thenReturn(true);
 
@@ -164,7 +160,7 @@ class SubmittedCaseEventHandlerTest {
         @Test
         void shouldNotPayAndNotEmitFailureEventIfPaymentDecisionIsNotPresent() {
             final CallbackRequest request = callbackRequest(OPEN, emptyMap());
-            final SubmittedCaseEvent submittedCaseEvent = new SubmittedCaseEvent(request, requestData);
+            final SubmittedCaseEvent submittedCaseEvent = new SubmittedCaseEvent(request);
 
             when(featureToggleService.isPaymentsEnabled()).thenReturn(true);
 
@@ -176,7 +172,7 @@ class SubmittedCaseEventHandlerTest {
         @Test
         void shouldNotPayAndEmitFailureEventIfPaymentDecisionsIsNo() {
             final CallbackRequest request = callbackRequest(OPEN, Map.of("displayAmountToPay", "No"));
-            final SubmittedCaseEvent submittedCaseEvent = new SubmittedCaseEvent(request, requestData);
+            final SubmittedCaseEvent submittedCaseEvent = new SubmittedCaseEvent(request);
 
             when(featureToggleService.isPaymentsEnabled()).thenReturn(true);
 
@@ -190,7 +186,7 @@ class SubmittedCaseEventHandlerTest {
         @Test
         void shouldEmitFailureEventWhenPaymentFailed() {
             final CallbackRequest request = callbackRequest(OPEN, Map.of("displayAmountToPay", "Yes"));
-            final SubmittedCaseEvent submittedCaseEvent = new SubmittedCaseEvent(request, requestData);
+            final SubmittedCaseEvent submittedCaseEvent = new SubmittedCaseEvent(request);
             final Exception exception = new PaymentsApiException("", new RuntimeException());
             when(featureToggleService.isPaymentsEnabled()).thenReturn(true);
             doThrow(exception).when(paymentService).makePaymentForCaseOrders(1L, caseData);
@@ -204,7 +200,7 @@ class SubmittedCaseEventHandlerTest {
         @Test
         void shouldPayWhenPaymentIsToggledOnAndCaseIsOpenedAndPaymentDesicionIsYes() {
             final CallbackRequest request = callbackRequest(OPEN, Map.of("displayAmountToPay", "Yes"));
-            final SubmittedCaseEvent submittedCaseEvent = new SubmittedCaseEvent(request, requestData);
+            final SubmittedCaseEvent submittedCaseEvent = new SubmittedCaseEvent(request);
 
             when(featureToggleService.isPaymentsEnabled()).thenReturn(true);
 

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/CaseManagementOrderProgressionServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/CaseManagementOrderProgressionServiceTest.java
@@ -22,7 +22,6 @@ import uk.gov.hmcts.reform.fpl.model.OrderAction;
 import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
 import uk.gov.hmcts.reform.fpl.model.common.dynamic.DynamicList;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -58,9 +57,6 @@ class CaseManagementOrderProgressionServiceTest {
     @Mock
     private ApplicationEventPublisher applicationEventPublisher;
 
-    @Mock
-    private RequestData requestData;
-
     private CaseManagementOrderProgressionService service;
 
     @MockBean
@@ -68,8 +64,7 @@ class CaseManagementOrderProgressionServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new CaseManagementOrderProgressionService(mapper, applicationEventPublisher, requestData,
-            documentDownloadService);
+        service = new CaseManagementOrderProgressionService(mapper, applicationEventPublisher, documentDownloadService);
     }
 
     @Test


### PR DESCRIPTION
RequestData can be injected in normal way in event handlers (@Async also)