### PR TITLE
Revert "chore(deps-dev): bump codeceptjs from 2.6.8 to 2.6.9"

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "FPL CCD e2e tests",
   "devDependencies": {
     "babel-eslint": "^10.1.0",
-    "codeceptjs": "2.6.9",
+    "codeceptjs": "2.6.8",
     "dateformat": "^3.0.3",
     "eslint": "7.7.0",
     "eslint-plugin-codeceptjs": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -555,10 +555,10 @@ cliui@^5.0.0:
     strip-ansi "^5.2.0"
     wrap-ansi "^5.1.0"
 
-codeceptjs@2.6.9:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/codeceptjs/-/codeceptjs-2.6.9.tgz#a1174aa7b85c1384348281c85252a9a253842807"
-  integrity sha512-9A03TMaGQsBGxUk+POuDw4T1FqXs6WYCXAOSvJHzJyyCr3vuzscm+fvuI2NabgIfFLz1Q1hN6cy0HLfB3ukR0Q==
+codeceptjs@2.6.8:
+  version "2.6.8"
+  resolved "https://registry.yarnpkg.com/codeceptjs/-/codeceptjs-2.6.8.tgz#ffe08ead3636f4c153518f0fa90b255bf94605a0"
+  integrity sha512-dVY5UZ/LLEyRws5mC1r4i8M9Xnp5NGF3Y7IJU7V8pVeQfOP+oPJgG6mysM99eZeKXPWI8yY9U2MUFxnz5S7kCQ==
   dependencies:
     "@codeceptjs/configure" "^0.4.1"
     allure-js-commons "^1.3.2"


### PR DESCRIPTION
Reverts hmcts/fpl-ccd-configuration#1529

Seems e2e are a lot more flakey.