### PR TITLE
impr: remove raw type warnings

### DIFF
--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/PlacementAboutToSubmitControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/PlacementAboutToSubmitControllerTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.fpl.controllers;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -112,8 +113,8 @@ class PlacementAboutToSubmitControllerTest extends AbstractControllerTest {
             .isEqualTo(expectedPlacementWithoutConfidentialDocuments(childPlacement, childApplication));
     }
 
-    private List convertToList(Map<String, Object> updatedCaseDetails, String string) {
-        return mapper.convertValue(updatedCaseDetails.get(string), List.class);
+    private List<?> convertToList(Map<String, Object> updatedCaseDetails, String string) {
+        return mapper.convertValue(updatedCaseDetails.get(string), new TypeReference<>() {});
     }
 
     private Placement placement(Element<Child> child, DocumentReference application) {

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/PlacementAboutToSubmitControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/PlacementAboutToSubmitControllerTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.fpl.controllers;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -114,7 +113,7 @@ class PlacementAboutToSubmitControllerTest extends AbstractControllerTest {
     }
 
     private List<?> convertToList(Map<String, Object> updatedCaseDetails, String string) {
-        return mapper.convertValue(updatedCaseDetails.get(string), new TypeReference<>() {});
+        return mapper.convertValue(updatedCaseDetails.get(string), List.class);
     }
 
     private Placement placement(Element<Child> child, DocumentReference application) {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/docmosis/BlankOrderGenerationService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/docmosis/BlankOrderGenerationService.java
@@ -20,7 +20,7 @@ public class BlankOrderGenerationService extends GeneratedOrderTemplateDataGener
     }
 
     @Override
-    DocmosisGeneratedOrderBuilder populateCustomOrderFields(CaseData caseData) {
+    DocmosisGeneratedOrderBuilder<?, ?> populateCustomOrderFields(CaseData caseData) {
         return DocmosisGeneratedOrder.builder()
             .orderTitle(defaultIfNull(caseData.getOrder().getTitle(), "Order"))
             .childrenAct("Children Act 1989")

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/docmosis/BlankOrderGenerationService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/docmosis/BlankOrderGenerationService.java
@@ -19,8 +19,9 @@ public class BlankOrderGenerationService extends GeneratedOrderTemplateDataGener
         super(caseDataExtractionService, localAuthorityNameLookupConfiguration);
     }
 
+    @SuppressWarnings("rawtypes")
     @Override
-    DocmosisGeneratedOrderBuilder<?, ?> populateCustomOrderFields(CaseData caseData) {
+    DocmosisGeneratedOrderBuilder populateCustomOrderFields(CaseData caseData) {
         return DocmosisGeneratedOrder.builder()
             .orderTitle(defaultIfNull(caseData.getOrder().getTitle(), "Order"))
             .childrenAct("Children Act 1989")

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/docmosis/CareOrderGenerationService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/docmosis/CareOrderGenerationService.java
@@ -23,8 +23,9 @@ public class CareOrderGenerationService extends GeneratedOrderTemplateDataGenera
         super(caseDataExtractionService, localAuthorityNameLookupConfiguration);
     }
 
+    @SuppressWarnings("rawtypes")
     @Override
-    DocmosisGeneratedOrderBuilder<?, ?> populateCustomOrderFields(CaseData caseData) {
+    DocmosisGeneratedOrderBuilder populateCustomOrderFields(CaseData caseData) {
         OrderTypeAndDocument orderTypeAndDocument = caseData.getOrderTypeAndDocument();
         GeneratedOrderSubtype subtype = orderTypeAndDocument.getSubtype();
         InterimEndDate interimEndDate = caseData.getInterimEndDate();

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/docmosis/CareOrderGenerationService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/docmosis/CareOrderGenerationService.java
@@ -24,7 +24,7 @@ public class CareOrderGenerationService extends GeneratedOrderTemplateDataGenera
     }
 
     @Override
-    DocmosisGeneratedOrderBuilder populateCustomOrderFields(CaseData caseData) {
+    DocmosisGeneratedOrderBuilder<?, ?> populateCustomOrderFields(CaseData caseData) {
         OrderTypeAndDocument orderTypeAndDocument = caseData.getOrderTypeAndDocument();
         GeneratedOrderSubtype subtype = orderTypeAndDocument.getSubtype();
         InterimEndDate interimEndDate = caseData.getInterimEndDate();

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/docmosis/EPOGenerationService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/docmosis/EPOGenerationService.java
@@ -28,8 +28,9 @@ public class EPOGenerationService extends GeneratedOrderTemplateDataGeneration {
         this.time = time;
     }
 
+    @SuppressWarnings("rawtypes")
     @Override
-    DocmosisGeneratedOrderBuilder<?, ?> populateCustomOrderFields(CaseData caseData) {
+    DocmosisGeneratedOrderBuilder populateCustomOrderFields(CaseData caseData) {
         return DocmosisGeneratedOrder.builder()
             .localAuthorityName(getLocalAuthorityName(caseData.getCaseLocalAuthority()))
             .childrenDescription(getChildrenDescription(caseData.getEpoChildren()))

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/docmosis/EPOGenerationService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/docmosis/EPOGenerationService.java
@@ -29,7 +29,7 @@ public class EPOGenerationService extends GeneratedOrderTemplateDataGeneration {
     }
 
     @Override
-    DocmosisGeneratedOrderBuilder populateCustomOrderFields(CaseData caseData) {
+    DocmosisGeneratedOrderBuilder<?, ?> populateCustomOrderFields(CaseData caseData) {
         return DocmosisGeneratedOrder.builder()
             .localAuthorityName(getLocalAuthorityName(caseData.getCaseLocalAuthority()))
             .childrenDescription(getChildrenDescription(caseData.getEpoChildren()))

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/docmosis/GeneratedOrderTemplateDataGeneration.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/docmosis/GeneratedOrderTemplateDataGeneration.java
@@ -41,7 +41,9 @@ public abstract class GeneratedOrderTemplateDataGeneration
         this.localAuthorityNameLookupConfiguration = localAuthorityNameLookupConfiguration;
     }
 
-    abstract DocmosisGeneratedOrderBuilder<?, ?> populateCustomOrderFields(CaseData caseData);
+    // If we use <?, ?> there is then an issue with sonar complaining about not using wildcard types as return types
+    @SuppressWarnings("rawtypes")
+    abstract DocmosisGeneratedOrderBuilder populateCustomOrderFields(CaseData caseData);
 
     @Override
     public DocmosisGeneratedOrder getTemplateData(CaseData caseData) {
@@ -88,7 +90,7 @@ public abstract class GeneratedOrderTemplateDataGeneration
     }
 
     List<Element<Child>> getSelectedChildren(List<Element<Child>> allChildren, ChildSelector selector,
-        String choice) {
+                                             String choice) {
         if (useAllChildren(choice)) {
             return allChildren;
         }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/docmosis/GeneratedOrderTemplateDataGeneration.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/docmosis/GeneratedOrderTemplateDataGeneration.java
@@ -41,7 +41,7 @@ public abstract class GeneratedOrderTemplateDataGeneration
         this.localAuthorityNameLookupConfiguration = localAuthorityNameLookupConfiguration;
     }
 
-    abstract DocmosisGeneratedOrderBuilder populateCustomOrderFields(CaseData caseData);
+    abstract DocmosisGeneratedOrderBuilder<?, ?> populateCustomOrderFields(CaseData caseData);
 
     @Override
     public DocmosisGeneratedOrder getTemplateData(CaseData caseData) {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/docmosis/SupervisionOrderGenerationService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/docmosis/SupervisionOrderGenerationService.java
@@ -33,8 +33,9 @@ public class SupervisionOrderGenerationService extends GeneratedOrderTemplateDat
         this.time = time;
     }
 
+    @SuppressWarnings("rawtypes")
     @Override
-    DocmosisGeneratedOrderBuilder<?, ?> populateCustomOrderFields(CaseData caseData) {
+    DocmosisGeneratedOrderBuilder populateCustomOrderFields(CaseData caseData) {
         OrderTypeAndDocument orderTypeAndDocument = caseData.getOrderTypeAndDocument();
         GeneratedOrderSubtype subtype = orderTypeAndDocument.getSubtype();
         InterimEndDate interimEndDate = caseData.getInterimEndDate();

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/docmosis/SupervisionOrderGenerationService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/docmosis/SupervisionOrderGenerationService.java
@@ -34,7 +34,7 @@ public class SupervisionOrderGenerationService extends GeneratedOrderTemplateDat
     }
 
     @Override
-    DocmosisGeneratedOrderBuilder populateCustomOrderFields(CaseData caseData) {
+    DocmosisGeneratedOrderBuilder<?, ?> populateCustomOrderFields(CaseData caseData) {
         OrderTypeAndDocument orderTypeAndDocument = caseData.getOrderTypeAndDocument();
         GeneratedOrderSubtype subtype = orderTypeAndDocument.getSubtype();
         InterimEndDate interimEndDate = caseData.getInterimEndDate();

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/docmosis/AbstractOrderGenerationServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/docmosis/AbstractOrderGenerationServiceTest.java
@@ -37,7 +37,7 @@ public abstract class AbstractOrderGenerationServiceTest {
 
     abstract CaseData.CaseDataBuilder populateCustomCaseData(GeneratedOrderSubtype subtype);
 
-    abstract DocmosisGeneratedOrderBuilder populateCustomOrderFields(GeneratedOrderSubtype subtype);
+    abstract DocmosisGeneratedOrderBuilder<?, ?> populateCustomOrderFields(GeneratedOrderSubtype subtype);
 
     CaseData createPopulatedCaseData(OrderStatus orderStatus) {
         return createPopulatedCaseData(null, orderStatus);

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/docmosis/AbstractOrderGenerationServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/docmosis/AbstractOrderGenerationServiceTest.java
@@ -37,7 +37,9 @@ public abstract class AbstractOrderGenerationServiceTest {
 
     abstract CaseData.CaseDataBuilder populateCustomCaseData(GeneratedOrderSubtype subtype);
 
-    abstract DocmosisGeneratedOrderBuilder<?, ?> populateCustomOrderFields(GeneratedOrderSubtype subtype);
+    // See comment in GeneratedOrderTemplateDataGeneration
+    @SuppressWarnings("rawtypes")
+    abstract DocmosisGeneratedOrderBuilder populateCustomOrderFields(GeneratedOrderSubtype subtype);
 
     CaseData createPopulatedCaseData(OrderStatus orderStatus) {
         return createPopulatedCaseData(null, orderStatus);

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/docmosis/BlankOrderGenerationServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/docmosis/BlankOrderGenerationServiceTest.java
@@ -71,7 +71,7 @@ class BlankOrderGenerationServiceTest extends AbstractOrderGenerationServiceTest
     }
 
     @Override
-    DocmosisGeneratedOrderBuilder populateCustomOrderFields(GeneratedOrderSubtype subtype) {
+    DocmosisGeneratedOrderBuilder<?, ?> populateCustomOrderFields(GeneratedOrderSubtype subtype) {
         return createOrderBuilder("Example Title", "Children Act 1989",
             "Example details", getChildren()).orderType(BLANK_ORDER);
     }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/docmosis/BlankOrderGenerationServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/docmosis/BlankOrderGenerationServiceTest.java
@@ -70,8 +70,9 @@ class BlankOrderGenerationServiceTest extends AbstractOrderGenerationServiceTest
             .orderAppliesToAllChildren(YES.getValue());
     }
 
+    @SuppressWarnings("rawtypes")
     @Override
-    DocmosisGeneratedOrderBuilder<?, ?> populateCustomOrderFields(GeneratedOrderSubtype subtype) {
+    DocmosisGeneratedOrderBuilder populateCustomOrderFields(GeneratedOrderSubtype subtype) {
         return createOrderBuilder("Example Title", "Children Act 1989",
             "Example details", getChildren()).orderType(BLANK_ORDER);
     }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/docmosis/CareOrderGenerationServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/docmosis/CareOrderGenerationServiceTest.java
@@ -98,8 +98,9 @@ class CareOrderGenerationServiceTest extends AbstractOrderGenerationServiceTest 
         return caseDataBuilder;
     }
 
+    @SuppressWarnings("rawtypes")
     @Override
-    DocmosisGeneratedOrderBuilder<?, ?> populateCustomOrderFields(GeneratedOrderSubtype subtype) {
+    DocmosisGeneratedOrderBuilder populateCustomOrderFields(GeneratedOrderSubtype subtype) {
         List<DocmosisChild> children = getChildren();
         DocmosisGeneratedOrderBuilder<?,?> orderBuilder = DocmosisGeneratedOrder.builder();
         if (subtype == INTERIM) {

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/docmosis/CareOrderGenerationServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/docmosis/CareOrderGenerationServiceTest.java
@@ -99,7 +99,7 @@ class CareOrderGenerationServiceTest extends AbstractOrderGenerationServiceTest 
     }
 
     @Override
-    DocmosisGeneratedOrderBuilder populateCustomOrderFields(GeneratedOrderSubtype subtype) {
+    DocmosisGeneratedOrderBuilder<?, ?> populateCustomOrderFields(GeneratedOrderSubtype subtype) {
         List<DocmosisChild> children = getChildren();
         DocmosisGeneratedOrderBuilder<?,?> orderBuilder = DocmosisGeneratedOrder.builder();
         if (subtype == INTERIM) {

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/docmosis/EPOGenerationServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/docmosis/EPOGenerationServiceTest.java
@@ -92,7 +92,7 @@ class EPOGenerationServiceTest extends AbstractOrderGenerationServiceTest {
     }
 
     @Override
-    DocmosisGeneratedOrderBuilder populateCustomOrderFields(GeneratedOrderSubtype subtype) {
+    DocmosisGeneratedOrderBuilder<?, ?> populateCustomOrderFields(GeneratedOrderSubtype subtype) {
         return DocmosisGeneratedOrder.builder()
             .orderType(EMERGENCY_PROTECTION_ORDER)
             .localAuthorityName(LOCAL_AUTHORITY_NAME)

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/docmosis/EPOGenerationServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/docmosis/EPOGenerationServiceTest.java
@@ -91,8 +91,9 @@ class EPOGenerationServiceTest extends AbstractOrderGenerationServiceTest {
             .orderAppliesToAllChildren(YES.getValue());
     }
 
+    @SuppressWarnings("rawtypes")
     @Override
-    DocmosisGeneratedOrderBuilder<?, ?> populateCustomOrderFields(GeneratedOrderSubtype subtype) {
+    DocmosisGeneratedOrderBuilder populateCustomOrderFields(GeneratedOrderSubtype subtype) {
         return DocmosisGeneratedOrder.builder()
             .orderType(EMERGENCY_PROTECTION_ORDER)
             .localAuthorityName(LOCAL_AUTHORITY_NAME)

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/docmosis/SupervisionOrderGenerationServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/docmosis/SupervisionOrderGenerationServiceTest.java
@@ -107,7 +107,7 @@ class SupervisionOrderGenerationServiceTest extends AbstractOrderGenerationServi
     }
 
     @Override
-    DocmosisGeneratedOrderBuilder populateCustomOrderFields(GeneratedOrderSubtype subtype) {
+    DocmosisGeneratedOrderBuilder<?, ?> populateCustomOrderFields(GeneratedOrderSubtype subtype) {
         String formattedDate = formatLocalDateToString(time.now().toLocalDate(), FormatStyle.LONG);
 
         ImmutableList<DocmosisChild> children = ImmutableList.of(

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/docmosis/SupervisionOrderGenerationServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/docmosis/SupervisionOrderGenerationServiceTest.java
@@ -106,8 +106,9 @@ class SupervisionOrderGenerationServiceTest extends AbstractOrderGenerationServi
         return caseDataBuilder;
     }
 
+    @SuppressWarnings("rawtypes")
     @Override
-    DocmosisGeneratedOrderBuilder<?, ?> populateCustomOrderFields(GeneratedOrderSubtype subtype) {
+    DocmosisGeneratedOrderBuilder populateCustomOrderFields(GeneratedOrderSubtype subtype) {
         String formattedDate = formatLocalDateToString(time.now().toLocalDate(), FormatStyle.LONG);
 
         ImmutableList<DocmosisChild> children = ImmutableList.of(

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/utils/assertions/AnnotationAssertion.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/utils/assertions/AnnotationAssertion.java
@@ -11,13 +11,13 @@ import static java.util.Objects.nonNull;
 import static java.util.stream.Collectors.toSet;
 import static org.junit.platform.commons.util.ReflectionUtils.findMethods;
 
-public class AnnotationAssertion extends AbstractAssert<AnnotationAssertion, Class> {
+public class AnnotationAssertion extends AbstractAssert<AnnotationAssertion, Class<?>> {
 
-    AnnotationAssertion(Class actual) {
+    AnnotationAssertion(Class<?> actual) {
         super(actual, AnnotationAssertion.class);
     }
 
-    public static AnnotationAssertion assertClass(Class actual) {
+    public static AnnotationAssertion assertClass(Class<?> actual) {
         return new AnnotationAssertion(actual);
     }
 

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/validation/AbstractValidationTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/validation/AbstractValidationTest.java
@@ -19,7 +19,7 @@ public abstract class AbstractValidationTest {
     @Autowired
     private Validator validator;
 
-    public <T> List<String> validate(T object, Class... groups) {
+    public <T> List<String> validate(T object, Class<?>... groups) {
         return validator.validate(object, groups).stream().map(ConstraintViolation::getMessage).collect(toList());
     }
 


### PR DESCRIPTION
### Change description ###

Removed instances of raw type warnings. Can check by adding `-Xlint:rawtypes` to

```gradle
tasks.withType(JavaCompile) {
  options.compilerArgs << "-Xlint:unchecked" << "-Werror"
}
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
