### PR TITLE
fix:Fix request data in async task issue

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/request/CacheAwareRequestData.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/request/CacheAwareRequestData.java
@@ -1,0 +1,39 @@
+package uk.gov.hmcts.reform.fpl.request;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.fpl.config.AsyncConfiguration;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ Access http request related attributes.
+ Uses ThreadLocalCache as a cache to avoid accessing http request from spawned threads
+ (http request can be already closed at the time when new thread access it)
+ @see AsyncConfiguration.AsyncTaskDecorator
+*/
+
+@Primary
+@Service
+public class CacheAwareRequestData implements RequestData {
+
+    private final HttpServletRequest httpServletRequest;
+
+    @Autowired
+    public CacheAwareRequestData(HttpServletRequest httpServletRequest) {
+        this.httpServletRequest = httpServletRequest;
+    }
+
+    public String authorisation() {
+        return RequestDataCache.get()
+            .map(RequestData::authorisation)
+            .orElseGet(() -> httpServletRequest.getHeader("authorization"));
+    }
+
+    public String userId() {
+        return RequestDataCache.get()
+            .map(RequestData::userId)
+            .orElseGet(() -> httpServletRequest.getHeader("user-id"));
+    }
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/request/RequestData.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/request/RequestData.java
@@ -1,25 +1,8 @@
 package uk.gov.hmcts.reform.fpl.request;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
+public interface RequestData {
 
-import javax.servlet.http.HttpServletRequest;
+    String authorisation();
 
-@Service
-public class RequestData {
-
-    private final HttpServletRequest httpServletRequest;
-
-    @Autowired
-    public RequestData(HttpServletRequest httpServletRequest) {
-        this.httpServletRequest = httpServletRequest;
-    }
-
-    public String authorisation() {
-        return httpServletRequest.getHeader("authorization");
-    }
-
-    public String userId() {
-        return httpServletRequest.getHeader("user-id");
-    }
+    String userId();
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/request/RequestDataCache.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/request/RequestDataCache.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.reform.fpl.request;
+
+import java.util.Optional;
+
+public class RequestDataCache {
+    private static final ThreadLocal<SimpleRequestData> REQUEST_DATA_THREAD_LOCAL = new ThreadLocal<>();
+
+    private RequestDataCache() {
+    }
+
+    public static void add(SimpleRequestData requestData) {
+        REQUEST_DATA_THREAD_LOCAL.set(new SimpleRequestData(requestData));
+    }
+
+    public static void remove() {
+        REQUEST_DATA_THREAD_LOCAL.remove();
+    }
+
+    public static Optional<RequestData> get() {
+        return Optional.ofNullable(REQUEST_DATA_THREAD_LOCAL.get());
+    }
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/request/SimpleRequestData.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/request/SimpleRequestData.java
@@ -1,0 +1,26 @@
+package uk.gov.hmcts.reform.fpl.request;
+
+public class SimpleRequestData implements RequestData {
+
+    private final String authorisation;
+    private final String userId;
+
+    public SimpleRequestData(RequestData requestData) {
+        this(requestData.authorisation(), requestData.userId());
+    }
+
+    public SimpleRequestData(String authorisation, String userId) {
+        this.authorisation = authorisation;
+        this.userId = userId;
+    }
+
+    @Override
+    public String authorisation() {
+        return authorisation;
+    }
+
+    @Override
+    public String userId() {
+        return userId;
+    }
+}

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/request/RequestDataTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/request/RequestDataTest.java
@@ -1,5 +1,8 @@
 package uk.gov.hmcts.reform.fpl.request;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -9,28 +12,63 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import javax.servlet.http.HttpServletRequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 class RequestDataTest {
     private static final String AUTH_TOKEN = "Bearer token";
+    private static final String CACHED_AUTH_TOKEN = "Cached bearer token";
     private static final String USER_ID = "example.gov.uk";
+    private static final String CACHED_USER_ID = "cached.gov.uk";
 
     @Mock
     private HttpServletRequest httpServletRequest;
 
     @InjectMocks
-    private RequestData requestData;
+    private CacheAwareRequestData requestData;
 
-    @Test
-    public void shouldReturnAuthorisationHeaderFromRequest() {
-        when(httpServletRequest.getHeader("authorization")).thenReturn(AUTH_TOKEN);
-        assertThat(requestData.authorisation()).isEqualTo(AUTH_TOKEN);
+    @Nested
+    class NotCachedRequestData {
+
+        @Test
+        void shouldReturnAuthorisationHeaderFromRequest() {
+            when(httpServletRequest.getHeader("authorization")).thenReturn(AUTH_TOKEN);
+            assertThat(requestData.authorisation()).isEqualTo(AUTH_TOKEN);
+        }
+
+        @Test
+        void shouldReturnUserIdFromRequest() {
+            when(httpServletRequest.getHeader("user-id")).thenReturn(USER_ID);
+            assertThat(requestData.userId()).isEqualTo(USER_ID);
+        }
     }
 
-    @Test
-    public void shouldReturnUserIdFromRequest() {
-        when(httpServletRequest.getHeader("user-id")).thenReturn(USER_ID);
-        assertThat(requestData.userId()).isEqualTo(USER_ID);
+    @Nested
+    class CachedRequestData {
+
+        final SimpleRequestData cachedRequestData = new SimpleRequestData(CACHED_AUTH_TOKEN, CACHED_USER_ID);
+
+        @BeforeEach
+        void setup() {
+            RequestDataCache.add(cachedRequestData);
+        }
+
+        @AfterEach
+        void cleanUp() {
+            RequestDataCache.remove();
+        }
+
+        @Test
+        void shouldReturnAuthorisationHeaderFromCache() {
+            assertThat(requestData.authorisation()).isEqualTo(CACHED_AUTH_TOKEN);
+            verifyNoInteractions(httpServletRequest);
+        }
+
+        @Test
+        void shouldReturnUserIdFromCache() {
+            assertThat(requestData.userId()).isEqualTo(CACHED_USER_ID);
+            verifyNoInteractions(httpServletRequest);
+        }
     }
 }


### PR DESCRIPTION
Currently RequestData accessed from @Async executor may be corrupted (returns nulls) when main request thread already committed http response (depends on timing). It can affect payments, share a case and notifications.
New approach is doing copy of RequestData in main request thread and attach it to every new thread spanned as ThreadLocal variable so accessing it from executor works fine even if http requested is closed.