### PR TITLE
impr: cleanup events to use DocumentReference

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/ActionCaseManagementOrderController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/ActionCaseManagementOrderController.java
@@ -20,7 +20,6 @@ import uk.gov.hmcts.reform.fpl.model.HearingBooking;
 import uk.gov.hmcts.reform.fpl.model.OrderAction;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
 import uk.gov.hmcts.reform.fpl.service.CaseManagementOrderService;
-import uk.gov.hmcts.reform.fpl.service.DocumentDownloadService;
 import uk.gov.hmcts.reform.fpl.service.HearingBookingService;
 import uk.gov.hmcts.reform.fpl.service.ccd.CoreCaseDataService;
 
@@ -54,7 +53,6 @@ public class ActionCaseManagementOrderController {
     private final ObjectMapper mapper;
     private final ApplicationEventPublisher applicationEventPublisher;
     private final CoreCaseDataService coreCaseDataService;
-    private final DocumentDownloadService documentDownloadService;
     private final HearingBookingService hearingBookingService;
 
     @PostMapping("/about-to-start")

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/ActionCaseManagementOrderController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/ActionCaseManagementOrderController.java
@@ -167,11 +167,9 @@ public class ActionCaseManagementOrderController {
         CaseManagementOrder actionedCmo = caseData.getCaseManagementOrder();
 
         if (!actionedCmo.isDraft()) {
-            final String actionCmoDocumentUrl = actionedCmo.getOrderDoc().getBinaryUrl();
-            byte[] documentContents = documentDownloadService.downloadDocument(actionCmoDocumentUrl);
 
             applicationEventPublisher.publishEvent(
-                new CaseManagementOrderIssuedEvent(callbackRequest, documentContents));
+                new CaseManagementOrderIssuedEvent(callbackRequest, actionedCmo.getOrderDoc()));
         }
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/GeneratedOrderController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/GeneratedOrderController.java
@@ -14,7 +14,6 @@ import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.document.domain.Document;
-import uk.gov.hmcts.reform.fpl.config.GatewayConfiguration;
 import uk.gov.hmcts.reform.fpl.enums.OrderStatus;
 import uk.gov.hmcts.reform.fpl.events.GeneratedOrderEvent;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
@@ -32,7 +31,6 @@ import uk.gov.hmcts.reform.fpl.model.order.generated.GeneratedOrder;
 import uk.gov.hmcts.reform.fpl.model.order.selector.Selector;
 import uk.gov.hmcts.reform.fpl.service.ChildrenService;
 import uk.gov.hmcts.reform.fpl.service.DischargeCareOrderService;
-import uk.gov.hmcts.reform.fpl.service.DocumentDownloadService;
 import uk.gov.hmcts.reform.fpl.service.FeatureToggleService;
 import uk.gov.hmcts.reform.fpl.service.GeneratedOrderService;
 import uk.gov.hmcts.reform.fpl.service.UploadDocumentService;
@@ -42,8 +40,6 @@ import uk.gov.hmcts.reform.fpl.service.docmosis.DocmosisDocumentGeneratorService
 import uk.gov.hmcts.reform.fpl.service.time.Time;
 import uk.gov.hmcts.reform.fpl.validation.groups.ValidateFamilyManCaseNumberGroup;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -79,11 +75,9 @@ public class GeneratedOrderController {
     private final DocmosisDocumentGeneratorService docmosisDocumentGeneratorService;
     private final UploadDocumentService uploadDocumentService;
     private final ApplicationEventPublisher applicationEventPublisher;
-    private final GatewayConfiguration gatewayConfiguration;
     private final CoreCaseDataService coreCaseDataService;
     private final ChildrenService childrenService;
     private final DischargeCareOrderService dischargeCareOrder;
-    private final DocumentDownloadService documentDownloadService;
     private final FeatureToggleService featureToggleService;
     private final Time time;
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/GeneratedOrderController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/GeneratedOrderController.java
@@ -294,10 +294,7 @@ public class GeneratedOrderController {
             "internal-change-SEND_DOCUMENT",
             Map.of("documentToBeSent", mostRecentUploadedDocument)
         );
-        applicationEventPublisher.publishEvent(new GeneratedOrderEvent(callbackRequest,
-            concatGatewayConfigurationUrlAndMostRecentUploadedOrderDocumentPath(
-                mostRecentUploadedDocument.getBinaryUrl()),
-            documentDownloadService.downloadDocument(mostRecentUploadedDocument.getBinaryUrl())));
+        applicationEventPublisher.publishEvent(new GeneratedOrderEvent(callbackRequest, mostRecentUploadedDocument));
     }
 
     private JudgeAndLegalAdvisor setAllocatedJudgeLabel(Judge allocatedJudge) {
@@ -319,7 +316,6 @@ public class GeneratedOrderController {
         DocmosisDocument docmosisDocument = docmosisDocumentGeneratorService.generateDocmosisDocument(
             orderTemplateData, typeAndDoc.getDocmosisTemplate());
 
-
         Document document = uploadDocumentService.uploadPDF(docmosisDocument.getBytes(),
             service.generateOrderDocumentFileName(typeAndDoc.getType(), typeAndDoc.getSubtype()));
 
@@ -328,19 +324,6 @@ public class GeneratedOrderController {
         }
 
         return document;
-    }
-
-    private String concatGatewayConfigurationUrlAndMostRecentUploadedOrderDocumentPath(
-        final String mostRecentUploadedOrderDocumentUrl) {
-        final String gatewayUrl = gatewayConfiguration.getUrl();
-
-        try {
-            URI uri = new URI(mostRecentUploadedOrderDocumentUrl);
-            return gatewayUrl + uri.getPath();
-        } catch (URISyntaxException e) {
-            log.error(mostRecentUploadedOrderDocumentUrl + " url incorrect.", e);
-        }
-        return "";
     }
 
     private List<Element<Child>> getUpdatedChildren(CaseData caseData) {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/PlacementController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/PlacementController.java
@@ -20,7 +20,6 @@ import uk.gov.hmcts.reform.fpl.model.Child;
 import uk.gov.hmcts.reform.fpl.model.Placement;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
 import uk.gov.hmcts.reform.fpl.model.common.dynamic.DynamicList;
-import uk.gov.hmcts.reform.fpl.service.DocumentDownloadService;
 import uk.gov.hmcts.reform.fpl.service.PlacementService;
 import uk.gov.hmcts.reform.fpl.service.ccd.CoreCaseDataService;
 
@@ -46,7 +45,6 @@ public class PlacementController {
     private final ObjectMapper mapper;
     private final PlacementService placementService;
     private final CoreCaseDataService coreCaseDataService;
-    private final DocumentDownloadService documentDownloadService;
 
     @PostMapping("/about-to-start")
     public AboutToStartOrSubmitCallbackResponse handleAboutToStart(@RequestBody CallbackRequest callbackRequest) {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/PlacementController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/PlacementController.java
@@ -18,7 +18,6 @@ import uk.gov.hmcts.reform.fpl.events.PlacementApplicationEvent;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.Child;
 import uk.gov.hmcts.reform.fpl.model.Placement;
-import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
 import uk.gov.hmcts.reform.fpl.model.common.dynamic.DynamicList;
 import uk.gov.hmcts.reform.fpl.service.DocumentDownloadService;
@@ -149,9 +148,7 @@ public class PlacementController {
                                                               CaseData caseDataBefore) {
         placementService.getUpdatedDocuments(caseData, caseDataBefore, NOTICE_OF_PLACEMENT_ORDER)
             .stream()
-            .map(DocumentReference::getBinaryUrl)
-            .map(documentDownloadService::downloadDocument)
-            .map(documentContents -> new NoticeOfPlacementOrderUploadedEvent(callbackRequest, documentContents))
+            .map(documentReference -> new NoticeOfPlacementOrderUploadedEvent(callbackRequest, documentReference))
             .forEach(applicationEventPublisher::publishEvent);
     }
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/events/CaseManagementOrderIssuedEvent.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/events/CaseManagementOrderIssuedEvent.java
@@ -3,14 +3,15 @@ package uk.gov.hmcts.reform.fpl.events;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
+import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
 public class CaseManagementOrderIssuedEvent extends CallbackEvent {
-    private final byte[] documentContents;
+    private final DocumentReference documentReference;
 
-    public CaseManagementOrderIssuedEvent(CallbackRequest callbackRequest, byte[] documentContents) {
+    public CaseManagementOrderIssuedEvent(CallbackRequest callbackRequest, DocumentReference documentReference) {
         super(callbackRequest);
-        this.documentContents = documentContents;
+        this.documentReference = documentReference;
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/events/GeneratedOrderEvent.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/events/GeneratedOrderEvent.java
@@ -3,18 +3,16 @@ package uk.gov.hmcts.reform.fpl.events;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
+import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
 public class GeneratedOrderEvent extends CallbackEvent {
 
-    private final String mostRecentUploadedDocumentUrl;
-    private final byte[] documentContents;
+    private final DocumentReference documentReference;
 
-    public GeneratedOrderEvent(CallbackRequest callbackRequest, String mostRecentUploadedDocumentUrl,
-                               byte[] documentContents) {
+    public GeneratedOrderEvent(CallbackRequest callbackRequest, DocumentReference documentReference) {
         super(callbackRequest);
-        this.mostRecentUploadedDocumentUrl = mostRecentUploadedDocumentUrl;
-        this.documentContents = documentContents;
+        this.documentReference = documentReference;
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/events/NoticeOfPlacementOrderUploadedEvent.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/events/NoticeOfPlacementOrderUploadedEvent.java
@@ -3,15 +3,16 @@ package uk.gov.hmcts.reform.fpl.events;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
+import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
 public class NoticeOfPlacementOrderUploadedEvent extends CallbackEvent {
 
-    private final byte[] documentContents;
+    private final DocumentReference documentReference;
 
-    public NoticeOfPlacementOrderUploadedEvent(CallbackRequest callbackRequest, byte[] documentContents) {
+    public NoticeOfPlacementOrderUploadedEvent(CallbackRequest callbackRequest, DocumentReference documentReference) {
         super(callbackRequest);
-        this.documentContents = documentContents;
+        this.documentReference = documentReference;
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/CaseManagementOrderIssuedEventHandler.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/CaseManagementOrderIssuedEventHandler.java
@@ -44,7 +44,7 @@ public class CaseManagementOrderIssuedEventHandler {
         sendToCafcass(eventData);
         sendToRepresentatives(eventData, DIGITAL_SERVICE);
         sendToRepresentatives(eventData, EMAIL);
-        issuedOrderAdminNotificationHandler.sendToAdmin(eventData, event.getDocumentContents(), CMO);
+        issuedOrderAdminNotificationHandler.sendToAdmin(eventData, event.getDocumentReference(), CMO);
     }
 
     private void sendToLocalAuthority(final EventData eventData) {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/GeneratedOrderEventHandler.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/GeneratedOrderEventHandler.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.enums.AllocatedJudgeNotificationType;
 import uk.gov.hmcts.reform.fpl.events.GeneratedOrderEvent;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
+import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
 import uk.gov.hmcts.reform.fpl.model.common.JudgeAndLegalAdvisor;
 import uk.gov.hmcts.reform.fpl.model.event.EventData;
 import uk.gov.hmcts.reform.fpl.model.notify.allocatedjudge.AllocatedJudgeTemplateForGeneratedOrder;
@@ -49,13 +50,13 @@ public class GeneratedOrderEventHandler {
 
         final String localAuthorityCode = eventData.getLocalAuthorityCode();
         final CaseDetails caseDetails = eventData.getCaseDetails();
-        final byte[] documentContents = orderEvent.getDocumentContents();
 
+        DocumentReference orderDoc = orderEvent.getDocumentReference();
         issuedOrderAdminNotificationHandler.sendToAdmin(
-            eventData, orderEvent.getDocumentContents(), GENERATED_ORDER);
+            eventData, orderDoc, GENERATED_ORDER);
 
-        sendNotificationToEmailServedRepresentatives(eventData, documentContents);
-        sendNotificationToLocalAuthorityAndDigitalServedRepresentatives(eventData, documentContents, localAuthorityCode,
+        sendNotificationToEmailServedRepresentatives(eventData, orderDoc);
+        sendNotificationToLocalAuthorityAndDigitalServedRepresentatives(eventData, orderDoc, localAuthorityCode,
             caseDetails);
     }
 
@@ -80,10 +81,10 @@ public class GeneratedOrderEventHandler {
     }
 
     private void sendNotificationToEmailServedRepresentatives(final EventData eventData,
-                                                              final byte[] documentContents) {
+                                                              DocumentReference documentReference) {
         final Map<String, Object> templateParameters =
             orderIssuedEmailContentProvider.buildParametersWithoutCaseUrl(
-                eventData.getCaseDetails(), eventData.getLocalAuthorityCode(), documentContents,
+                eventData.getCaseDetails(), eventData.getLocalAuthorityCode(), documentReference,
                 GENERATED_ORDER);
 
         representativeNotificationService.sendToRepresentativesByServedPreference(EMAIL,
@@ -91,12 +92,12 @@ public class GeneratedOrderEventHandler {
     }
 
     private void sendNotificationToLocalAuthorityAndDigitalServedRepresentatives(final EventData eventData,
-                                                                               final byte[] documentContents,
-                                                                               final String localAuthorityCode,
-                                                                               final CaseDetails caseDetails) {
+                                                                                 DocumentReference documentReference,
+                                                                                 final String localAuthorityCode,
+                                                                                 final CaseDetails caseDetails) {
         final Map<String, Object> templateParameters =
             orderIssuedEmailContentProvider.buildParametersWithCaseUrl(
-                caseDetails, eventData.getLocalAuthorityCode(), documentContents, GENERATED_ORDER);
+                caseDetails, eventData.getLocalAuthorityCode(), documentReference, GENERATED_ORDER);
 
         sendToLocalAuthority(caseDetails, localAuthorityCode, templateParameters);
         representativeNotificationService.sendToRepresentativesByServedPreference(DIGITAL_SERVICE,

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/IssuedOrderAdminNotificationHandler.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/IssuedOrderAdminNotificationHandler.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.fpl.enums.IssuedOrderType;
+import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
 import uk.gov.hmcts.reform.fpl.model.event.EventData;
 import uk.gov.hmcts.reform.fpl.service.email.NotificationService;
 import uk.gov.hmcts.reform.fpl.service.email.content.OrderIssuedEmailContentProvider;
@@ -20,10 +21,10 @@ public class IssuedOrderAdminNotificationHandler {
     private final OrderIssuedEmailContentProvider orderIssuedEmailContentProvider;
 
     public void sendToAdmin(final EventData eventData,
-                            final byte[] documentContents,
+                            final DocumentReference documentReference,
                             final IssuedOrderType issuedOrderType) {
         Map<String, Object> parameters = orderIssuedEmailContentProvider.buildParametersWithCaseUrl(
-            eventData.getCaseDetails(), eventData.getLocalAuthorityCode(), documentContents, issuedOrderType);
+            eventData.getCaseDetails(), eventData.getLocalAuthorityCode(), documentReference, issuedOrderType);
 
         String email = adminNotificationHandler.getHmctsAdminEmail(eventData);
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/NoticeOfPlacementOrderUploadedEventHandler.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/NoticeOfPlacementOrderUploadedEventHandler.java
@@ -45,7 +45,7 @@ public class NoticeOfPlacementOrderUploadedEventHandler {
             eventData.getReference());
 
         issuedOrderAdminNotificationHandler.sendToAdmin(eventData,
-            noticeOfPlacementEvent.getDocumentContents(), NOTICE_OF_PLACEMENT_ORDER);
+            noticeOfPlacementEvent.getDocumentReference(), NOTICE_OF_PLACEMENT_ORDER);
 
         representativeNotificationService.sendToRepresentativesByServedPreference(DIGITAL_SERVICE,
             NOTICE_OF_PLACEMENT_ORDER_UPLOADED_TEMPLATE, parameters, eventData);
@@ -53,7 +53,7 @@ public class NoticeOfPlacementOrderUploadedEventHandler {
         Map<String, Object> representativesTemplateParameters =
             orderIssuedEmailContentProvider.buildParametersWithoutCaseUrl(
                 eventData.getCaseDetails(), eventData.getLocalAuthorityCode(),
-                noticeOfPlacementEvent.getDocumentContents(), NOTICE_OF_PLACEMENT_ORDER);
+                noticeOfPlacementEvent.getDocumentReference(), NOTICE_OF_PLACEMENT_ORDER);
 
         representativeNotificationService.sendToRepresentativesByServedPreference(EMAIL,
             ORDER_ISSUED_NOTIFICATION_TEMPLATE_FOR_REPRESENTATIVES, representativesTemplateParameters, eventData);

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/email/content/OrderIssuedEmailContentProvider.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/email/content/OrderIssuedEmailContentProvider.java
@@ -43,7 +43,7 @@ public class OrderIssuedEmailContentProvider extends AbstractEmailContentProvide
             .put("orderType", getTypeOfOrder(caseData, issuedOrderType))
             .put("callout", (issuedOrderType != NOTICE_OF_PLACEMENT_ORDER) ? buildCallout(caseData) : "")
             .put("courtName", config.getCourt(localAuthorityCode).getName())
-            .putAll(linkToAttachedDocument(documentReference))
+            .put("documentLink", linkToAttachedDocument(documentReference))
             .put("respondentLastName", getFirstRespondentLastName(caseData.getRespondents1()))
             .build();
     }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/CaseManagementOrderIssuedEventHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/CaseManagementOrderIssuedEventHandlerTest.java
@@ -12,7 +12,6 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.events.CaseManagementOrderIssuedEvent;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.notify.draftcmo.IssuedCMOTemplate;
-import uk.gov.hmcts.reform.fpl.service.CaseUrlService;
 import uk.gov.hmcts.reform.fpl.service.InboxLookupService;
 import uk.gov.hmcts.reform.fpl.service.RepresentativeService;
 import uk.gov.hmcts.reform.fpl.service.config.LookupTestConfig;
@@ -30,7 +29,7 @@ import static uk.gov.hmcts.reform.fpl.enums.IssuedOrderType.CMO;
 import static uk.gov.hmcts.reform.fpl.enums.RepresentativeServingPreferences.DIGITAL_SERVICE;
 import static uk.gov.hmcts.reform.fpl.handlers.NotificationEventHandlerTestData.COURT_EMAIL_ADDRESS;
 import static uk.gov.hmcts.reform.fpl.handlers.NotificationEventHandlerTestData.CTSC_INBOX;
-import static uk.gov.hmcts.reform.fpl.handlers.NotificationEventHandlerTestData.DOCUMENT_CONTENTS;
+import static uk.gov.hmcts.reform.fpl.handlers.NotificationEventHandlerTestData.DOCUMENT_REFERENCE;
 import static uk.gov.hmcts.reform.fpl.handlers.NotificationEventHandlerTestData.LOCAL_AUTHORITY_CODE;
 import static uk.gov.hmcts.reform.fpl.handlers.NotificationEventHandlerTestData.LOCAL_AUTHORITY_EMAIL_ADDRESS;
 import static uk.gov.hmcts.reform.fpl.handlers.NotificationEventHandlerTestData.LOCAL_AUTHORITY_NAME;
@@ -46,7 +45,7 @@ import static uk.gov.hmcts.reform.fpl.utils.matchers.JsonMatcher.eqJson;
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = {CaseManagementOrderIssuedEventHandler.class, JacksonAutoConfiguration.class,
     LookupTestConfig.class, IssuedOrderAdminNotificationHandler.class, HmctsAdminNotificationHandler.class,
-    RepresentativeService.class,  FixedTimeConfiguration.class})
+    RepresentativeService.class, FixedTimeConfiguration.class})
 public class CaseManagementOrderIssuedEventHandlerTest {
 
     @MockBean
@@ -63,9 +62,6 @@ public class CaseManagementOrderIssuedEventHandlerTest {
 
     @MockBean
     private CaseManagementOrderEmailContentProvider caseManagementOrderEmailContentProvider;
-
-    @MockBean
-    private CaseUrlService caseUrlService;
 
     @Autowired
     private CaseManagementOrderIssuedEventHandler caseManagementOrderIssuedEventHandler;
@@ -85,11 +81,11 @@ public class CaseManagementOrderIssuedEventHandlerTest {
             .willReturn(issuedCMOTemplate);
 
         given(orderIssuedEmailContentProvider.buildParametersWithCaseUrl(
-            callbackRequest().getCaseDetails(), LOCAL_AUTHORITY_CODE, DOCUMENT_CONTENTS, CMO))
+            callbackRequest().getCaseDetails(), LOCAL_AUTHORITY_CODE, DOCUMENT_REFERENCE, CMO))
             .willReturn(getExpectedCaseUrlParameters(CMO.getLabel(), true));
 
         caseManagementOrderIssuedEventHandler.sendEmailsForIssuedCaseManagementOrder(
-            new CaseManagementOrderIssuedEvent(callbackRequest, DOCUMENT_CONTENTS));
+            new CaseManagementOrderIssuedEvent(callbackRequest, DOCUMENT_REFERENCE));
 
         verify(notificationService).sendEmail(
             CMO_ORDER_ISSUED_NOTIFICATION_TEMPLATE,
@@ -114,11 +110,11 @@ public class CaseManagementOrderIssuedEventHandlerTest {
             .willReturn(getCMOIssuedCaseLinkNotificationParameters());
 
         given(orderIssuedEmailContentProvider.buildParametersWithCaseUrl(
-            callbackRequest.getCaseDetails(), LOCAL_AUTHORITY_CODE, DOCUMENT_CONTENTS, CMO))
+            callbackRequest.getCaseDetails(), LOCAL_AUTHORITY_CODE, DOCUMENT_REFERENCE, CMO))
             .willReturn(getExpectedCaseUrlParameters(CMO.getLabel(), true));
 
         caseManagementOrderIssuedEventHandler.sendEmailsForIssuedCaseManagementOrder(
-            new CaseManagementOrderIssuedEvent(callbackRequest, DOCUMENT_CONTENTS));
+            new CaseManagementOrderIssuedEvent(callbackRequest, DOCUMENT_REFERENCE));
 
         verify(notificationService).sendEmail(
             eq(ORDER_ISSUED_NOTIFICATION_TEMPLATE_FOR_ADMIN),
@@ -143,7 +139,7 @@ public class CaseManagementOrderIssuedEventHandlerTest {
             .willReturn(issuedCMOTemplate);
 
         caseManagementOrderIssuedEventHandler.sendEmailsForIssuedCaseManagementOrder(
-            new CaseManagementOrderIssuedEvent(callbackRequest, DOCUMENT_CONTENTS));
+            new CaseManagementOrderIssuedEvent(callbackRequest, DOCUMENT_REFERENCE));
 
         verify(notificationService).sendEmail(
             CMO_ORDER_ISSUED_NOTIFICATION_TEMPLATE,

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/GeneratedOrderEventHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/GeneratedOrderEventHandlerTest.java
@@ -17,7 +17,6 @@ import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.Representative;
 import uk.gov.hmcts.reform.fpl.model.common.JudgeAndLegalAdvisor;
 import uk.gov.hmcts.reform.fpl.model.notify.allocatedjudge.AllocatedJudgeTemplateForGeneratedOrder;
-import uk.gov.hmcts.reform.fpl.service.CaseUrlService;
 import uk.gov.hmcts.reform.fpl.service.FeatureToggleService;
 import uk.gov.hmcts.reform.fpl.service.GeneratedOrderService;
 import uk.gov.hmcts.reform.fpl.service.InboxLookupService;
@@ -46,7 +45,7 @@ import static uk.gov.hmcts.reform.fpl.enums.RepresentativeServingPreferences.DIG
 import static uk.gov.hmcts.reform.fpl.enums.RepresentativeServingPreferences.EMAIL;
 import static uk.gov.hmcts.reform.fpl.handlers.NotificationEventHandlerTestData.ALLOCATED_JUDGE_EMAIL_ADDRESS;
 import static uk.gov.hmcts.reform.fpl.handlers.NotificationEventHandlerTestData.COURT_EMAIL_ADDRESS;
-import static uk.gov.hmcts.reform.fpl.handlers.NotificationEventHandlerTestData.DOCUMENT_CONTENTS;
+import static uk.gov.hmcts.reform.fpl.handlers.NotificationEventHandlerTestData.DOCUMENT_REFERENCE;
 import static uk.gov.hmcts.reform.fpl.handlers.NotificationEventHandlerTestData.LOCAL_AUTHORITY_CODE;
 import static uk.gov.hmcts.reform.fpl.handlers.NotificationEventHandlerTestData.LOCAL_AUTHORITY_EMAIL_ADDRESS;
 import static uk.gov.hmcts.reform.fpl.utils.CoreCaseDataStoreLoader.callbackRequest;
@@ -79,9 +78,6 @@ class GeneratedOrderEventHandlerTest {
     @MockBean
     private NotificationService notificationService;
 
-    @MockBean
-    private CaseUrlService caseUrlService;
-
     @Autowired
     private ObjectMapper objectMapper;
 
@@ -102,11 +98,11 @@ class GeneratedOrderEventHandlerTest {
             .willReturn(LOCAL_AUTHORITY_EMAIL_ADDRESS);
 
         given(orderIssuedEmailContentProvider.buildParametersWithCaseUrl(
-            callbackRequest().getCaseDetails(), LOCAL_AUTHORITY_CODE, DOCUMENT_CONTENTS, GENERATED_ORDER))
+            callbackRequest().getCaseDetails(), LOCAL_AUTHORITY_CODE, DOCUMENT_REFERENCE, GENERATED_ORDER))
             .willReturn(getExpectedCaseUrlParameters(BLANK_ORDER.getLabel(), true));
 
         given(orderIssuedEmailContentProvider.buildParametersWithoutCaseUrl(
-            callbackRequest().getCaseDetails(), LOCAL_AUTHORITY_CODE, DOCUMENT_CONTENTS, GENERATED_ORDER))
+            callbackRequest().getCaseDetails(), LOCAL_AUTHORITY_CODE, DOCUMENT_REFERENCE, GENERATED_ORDER))
             .willReturn(getExpectedParametersForRepresentatives(BLANK_ORDER.getLabel(), true));
     }
 
@@ -119,8 +115,7 @@ class GeneratedOrderEventHandlerTest {
             DIGITAL_SERVICE))
             .willReturn(getExpectedDigitalServedRepresentativesForAddingPartiesToCase());
 
-        generatedOrderEventHandler.sendEmailsForOrder(new GeneratedOrderEvent(callbackRequest(),
-            mostRecentUploadedDocumentUrl, DOCUMENT_CONTENTS));
+        generatedOrderEventHandler.sendEmailsForOrder(new GeneratedOrderEvent(callbackRequest(), DOCUMENT_REFERENCE));
 
         verify(notificationService).sendEmail(
             eq(ORDER_ISSUED_NOTIFICATION_TEMPLATE_FOR_ADMIN),
@@ -166,8 +161,8 @@ class GeneratedOrderEventHandlerTest {
         given(orderIssuedEmailContentProvider.buildAllocatedJudgeOrderIssuedNotification(
             caseDetails)).willReturn(expectedParameters);
 
-        generatedOrderEventHandler.sendNotificationToAllocatedJudgeForOrder(new GeneratedOrderEvent(callbackRequest(),
-            mostRecentUploadedDocumentUrl, DOCUMENT_CONTENTS));
+        generatedOrderEventHandler.sendNotificationToAllocatedJudgeForOrder(
+            new GeneratedOrderEvent(callbackRequest(), DOCUMENT_REFERENCE));
 
         verify(notificationService).sendEmail(
             eq(ORDER_ISSUED_NOTIFICATION_TEMPLATE_FOR_JUDGE),
@@ -195,8 +190,8 @@ class GeneratedOrderEventHandlerTest {
         given(orderIssuedEmailContentProvider.buildAllocatedJudgeOrderIssuedNotification(
             caseDetails)).willReturn(expectedParameters);
 
-        generatedOrderEventHandler.sendNotificationToAllocatedJudgeForOrder(new GeneratedOrderEvent(callbackRequest(),
-            mostRecentUploadedDocumentUrl, DOCUMENT_CONTENTS));
+        generatedOrderEventHandler.sendNotificationToAllocatedJudgeForOrder(
+            new GeneratedOrderEvent(callbackRequest(), DOCUMENT_REFERENCE));
 
         verify(notificationService, never()).sendEmail(
             eq(ORDER_ISSUED_NOTIFICATION_TEMPLATE_FOR_JUDGE),
@@ -222,8 +217,8 @@ class GeneratedOrderEventHandlerTest {
         given(orderIssuedEmailContentProvider.buildAllocatedJudgeOrderIssuedNotification(
             caseDetails)).willReturn(expectedParameters);
 
-        generatedOrderEventHandler.sendNotificationToAllocatedJudgeForOrder(new GeneratedOrderEvent(callbackRequest(),
-            mostRecentUploadedDocumentUrl, DOCUMENT_CONTENTS));
+        generatedOrderEventHandler.sendNotificationToAllocatedJudgeForOrder(
+            new GeneratedOrderEvent(callbackRequest(), DOCUMENT_REFERENCE));
 
         verify(notificationService, never()).sendEmail(
             eq(ORDER_ISSUED_NOTIFICATION_TEMPLATE_FOR_JUDGE),

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/NoticeOfPlacementOrderUploadedEventHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/NoticeOfPlacementOrderUploadedEventHandlerTest.java
@@ -9,7 +9,6 @@ import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.events.NoticeOfPlacementOrderUploadedEvent;
 import uk.gov.hmcts.reform.fpl.model.event.EventData;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 import uk.gov.hmcts.reform.fpl.service.InboxLookupService;
 import uk.gov.hmcts.reform.fpl.service.email.NotificationService;
 import uk.gov.hmcts.reform.fpl.service.email.content.LocalAuthorityEmailContentProvider;
@@ -25,16 +24,13 @@ import static uk.gov.hmcts.reform.fpl.NotifyTemplates.ORDER_ISSUED_NOTIFICATION_
 import static uk.gov.hmcts.reform.fpl.enums.IssuedOrderType.NOTICE_OF_PLACEMENT_ORDER;
 import static uk.gov.hmcts.reform.fpl.enums.RepresentativeServingPreferences.DIGITAL_SERVICE;
 import static uk.gov.hmcts.reform.fpl.enums.RepresentativeServingPreferences.EMAIL;
-import static uk.gov.hmcts.reform.fpl.handlers.NotificationEventHandlerTestData.DOCUMENT_CONTENTS;
+import static uk.gov.hmcts.reform.fpl.handlers.NotificationEventHandlerTestData.DOCUMENT_REFERENCE;
 import static uk.gov.hmcts.reform.fpl.handlers.NotificationEventHandlerTestData.LOCAL_AUTHORITY_CODE;
 import static uk.gov.hmcts.reform.fpl.handlers.NotificationEventHandlerTestData.LOCAL_AUTHORITY_EMAIL_ADDRESS;
 import static uk.gov.hmcts.reform.fpl.utils.CoreCaseDataStoreLoader.callbackRequest;
 
 @ExtendWith(SpringExtension.class)
 public class NoticeOfPlacementOrderUploadedEventHandlerTest {
-
-    @Mock
-    private RequestData requestData;
 
     @Mock
     private InboxLookupService inboxLookupService;
@@ -65,8 +61,8 @@ public class NoticeOfPlacementOrderUploadedEventHandlerTest {
 
         final CallbackRequest caseData = callbackRequest();
         final CaseDetails caseDetails = caseData.getCaseDetails();
-        final NoticeOfPlacementOrderUploadedEvent event = new NoticeOfPlacementOrderUploadedEvent(
-            caseData, DOCUMENT_CONTENTS);
+        final NoticeOfPlacementOrderUploadedEvent event = new NoticeOfPlacementOrderUploadedEvent(caseData,
+            DOCUMENT_REFERENCE);
         final EventData eventData = new EventData(event);
 
         given(inboxLookupService.getNotificationRecipientEmail(caseDetails, LOCAL_AUTHORITY_CODE))
@@ -76,7 +72,7 @@ public class NoticeOfPlacementOrderUploadedEventHandlerTest {
             .willReturn(localAuthorityParameters);
 
         given(orderIssuedEmailContentProvider.buildParametersWithoutCaseUrl(
-            caseDetails, LOCAL_AUTHORITY_CODE, DOCUMENT_CONTENTS, NOTICE_OF_PLACEMENT_ORDER))
+            caseDetails, LOCAL_AUTHORITY_CODE, DOCUMENT_REFERENCE, NOTICE_OF_PLACEMENT_ORDER))
             .willReturn(representativesParameters);
 
         noticeOfPlacementOrderUploadedEventHandler.sendEmailForNoticeOfPlacementOrderUploaded(event);
@@ -89,7 +85,7 @@ public class NoticeOfPlacementOrderUploadedEventHandlerTest {
 
         verify(issuedOrderAdminNotificationHandler).sendToAdmin(
             eventData,
-            event.getDocumentContents(),
+            event.getDocumentReference(),
             NOTICE_OF_PLACEMENT_ORDER);
 
         verify(representativeNotificationService).sendToRepresentativesByServedPreference(

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/NotificationEventHandlerTestData.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/NotificationEventHandlerTestData.java
@@ -6,6 +6,7 @@ import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.Representative;
+import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
 import uk.gov.hmcts.reform.fpl.model.notify.allocatedjudge.AllocatedJudgeTemplate;
 import uk.gov.hmcts.reform.fpl.model.notify.allocatedjudge.AllocatedJudgeTemplateForCMO;
 
@@ -18,6 +19,7 @@ import static uk.gov.hmcts.reform.fpl.enums.RepresentativeServingPreferences.DIG
 import static uk.gov.hmcts.reform.fpl.enums.RepresentativeServingPreferences.EMAIL;
 import static uk.gov.hmcts.reform.fpl.utils.CaseDataGeneratorHelper.createRepresentatives;
 import static uk.gov.hmcts.reform.fpl.utils.CoreCaseDataStoreLoader.callbackRequest;
+import static uk.gov.hmcts.reform.fpl.utils.TestDataHelper.testDocumentReference;
 
 public class NotificationEventHandlerTestData {
     static final String LOCAL_AUTHORITY_CODE = "example";
@@ -35,6 +37,8 @@ public class NotificationEventHandlerTestData {
     static final String PARTY_ADDED_TO_CASE_BY_EMAIL_ADDRESS = "barney@rubble.com";
     static final String PARTY_ADDED_TO_CASE_THROUGH_DIGITAL_SERVICE_EMAIL = "fred@flinstone.com";
     static final byte[] DOCUMENT_CONTENTS = {1, 2, 3, 4, 5};
+    static final DocumentReference DOCUMENT_REFERENCE = testDocumentReference();
+
 
     private NotificationEventHandlerTestData() {
     }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/email/content/OrderIssuedEmailContentProviderTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/email/content/OrderIssuedEmailContentProviderTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.fpl.service.email.content;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -22,6 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static uk.gov.hmcts.reform.fpl.enums.GeneratedOrderType.BLANK_ORDER;
 import static uk.gov.hmcts.reform.fpl.enums.IssuedOrderType.CMO;
@@ -35,13 +37,15 @@ import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.wrapElements;
 import static uk.gov.hmcts.reform.fpl.utils.OrderIssuedNotificationTestHelper.getExpectedAllocatedJudgeParameters;
 import static uk.gov.hmcts.reform.fpl.utils.OrderIssuedNotificationTestHelper.getExpectedCaseUrlParameters;
 import static uk.gov.hmcts.reform.fpl.utils.OrderIssuedNotificationTestHelper.getExpectedParametersForRepresentatives;
+import static uk.gov.hmcts.reform.fpl.utils.TestDataHelper.DOCUMENT_CONTENT;
+import static uk.gov.hmcts.reform.fpl.utils.TestDataHelper.testDocumentReference;
 
 @ContextConfiguration(classes = {OrderIssuedEmailContentProvider.class, LookupTestConfig.class,
     EmailNotificationHelper.class, FixedTimeConfiguration.class,
 })
 class OrderIssuedEmailContentProviderTest extends AbstractEmailContentProviderTest {
 
-    private static final byte[] documentContents = {1, 2, 3, 4, 5};
+    private static final DocumentReference documentReference = testDocumentReference();
 
     @MockBean
     private GeneratedOrderService generatedOrderService;
@@ -52,10 +56,15 @@ class OrderIssuedEmailContentProviderTest extends AbstractEmailContentProviderTe
     @Autowired
     private ObjectMapper mapper;
 
+    @BeforeEach
+    void init() {
+        given(documentDownloadService.downloadDocument(anyString())).willReturn(DOCUMENT_CONTENT);
+    }
+
     @Test
     void shouldBuildGeneratedOrderParametersWithCaseUrl() {
         Map<String, Object> actualParameters = orderIssuedEmailContentProvider.buildParametersWithCaseUrl(
-            createCase(), LOCAL_AUTHORITY_CODE, documentContents, GENERATED_ORDER);
+            createCase(), LOCAL_AUTHORITY_CODE, documentReference, GENERATED_ORDER);
         Map<String, Object> expectedParameters = getExpectedCaseUrlParameters(BLANK_ORDER.getLabel(), true);
 
         assertEquals(actualParameters, expectedParameters);
@@ -64,7 +73,7 @@ class OrderIssuedEmailContentProviderTest extends AbstractEmailContentProviderTe
     @Test
     void shouldBuildGeneratedOrderParametersWithoutCaseUrl() {
         Map<String, Object> actualParameters = orderIssuedEmailContentProvider.buildParametersWithoutCaseUrl(
-            createCase(), LOCAL_AUTHORITY_CODE, documentContents, GENERATED_ORDER);
+            createCase(), LOCAL_AUTHORITY_CODE, documentReference, GENERATED_ORDER);
         Map<String, Object> expectedParameters = getExpectedParametersForRepresentatives(BLANK_ORDER.getLabel(), true);
 
         assertEquals(actualParameters, expectedParameters);
@@ -73,7 +82,7 @@ class OrderIssuedEmailContentProviderTest extends AbstractEmailContentProviderTe
     @Test
     void shouldBuildNoticeOfPlacementOrderParameters() {
         Map<String, Object> actualParameters = orderIssuedEmailContentProvider.buildParametersWithCaseUrl(
-            createCase(), LOCAL_AUTHORITY_CODE, documentContents, NOTICE_OF_PLACEMENT_ORDER);
+            createCase(), LOCAL_AUTHORITY_CODE, documentReference, NOTICE_OF_PLACEMENT_ORDER);
         Map<String, Object> expectedParameters = getExpectedCaseUrlParameters(NOTICE_OF_PLACEMENT_ORDER.getLabel(),
             false);
 
@@ -83,7 +92,7 @@ class OrderIssuedEmailContentProviderTest extends AbstractEmailContentProviderTe
     @Test
     void shouldBuildCaseManagementOrderParameters() {
         Map<String, Object> actualParameters = orderIssuedEmailContentProvider.buildParametersWithCaseUrl(
-            createCase(), LOCAL_AUTHORITY_CODE, documentContents, CMO);
+            createCase(), LOCAL_AUTHORITY_CODE, documentReference, CMO);
         Map<String, Object> expectedParameters = getExpectedCaseUrlParameters(CMO.getLabel(), true);
 
         assertEquals(actualParameters, expectedParameters);


### PR DESCRIPTION
### Change description ###

Pass DocumentReference to events in submitted callbacks instead of passing byte[] documentContents. This allows event handlers/content providers to better utilise linkToAttachedDocument in AbstractEmailContentProvider (less duplication of code invoking documentDownloadService). This also fixes an issue with document links of generated orders being links directly to the document instead of a gov notify download of the attachment.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
