### PR TITLE
feat: updated CMO ready for approval notifications (FPLA-2029)

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/NotifyTemplates.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/NotifyTemplates.java
@@ -22,9 +22,9 @@ public class NotifyTemplates {
         "1827ae2d-d7c3-4094-8978-c2f77d7713fa";
     public static final String CMO_ORDER_ISSUED_NOTIFICATION_TEMPLATE = "0ec7f651-4f0e-4f95-bff1-6ec232b9baf6";
     public static final String CMO_READY_FOR_JUDGE_REVIEW_NOTIFICATION_TEMPLATE =
-        "58aa7e13-e80a-4630-a610-ee7fc1b6f9f9";
+        "90c5f4b3-738b-4c8d-b433-c8c90095f815";
     public static final String CMO_READY_FOR_JUDGE_REVIEW_NOTIFICATION_TEMPLATE_JUDGE =
-        "c61f59d0-2ece-4b00-acef-3d168943d583";
+        "5a092766-6a39-4c00-a7a7-a31a72c60b48";
     public static final String CMO_READY_FOR_PARTY_REVIEW_NOTIFICATION_TEMPLATE =
         "7a513cfd-cf3c-4778-aca0-4bbd1a37863a";
     public static final String CMO_REJECTED_BY_JUDGE_TEMPLATE = "d1454061-e2bc-4b89-9a66-7add40656bf8";

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/cmo/NewCMOUploadedEventHandler.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/cmo/NewCMOUploadedEventHandler.java
@@ -34,7 +34,7 @@ public class NewCMOUploadedEventHandler {
         CMOReadyToSealTemplate template = contentProvider.buildTemplate(
             event.getHearing(),
             eventData.getCaseDetails().getId(),
-            event.getHearing().getJudgeAndLegalAdvisor(),
+            caseData.getAllocatedJudge(),
             caseData.getAllRespondents(),
             caseData.getFamilyManCaseNumber()
         );

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/email/content/cmo/NewCMOUploadedContentProvider.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/email/content/cmo/NewCMOUploadedContentProvider.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.reform.fpl.service.email.content.base.AbstractEmailContentPr
 
 import java.util.List;
 
+import static org.apache.commons.lang3.StringUtils.uncapitalize;
 import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.DATE;
 import static uk.gov.hmcts.reform.fpl.utils.EmailNotificationHelper.buildSubjectLine;
 import static uk.gov.hmcts.reform.fpl.utils.PeopleInCaseHelper.getFirstRespondentLastName;
@@ -30,6 +31,7 @@ public class NewCMOUploadedContentProvider extends AbstractEmailContentProvider 
 
     private String subjectLine(HearingBooking hearing, List<Element<Respondent>> respondents,
                                String familyManCaseNumber) {
-        return String.format("%s, %s", buildSubjectLine(familyManCaseNumber, respondents), hearing.toLabel(DATE));
+        return String.format("%s, %s", buildSubjectLine(familyManCaseNumber, respondents),
+            uncapitalize(hearing.toLabel(DATE)));
     }
 }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/cmo/NewCMOUploadedEventHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/cmo/NewCMOUploadedEventHandlerTest.java
@@ -75,22 +75,21 @@ class NewCMOUploadedEventHandlerTest {
 
     @Test
     void shouldSendNotificationForAdmin() {
-        CaseData caseData = caseDataWithoutAllocatedJudgeEmail();
+        CaseData caseData = caseDataWithAllocatedJudgeEmail(HMCTS_JUDGE_EMAIL);
         CallbackRequest request = callbackRequest(caseData);
         HearingBooking hearing = buildHearing();
-        CMOReadyToSealTemplate template = expectedTemplate("Dave");
+        CMOReadyToSealTemplate template = expectedTemplate();
 
         mockContentProvider(
             caseData.getAllRespondents(),
             caseData.getFamilyManCaseNumber(),
             hearing,
-            hearing.getJudgeAndLegalAdvisor(),
+            caseData.getAllocatedJudge(),
             template
         );
 
         NewCMOUploaded event = new NewCMOUploaded(request, hearing);
         eventHandler.sendNotificationForAdmin(event);
-
 
         verify(notificationService).sendEmail(
             CMO_READY_FOR_JUDGE_REVIEW_NOTIFICATION_TEMPLATE,
@@ -105,7 +104,7 @@ class NewCMOUploadedEventHandlerTest {
         CaseData caseData = caseDataWithAllocatedJudgeEmail(HMCTS_JUDGE_EMAIL);
         CallbackRequest request = callbackRequest(caseData);
         HearingBooking hearing = buildHearing();
-        CMOReadyToSealTemplate template = expectedTemplate("Not Dave");
+        CMOReadyToSealTemplate template = expectedTemplate();
 
         mockContentProvider(
             caseData.getAllRespondents(),
@@ -117,7 +116,6 @@ class NewCMOUploadedEventHandlerTest {
 
         NewCMOUploaded event = new NewCMOUploaded(request, hearing);
         eventHandler.sendNotificationForJudge(event);
-
 
         verify(notificationService).sendEmail(
             CMO_READY_FOR_JUDGE_REVIEW_NOTIFICATION_TEMPLATE_JUDGE,
@@ -165,7 +163,6 @@ class NewCMOUploadedEventHandlerTest {
             .build();
     }
 
-
     private CaseData caseDataWithoutAllocatedJudgeEmail() {
         return caseDataWithAllocatedJudgeEmail("");
     }
@@ -184,18 +181,18 @@ class NewCMOUploadedEventHandlerTest {
             )
             .allocatedJudge(Judge.builder()
                 .judgeTitle(HIS_HONOUR_JUDGE)
-                .judgeLastName("Not Dave")
+                .judgeLastName("Hastings")
                 .judgeEmailAddress(email)
                 .build());
 
         return builder.build();
     }
 
-    private static CMOReadyToSealTemplate expectedTemplate(String judgeName) {
+    private static CMOReadyToSealTemplate expectedTemplate() {
         return new CMOReadyToSealTemplate()
             .setRespondentLastName("Smith")
             .setJudgeTitle("His Honour Judge")
-            .setJudgeName(judgeName)
+            .setJudgeName("Hastings")
             .setCaseUrl(FAKE_URL)
             .setSubjectLineWithHearingDate("Smith, 12345, Case management hearing, 1 February 2020");
     }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/email/content/cmo/NewCMOUploadedContentProviderTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/email/content/cmo/NewCMOUploadedContentProviderTest.java
@@ -58,7 +58,7 @@ class NewCMOUploadedContentProviderTest extends AbstractEmailContentProviderTest
             .setJudgeName("Simmons")
             .setJudgeTitle("Her Honour Judge")
             .setRespondentLastName("Vlad")
-            .setSubjectLineWithHearingDate("Vlad, 123456, Case management hearing, 20 February 2020")
+            .setSubjectLineWithHearingDate("Vlad, 123456, case management hearing, 20 February 2020")
             .setCaseUrl(caseUrl(CASE_NUMBER.toString()));
 
         assertThat(template).isEqualToComparingFieldByField(expected);


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FPLA-2029

### Change description ###

Updated the admin and judge emails that are sent when an LA uploads an agreed draft CMO
https://www.notifications.service.gov.uk/services/12f756df-f01d-4a32-a405-e1ea8a494fbb/templates/90c5f4b3-738b-4c8d-b433-c8c90095f815 (admin)
https://www.notifications.service.gov.uk/services/12f756df-f01d-4a32-a405-e1ea8a494fbb/templates/5a092766-6a39-4c00-a7a7-a31a72c60b48 (judge)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
