### PR TITLE
chore: resolve plugin id 'org.sonarqube' not found error

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -5,7 +5,7 @@ plugins {
   id 'io.spring.dependency-management' version '1.0.9.RELEASE'
   id 'org.springframework.boot' version '2.3.0.RELEASE'
   id 'com.github.ben-manes.versions' version '0.28.0'
-  id 'org.sonarqube' version '3.0'
+  id 'org.sonarqube' version '2.8'
   id 'project-report'
 }
 
@@ -207,7 +207,7 @@ dependencies {
 
   compile group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
   compile group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger
-  
+
   compile group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version: '0.0.4'
   compile group: 'uk.gov.hmcts.reform', name: 'logging', version: versions.reformLogging
   compile group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: versions.reformLogging


### PR DESCRIPTION
### JIRA link (if applicable) ###
NA


### Change description ###
Resolve the below error. Also, [here](https://plugins.gradle.org/plugin/org.sonarqube) plugin is 2.8
```
Plugin [id: 'org.sonarqube', version: '3.0'] was not found in any of the following sources:

- Gradle Core Plugins (plugin is not in 'org.gradle' namespace)
- Plugin Repositories (could not resolve plugin artifact 'org.sonarqube:org.sonarqube.gradle.plugin:3.0')
  Searched in the following repositories:
    Gradle Central Plugin Repository
```


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
