### PR TITLE
Rename internal-changeState to avoid double-encoding bug

### DIFF
--- a/ccd-definition/AuthorisationCaseEvent/AuthorisationCaseEvent.json
+++ b/ccd-definition/AuthorisationCaseEvent/AuthorisationCaseEvent.json
@@ -492,7 +492,7 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "CaseEventID": "internal-changeState:Gatekeeping->PREPARE_FOR_HEARING",
+    "CaseEventID": "internal-changeState-Gatekeeping->PREPARE_FOR_HEARING",
     "UserRole": "caseworker-publiclaw-systemupdate",
     "CRUD": "C"
   },

--- a/ccd-definition/CaseEvent/StateChange.json
+++ b/ccd-definition/CaseEvent/StateChange.json
@@ -69,7 +69,7 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "ID": "internal-changeState:Gatekeeping->PREPARE_FOR_HEARING",
+    "ID": "internal-changeState-Gatekeeping->PREPARE_FOR_HEARING",
     "Name": "-",
     "PreConditionState(s)": "Gatekeeping",
     "PostConditionState": "PREPARE_FOR_HEARING",

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/DraftOrdersControllerSubmittedTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/DraftOrdersControllerSubmittedTest.java
@@ -41,7 +41,7 @@ import static uk.gov.hmcts.reform.fpl.service.HearingBookingService.HEARING_DETA
 @OverrideAutoConfiguration(enabled = true)
 public class DraftOrdersControllerSubmittedTest extends AbstractControllerTest {
     private static final Long CASE_ID = 1L;
-    private static final String PREPARE_FOR_HEARING_EVENT = "internal-changeState:Gatekeeping->PREPARE_FOR_HEARING";
+    private static final String PREPARE_FOR_HEARING_EVENT = "internal-changeState-Gatekeeping->PREPARE_FOR_HEARING";
     private static final String SEND_DOCUMENT_EVENT = "internal-change-SEND_DOCUMENT";
     private static final DocumentReference DOCUMENT_REFERENCE = DocumentReference.builder().build();
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/DraftOrdersController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/DraftOrdersController.java
@@ -224,7 +224,7 @@ public class DraftOrdersController {
             callbackRequest.getCaseDetails().getJurisdiction(),
             callbackRequest.getCaseDetails().getCaseTypeId(),
             callbackRequest.getCaseDetails().getId(),
-            "internal-changeState:Gatekeeping->PREPARE_FOR_HEARING"
+            "internal-changeState-Gatekeeping->PREPARE_FOR_HEARING"
         );
 
         if (standardDirectionOrder.getOrderStatus() == SEALED) {


### PR DESCRIPTION
### Change description ###

Added missing internal-change state change
(rename from internal-changeState: to internal-changeState-

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
