### PR TITLE
Hide Start application tab when task list is not yet present (old cas…

### DIFF
--- a/ccd-definition/CaseTypeTab/CareSupervision/0_ApplicationTasks-nonprod.json
+++ b/ccd-definition/CaseTypeTab/CareSupervision/0_ApplicationTasks-nonprod.json
@@ -19,7 +19,7 @@
     "CaseFieldID": "taskList",
     "TabFieldDisplayOrder": 2,
     "FieldShowCondition": "taskList = \"DO_NOT_SHOW\"",
-    "TabShowCondition": "[STATE] = \"Open\"",
+    "TabShowCondition": "[STATE] = \"Open\" AND taskList !=\"\"",
     "Comment": "taskListLabel is defined as '${taskList}' thus taskList must be present on tab"
   }
 ]


### PR DESCRIPTION
…es on prod without calculated task list)

Task list is calculated after every relevant event in open state
For old cases, created before task list release, task list filed wont be initially present in ccd data and tab is displayed empty. Task list will appear after next event 
PO wants to hide this tab in such scenario