### PR TITLE
fix: reverted court admin permissions to respondents1 (FPLA-1927)

### DIFF
--- a/ccd-definition/AuthorisationCaseField/court-admin.json
+++ b/ccd-definition/AuthorisationCaseField/court-admin.json
@@ -130,7 +130,7 @@
     "CaseTypeID": "CARE_SUPERVISION_EPO",
     "CaseFieldID": "respondents1",
     "UserRole": "caseworker-publiclaw-courtadmin",
-    "CRUD": "CRU"
+    "CRUD": "CRUD"
   },
   {
     "LiveFrom": "01/01/2017",


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] PR's title includes JIRA ticket number and follow [Conventional Commits](https://www.conventionalcommits.org/) specification
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FPLA-1927

### Change description ###
There's an issue in prod in which a case cannot progress past 'amendRespondents' because respondents1 has an empty 'representedBy' field. CCD treats this as a delete operation which is not permitted. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
