### PR TITLE
fix: pass c2 document instead of c110a in c2 notification

### DIFF
--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/UploadC2DocumentsSubmittedControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/UploadC2DocumentsSubmittedControllerTest.java
@@ -21,7 +21,6 @@ import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
 import uk.gov.hmcts.reform.fpl.model.notify.c2uploaded.C2UploadedTemplate;
 import uk.gov.hmcts.reform.fpl.service.DocumentDownloadService;
 import uk.gov.hmcts.reform.fpl.service.payment.PaymentService;
-import uk.gov.hmcts.reform.fpl.utils.TestDataHelper;
 import uk.gov.hmcts.reform.idam.client.IdamApi;
 import uk.gov.hmcts.reform.idam.client.models.UserInfo;
 import uk.gov.service.notify.NotificationClient;
@@ -59,7 +58,8 @@ class UploadC2DocumentsSubmittedControllerTest extends AbstractControllerTest {
     private static final String LOCAL_AUTHORITY_CODE = "example";
     private static final Long CASE_ID = 12345L;
     private static DocumentReference applicationDocument;
-    private static final byte[] APPLICATION_BINARY = TestDataHelper.DOCUMENT_CONTENT;
+    private static DocumentReference latestC2Document;
+    private static final byte[] C2_BINARY = {5, 4, 3, 2, 1};
 
     @MockBean
     private NotificationClient notificationClient;
@@ -82,8 +82,9 @@ class UploadC2DocumentsSubmittedControllerTest extends AbstractControllerTest {
         given(idamApi.retrieveUserInfo(any())).willReturn(USER_INFO_CAFCASS);
 
         applicationDocument = testDocumentReference();
-        when(documentDownloadService.downloadDocument(applicationDocument.getBinaryUrl()))
-            .thenReturn(APPLICATION_BINARY);
+        latestC2Document = testDocumentReference();
+        when(documentDownloadService.downloadDocument(latestC2Document.getBinaryUrl()))
+            .thenReturn(C2_BINARY);
     }
 
     @Test
@@ -304,6 +305,7 @@ class UploadC2DocumentsSubmittedControllerTest extends AbstractControllerTest {
     private Map<String, Object> buildC2DocumentBundle(YesNo usePbaPayment) {
         return ImmutableMap.of(
             "c2DocumentBundle", wrapElements(C2DocumentBundle.builder()
+                .document(latestC2Document)
                 .usePbaPayment(usePbaPayment.getValue())
                 .build())
         );
@@ -320,7 +322,7 @@ class UploadC2DocumentsSubmittedControllerTest extends AbstractControllerTest {
         c2UploadedTemplate.setCallout(String.format("%s, %s", RESPONDENT_SURNAME, CASE_ID.toString()));
         c2UploadedTemplate.setRespondentLastName("Watson");
         c2UploadedTemplate.setCaseUrl("http://fake-url/cases/case-details/" + CASE_ID);
-        c2UploadedTemplate.setDocumentLink(generateAttachedDocumentLink(APPLICATION_BINARY)
+        c2UploadedTemplate.setDocumentLink(generateAttachedDocumentLink(C2_BINARY)
             .map(JSONObject::toMap)
             .orElse(null));
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/UploadC2DocumentsController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/UploadC2DocumentsController.java
@@ -125,10 +125,9 @@ public class UploadC2DocumentsController {
             applicationEventPublisher.publishEvent(new FailedPBAPaymentEvent(callbackRequest, C2_APPLICATION));
         }
 
-        applicationEventPublisher.publishEvent(new C2UploadedEvent(callbackRequest));
-
         C2DocumentBundle c2DocumentBundle = caseData.getLastC2DocumentBundle();
 
+        applicationEventPublisher.publishEvent(new C2UploadedEvent(callbackRequest, c2DocumentBundle));
         if (isNotPaidByPba(c2DocumentBundle)) {
             applicationEventPublisher.publishEvent(new C2PbaPaymentNotTakenEvent(callbackRequest));
         }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/events/C2UploadedEvent.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/events/C2UploadedEvent.java
@@ -1,10 +1,18 @@
 package uk.gov.hmcts.reform.fpl.events;
 
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
+import uk.gov.hmcts.reform.fpl.model.common.C2DocumentBundle;
+
 
 public class C2UploadedEvent extends CallbackEvent {
+    private final C2DocumentBundle uploadedBundle;
 
-    public C2UploadedEvent(CallbackRequest callbackRequest) {
+    public C2UploadedEvent(CallbackRequest callbackRequest, C2DocumentBundle c2DocumentBundle) {
         super(callbackRequest);
+        uploadedBundle = c2DocumentBundle;
+    }
+
+    public C2DocumentBundle getUploadedBundle() {
+        return uploadedBundle;
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/events/C2UploadedEvent.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/events/C2UploadedEvent.java
@@ -1,9 +1,10 @@
 package uk.gov.hmcts.reform.fpl.events;
 
+import lombok.EqualsAndHashCode;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.fpl.model.common.C2DocumentBundle;
 
-
+@EqualsAndHashCode(callSuper = true)
 public class C2UploadedEvent extends CallbackEvent {
     private final C2DocumentBundle uploadedBundle;
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/C2UploadedEventHandler.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/C2UploadedEventHandler.java
@@ -40,7 +40,7 @@ public class C2UploadedEventHandler {
         if (!roles.containsAll(UserRole.HMCTS_ADMIN.getRoles())) {
             EventData eventData = new EventData(event);
             C2UploadedTemplate parameters = c2UploadedEmailContentProvider.buildC2UploadNotificationTemplate(
-                eventData.getCaseDetails());
+                eventData.getCaseDetails(), event.getUploadedBundle().getDocument());
 
             String email = adminNotificationHandler.getHmctsAdminEmail(eventData);
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/email/content/C2UploadedEmailContentProvider.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/email/content/C2UploadedEmailContentProvider.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.HearingBooking;
+import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
 import uk.gov.hmcts.reform.fpl.model.notify.allocatedjudge.AllocatedJudgeTemplateForC2;
 import uk.gov.hmcts.reform.fpl.model.notify.c2uploaded.C2UploadedTemplate;
 import uk.gov.hmcts.reform.fpl.service.email.content.base.AbstractEmailContentProvider;
@@ -24,14 +25,15 @@ public class C2UploadedEmailContentProvider extends AbstractEmailContentProvider
     private final ObjectMapper mapper;
     private final Time time;
 
-    public C2UploadedTemplate buildC2UploadNotificationTemplate(final CaseDetails caseDetails) {
+    public C2UploadedTemplate buildC2UploadNotificationTemplate(final CaseDetails caseDetails,
+                                                                final DocumentReference latestC2) {
         CaseData caseData = mapper.convertValue(caseDetails.getData(), CaseData.class);
 
         C2UploadedTemplate adminTemplateForC2 = new C2UploadedTemplate();
         adminTemplateForC2.setCallout(buildCallout(caseData));
         adminTemplateForC2.setRespondentLastName(getFirstRespondentLastName(caseData.getRespondents1()));
         adminTemplateForC2.setCaseUrl(getCaseUrl(caseDetails.getId()));
-        adminTemplateForC2.setDocumentLink(linkToAttachedDocument(caseData.getSubmittedForm()));
+        adminTemplateForC2.setDocumentLink(linkToAttachedDocument(latestC2));
 
         return adminTemplateForC2;
     }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/C2UploadedEventHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/C2UploadedEventHandlerTest.java
@@ -131,7 +131,8 @@ public class C2UploadedEventHandlerTest {
             given(inboxLookupService.getNotificationRecipientEmail(caseDetails, LOCAL_AUTHORITY_CODE))
                 .willReturn(LOCAL_AUTHORITY_EMAIL_ADDRESS);
 
-            given(c2UploadedEmailContentProvider.buildC2UploadNotificationTemplate(caseDetails, c2DocumentBundle.getDocument()))
+            given(c2UploadedEmailContentProvider
+                .buildC2UploadNotificationTemplate(caseDetails, c2DocumentBundle.getDocument()))
                 .willReturn(c2Parameters);
 
             c2UploadedEventHandler.sendNotifications(

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/C2UploadedEventHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/C2UploadedEventHandlerTest.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.config.HmctsCourtLookupConfiguration;
 import uk.gov.hmcts.reform.fpl.events.C2UploadedEvent;
+import uk.gov.hmcts.reform.fpl.model.common.C2DocumentBundle;
 import uk.gov.hmcts.reform.fpl.model.notify.allocatedjudge.AllocatedJudgeTemplateForC2;
 import uk.gov.hmcts.reform.fpl.model.notify.c2uploaded.C2UploadedTemplate;
 import uk.gov.hmcts.reform.fpl.request.RequestData;
@@ -82,6 +83,8 @@ public class C2UploadedEventHandlerTest {
     @Autowired
     private C2UploadedEventHandler c2UploadedEventHandler;
 
+    private C2DocumentBundle c2DocumentBundle = C2DocumentBundle.builder().build();
+
     @Nested
     class C2UploadedNotificationChecks {
         final String subjectLine = "Lastname, SACCCCCCCC5676576567";
@@ -91,7 +94,8 @@ public class C2UploadedEventHandlerTest {
         void before() {
             CaseDetails caseDetails = callbackRequest().getCaseDetails();
 
-            given(c2UploadedEmailContentProvider.buildC2UploadNotificationTemplate(callbackRequest().getCaseDetails()))
+            given(c2UploadedEmailContentProvider.buildC2UploadNotificationTemplate(callbackRequest().getCaseDetails(),
+                c2DocumentBundle.getDocument()))
                 .willReturn(c2Parameters);
 
             given(requestData.authorisation()).willReturn(AUTH_TOKEN);
@@ -110,7 +114,7 @@ public class C2UploadedEventHandlerTest {
                     COURT_CODE));
 
             c2UploadedEventHandler.sendNotifications(
-                new C2UploadedEvent(callbackRequest()));
+                new C2UploadedEvent(callbackRequest(), c2DocumentBundle));
 
             verify(notificationService).sendEmail(
                 C2_UPLOAD_NOTIFICATION_TEMPLATE, "hmcts-non-admin@test.com", c2Parameters, "12345");
@@ -127,11 +131,11 @@ public class C2UploadedEventHandlerTest {
             given(inboxLookupService.getNotificationRecipientEmail(caseDetails, LOCAL_AUTHORITY_CODE))
                 .willReturn(LOCAL_AUTHORITY_EMAIL_ADDRESS);
 
-            given(c2UploadedEmailContentProvider.buildC2UploadNotificationTemplate(caseDetails))
+            given(c2UploadedEmailContentProvider.buildC2UploadNotificationTemplate(caseDetails, c2DocumentBundle.getDocument()))
                 .willReturn(c2Parameters);
 
             c2UploadedEventHandler.sendNotifications(
-                new C2UploadedEvent(callbackRequest));
+                new C2UploadedEvent(callbackRequest, c2DocumentBundle));
 
             verify(notificationService).sendEmail(
                 C2_UPLOAD_NOTIFICATION_TEMPLATE,
@@ -146,7 +150,7 @@ public class C2UploadedEventHandlerTest {
                 UserInfo.builder().sub("hmcts-admin@test.com").roles(HMCTS_ADMIN.getRoles()).build());
 
             c2UploadedEventHandler.sendNotifications(
-                new C2UploadedEvent(callbackRequest()));
+                new C2UploadedEvent(callbackRequest(), c2DocumentBundle));
 
             verify(notificationService, never())
                 .sendEmail(C2_UPLOAD_NOTIFICATION_TEMPLATE, "hmcts-admin@test.com",
@@ -165,7 +169,7 @@ public class C2UploadedEventHandlerTest {
                 .willReturn(allocatedJudgeParametersForC2);
 
             c2UploadedEventHandler.sendC2UploadedNotificationToAllocatedJudge(
-                new C2UploadedEvent(callbackRequest));
+                new C2UploadedEvent(callbackRequest, c2DocumentBundle));
 
             verify(notificationService).sendEmail(
                 C2_UPLOAD_NOTIFICATION_TEMPLATE_JUDGE,
@@ -186,7 +190,7 @@ public class C2UploadedEventHandlerTest {
                 .willReturn(allocatedJudgeParametersForC2);
 
             c2UploadedEventHandler.sendC2UploadedNotificationToAllocatedJudge(
-                new C2UploadedEvent(callbackRequest));
+                new C2UploadedEvent(callbackRequest, c2DocumentBundle));
 
             verify(notificationService, never()).sendEmail(
                 eq(C2_UPLOAD_NOTIFICATION_TEMPLATE_JUDGE),
@@ -208,7 +212,7 @@ public class C2UploadedEventHandlerTest {
                 .willReturn(getAllocatedJudgeParametersForC2());
 
             c2UploadedEventHandler.sendC2UploadedNotificationToAllocatedJudge(
-                new C2UploadedEvent(callbackRequest));
+                new C2UploadedEvent(callbackRequest, c2DocumentBundle));
 
             verify(notificationService, never()).sendEmail(any(), any(), anyMap(), any());
         }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/email/content/C2UploadedEmailContentProviderTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/email/content/C2UploadedEmailContentProviderTest.java
@@ -12,7 +12,6 @@ import uk.gov.hmcts.reform.fpl.model.notify.allocatedjudge.AllocatedJudgeTemplat
 import uk.gov.hmcts.reform.fpl.model.notify.c2uploaded.C2UploadedTemplate;
 import uk.gov.hmcts.reform.fpl.utils.EmailNotificationHelper;
 import uk.gov.hmcts.reform.fpl.utils.FixedTimeConfiguration;
-import uk.gov.hmcts.reform.fpl.utils.TestDataHelper;
 
 import java.util.Map;
 
@@ -30,14 +29,15 @@ class C2UploadedEmailContentProviderTest extends AbstractEmailContentProviderTes
     @Autowired
     private C2UploadedEmailContentProvider c2UploadedEmailContentProvider;
 
-    private static final byte[] APPLICATION_BINARY = TestDataHelper.DOCUMENT_CONTENT;
+    private static final byte[] C2_DOCUMENT_BINARY = {5};
     private static DocumentReference applicationDocument;
+    private DocumentReference uploadedC2 = testDocumentReference();
 
     @BeforeEach
     void init() {
         applicationDocument = testDocumentReference();
-        when(documentDownloadService.downloadDocument(applicationDocument.getBinaryUrl()))
-            .thenReturn(APPLICATION_BINARY);
+        when(documentDownloadService.downloadDocument(uploadedC2.getBinaryUrl()))
+            .thenReturn(C2_DOCUMENT_BINARY);
     }
 
     @Test
@@ -47,7 +47,7 @@ class C2UploadedEmailContentProviderTest extends AbstractEmailContentProviderTes
 
         C2UploadedTemplate c2UploadedTemplateParameters = getC2UploadedTemplateParameters();
 
-        assertThat(c2UploadedEmailContentProvider.buildC2UploadNotificationTemplate(caseDetails))
+        assertThat(c2UploadedEmailContentProvider.buildC2UploadNotificationTemplate(caseDetails, uploadedC2))
             .isEqualToComparingFieldByField(c2UploadedTemplateParameters);
     }
 
@@ -93,7 +93,7 @@ class C2UploadedEmailContentProviderTest extends AbstractEmailContentProviderTes
         c2UploadedTemplate.setCallout(format("Smith, %s", CASE_REFERENCE));
         c2UploadedTemplate.setRespondentLastName("Smith");
         c2UploadedTemplate.setCaseUrl("http://fake-url/cases/case-details/12345");
-        c2UploadedTemplate.setDocumentLink(generateAttachedDocumentLink(APPLICATION_BINARY)
+        c2UploadedTemplate.setDocumentLink(generateAttachedDocumentLink(C2_DOCUMENT_BINARY)
             .map(JSONObject::toMap)
             .orElse(null));
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FPLA-2081

### Change description ###

Fixes the above defect and provides expected latest c2 bundle. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
