### PR TITLE
impr: remove "by unknown" from SDO (FPLA-1887)

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/CaseDataExtractionService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/CaseDataExtractionService.java
@@ -34,7 +34,6 @@ import static java.time.format.FormatStyle.LONG;
 import static java.util.Collections.emptyList;
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toList;
-import static org.apache.commons.lang3.StringUtils.lowerCase;
 import static org.apache.commons.lang3.StringUtils.trim;
 import static uk.gov.hmcts.reform.fpl.model.configuration.Display.Due.BY;
 import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.DATE_TIME;
@@ -158,10 +157,16 @@ public class CaseDataExtractionService {
         }
 
         // create direction display title for docmosis in format "index. directionTitle (by / on) date"
-        return format("%d. %s %s %s", index, direction.getDirectionType(), lowerCase(config.due.toString()),
-            ofNullable(direction.getDateToBeCompletedBy())
-                .map(date -> formatLocalDateTimeBaseUsingFormat(date, config.pattern))
-                .orElse("unknown"));
+        return format("%d. %s %s", index, direction.getDirectionType(),
+            buildDate(direction.getDateToBeCompletedBy(), config.pattern, config.due)).trim();
+    }
+
+    private String buildDate(LocalDateTime date, String pattern, Display.Due due) {
+        if (date == null) {
+            return "";
+        }
+
+        return due.toString().toLowerCase() + " " + formatLocalDateTimeBaseUsingFormat(date, pattern);
     }
 
     private DocmosisHearingBooking buildHearingBooking(HearingBooking hearing) {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/CaseDataExtractionService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/CaseDataExtractionService.java
@@ -156,12 +156,12 @@ public class CaseDataExtractionService {
             }
         }
 
-        // create direction display title for docmosis in format "index. directionTitle (by / on) date"
+        // create direction display title for docmosis in format "index. directionTitle [(by / on) date]"
         return format("%d. %s %s", index, direction.getDirectionType(),
-            buildDate(direction.getDateToBeCompletedBy(), config.pattern, config.due)).trim();
+            formatTitleDate(direction.getDateToBeCompletedBy(), config.pattern, config.due)).trim();
     }
 
-    private String buildDate(LocalDateTime date, String pattern, Display.Due due) {
+    private String formatTitleDate(LocalDateTime date, String pattern, Display.Due due) {
         if (date == null) {
             return "";
         }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/CaseDataExtractionServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/CaseDataExtractionServiceTest.java
@@ -285,7 +285,7 @@ class CaseDataExtractionServiceTest {
         assertThat(service.baseDirection(direction, 1))
             .isEqualToComparingFieldByField(DocmosisDirection.builder()
                 .assignee(DirectionAssignee.LOCAL_AUTHORITY)
-                .title("1. Example title by unknown")
+                .title("1. Example title")
                 .body("Example description"));
     }
 

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/docmosis/StandardDirectionOrderGenerationServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/docmosis/StandardDirectionOrderGenerationServiceTest.java
@@ -273,7 +273,7 @@ class StandardDirectionOrderGenerationServiceTest {
 
         return getDirections().stream()
             .map(direction -> DocmosisDirection.builder()
-                .title(at.getAndIncrement() + ". " + direction.getValue().getDirectionType() + " by unknown")
+                .title(at.getAndIncrement() + ". " + direction.getValue().getDirectionType())
                 .assignee(direction.getValue().getAssignee())
                 .build())
             .collect(toList());


### PR DESCRIPTION
### JIRA link (if applicable) ###

[FPLA-1887](https://tools.hmcts.net/jira/browse/FPLA-1887)

### Change description ###

alter `formatTile(...)` in `CaseDataExtractionService` to no longer add "unknown" to directions that don't have a date added.

![image](https://user-images.githubusercontent.com/22620804/84767998-59eabf80-afcb-11ea-93e3-5e3d663712ca.png)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
