### PR TITLE
fix: flaky delete application test

### DIFF
--- a/e2e/tests/localAuthorityDeletesApplication_test.js
+++ b/e2e/tests/localAuthorityDeletesApplication_test.js
@@ -28,7 +28,8 @@ Scenario('local authority tries to submit incomplete case', async (I, caseViewPa
 Scenario('local authority deletes application', async (I, caseViewPage, deleteApplicationEventPage, caseListPage) => {
   await caseViewPage.goToNewActions(config.applicationActions.deleteApplication);
   deleteApplicationEventPage.tickDeletionConsent();
-  await I.completeEvent('Delete application');
+  await I.retryUntilExists(() => I.click('Continue'), '.check-your-answers');
+  await I.retryUntilExists(() => I.click('Delete application'), '.search-block');
   await caseListPage.searchForCasesWithName(caseName);
   I.see('No cases found.');
 });


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Update the delete application test to no longer look for the `.alert-success` green banner.
With the update to no one having access to the cases in the deleted states, unless the system is running slow the green banner will not be visible for long enough and instead the page will automatically change to the case list page.
The e2e test has been updated to reflect this.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
