### PR TITLE
fix: close case judiciary permission

### DIFF
--- a/ccd-definition/AuthorisationCaseField/judiciary.json
+++ b/ccd-definition/AuthorisationCaseField/judiciary.json
@@ -562,6 +562,34 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseFieldID": "closeCaseTabField",
+    "UserRole": "caseworker-publiclaw-judiciary",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseFieldID": "closeCaseFromOrder",
+    "UserRole": "caseworker-publiclaw-judiciary",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseFieldID": "showCloseCaseFromOrderPage",
+    "UserRole": "caseworker-publiclaw-judiciary",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseFieldID": "state",
+    "UserRole": "caseworker-publiclaw-judiciary",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
     "CaseFieldID": "documents_socialWorkChronology_document",
     "UserRole": "caseworker-publiclaw-judiciary",
     "CRUD": "R"


### PR DESCRIPTION
### Change description ###

During [FPLA-1747](https://tools.hmcts.net/jira/browse/FPLA-1747) I noticed that I had forgotten to give the judiciary user role permissions to the relevant close case fields for the create order event as part of [FPLA-1605](https://tools.hmcts.net/jira/browse/FPLA-1605).
Seeing as the judiciary role has permissions to access the create order event these have been duplicated so that it doens't break for those users that only have `judiciary` and not `admin`.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
