### PR TITLE
chore: remove Publish to cosmos which was not used anyway

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -165,7 +165,6 @@ withPipeline(type, product, component) {
 
   after('functionalTest:preview') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'output/**/*'
-    publishToCosmosDb(this, params, 'dbs/jenkins/colls/fpl-test-metrics', "${WORKSPACE}/output", 'metrics')
   }
 
   before('buildinfra:demo') {


### PR DESCRIPTION
Remove unused publish to cosmos db