### PR TITLE
refactor: SDO change state without extra event (FPLA-2157)

### DIFF
--- a/ccd-definition/AuthorisationCaseEvent/CareSupervision/AuthorisationCaseEvent.json
+++ b/ccd-definition/AuthorisationCaseEvent/CareSupervision/AuthorisationCaseEvent.json
@@ -485,13 +485,6 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "CaseEventID": "internal-changeState-Gatekeeping->PREPARE_FOR_HEARING",
-    "UserRole": "caseworker-publiclaw-systemupdate",
-    "CRUD": "C"
-  },
-  {
-    "LiveFrom": "01/01/2017",
-    "CaseTypeID": "CARE_SUPERVISION_EPO",
     "CaseEventID": "draftSDO",
     "UserRole": "caseworker-publiclaw-gatekeeper",
     "CRUD": "CRU"

--- a/ccd-definition/CaseEvent/CareSupervision/Gatekeeping.json
+++ b/ccd-definition/CaseEvent/CareSupervision/Gatekeeping.json
@@ -38,7 +38,7 @@
     "Description": "Draft standard directions",
     "DisplayOrder": 9,
     "PreConditionState(s)": "Gatekeeping",
-    "PostConditionState": "Gatekeeping",
+    "PostConditionState": "*",
     "SecurityClassification": "Public",
     "CallBackURLAboutToStartEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/draft-standard-directions/about-to-start",
     "CallBackURLAboutToSubmitEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/draft-standard-directions/about-to-submit",

--- a/ccd-definition/CaseEvent/CareSupervision/StateChange.json
+++ b/ccd-definition/CaseEvent/CareSupervision/StateChange.json
@@ -68,15 +68,6 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "ID": "internal-changeState-Gatekeeping->PREPARE_FOR_HEARING",
-    "Name": "-",
-    "PreConditionState(s)": "Gatekeeping",
-    "PostConditionState": "PREPARE_FOR_HEARING",
-    "SecurityClassification": "Public"
-  },
-  {
-    "LiveFrom": "01/01/2017",
-    "CaseTypeID": "CARE_SUPERVISION_EPO",
     "ID": "closeCase",
     "Name": "Close the case",
     "Description": "Close the case",

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/DraftOrdersControllerSubmittedTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/DraftOrdersControllerSubmittedTest.java
@@ -44,7 +44,6 @@ import static uk.gov.hmcts.reform.fpl.service.HearingBookingService.HEARING_DETA
 @OverrideAutoConfiguration(enabled = true)
 public class DraftOrdersControllerSubmittedTest extends AbstractControllerTest {
     private static final Long CASE_ID = 1L;
-    private static final String CASE_MANAGEMENT_EVENT = "internal-changeState-Gatekeeping->PREPARE_FOR_HEARING";
     private static final String SEND_DOCUMENT_EVENT = "internal-change-SEND_DOCUMENT";
     private static final DocumentReference DOCUMENT_REFERENCE = TestDataHelper.testDocumentReference();
     private static final String NOTIFICATION_REFERENCE = "localhost/" + CASE_ID;
@@ -104,20 +103,6 @@ public class DraftOrdersControllerSubmittedTest extends AbstractControllerTest {
             CASE_ID,
             SEND_DOCUMENT_EVENT,
             Map.of("documentToBeSent", DOCUMENT_REFERENCE));
-    }
-
-    @Test
-    void shouldTriggerStateChangeWhenOrderIsMarkedAsFinal() {
-        postSubmittedEvent(buildCallbackRequest(SEALED));
-
-        verify(coreCaseDataService).triggerEvent(JURISDICTION, CASE_TYPE, CASE_ID, CASE_MANAGEMENT_EVENT);
-    }
-
-    @Test
-    void shouldNotTriggerStateChangeWhenOrderIsStillInDraftState() {
-        postSubmittedEvent(buildCallbackRequest(DRAFT));
-
-        verify(coreCaseDataService, never()).triggerEvent(any(), any(), any(), eq(CASE_MANAGEMENT_EVENT));
     }
 
     private Map<String, Object> cafcassParameters() {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/DraftOrdersController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/DraftOrdersController.java
@@ -14,7 +14,7 @@ import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.document.domain.Document;
 import uk.gov.hmcts.reform.fpl.enums.DirectionAssignee;
-import uk.gov.hmcts.reform.fpl.enums.OrderStatus;
+import uk.gov.hmcts.reform.fpl.enums.State;
 import uk.gov.hmcts.reform.fpl.events.StandardDirectionsOrderIssuedEvent;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.Direction;
@@ -167,7 +167,7 @@ public class DraftOrdersController {
         if (!validationErrors.isEmpty()) {
             return AboutToStartOrSubmitCallbackResponse.builder()
                 .data(caseDetails.getData())
-                .errors(orderValidationService.validate(caseData))
+                .errors(validationErrors)
                 .build();
         }
 
@@ -206,6 +206,10 @@ public class DraftOrdersController {
         caseDetails.getData().remove(JUDGE_AND_LEGAL_ADVISOR_KEY);
         caseDetails.getData().remove("dateOfIssue");
 
+        if (order.getOrderStatus() == SEALED) {
+            caseDetails.getData().put("state", State.CASE_MANAGEMENT.getValue());
+        }
+
         return AboutToStartOrSubmitCallbackResponse.builder()
             .data(caseDetails.getData())
             .build();
@@ -216,7 +220,7 @@ public class DraftOrdersController {
         CaseData caseData = mapper.convertValue(callbackRequest.getCaseDetails().getData(), CaseData.class);
 
         Order standardDirectionOrder = caseData.getStandardDirectionOrder();
-        if (standardDirectionOrder.getOrderStatus() != OrderStatus.SEALED) {
+        if (standardDirectionOrder.getOrderStatus() != SEALED) {
             return;
         }
 
@@ -224,19 +228,10 @@ public class DraftOrdersController {
             callbackRequest.getCaseDetails().getJurisdiction(),
             callbackRequest.getCaseDetails().getCaseTypeId(),
             callbackRequest.getCaseDetails().getId(),
-            "internal-changeState-Gatekeeping->PREPARE_FOR_HEARING"
+            "internal-change-SEND_DOCUMENT",
+            Map.of("documentToBeSent", standardDirectionOrder.getOrderDoc())
         );
-
-        if (standardDirectionOrder.getOrderStatus() == SEALED) {
-            coreCaseDataService.triggerEvent(
-                callbackRequest.getCaseDetails().getJurisdiction(),
-                callbackRequest.getCaseDetails().getCaseTypeId(),
-                callbackRequest.getCaseDetails().getId(),
-                "internal-change-SEND_DOCUMENT",
-                Map.of("documentToBeSent", standardDirectionOrder.getOrderDoc())
-            );
-            applicationEventPublisher.publishEvent(new StandardDirectionsOrderIssuedEvent(callbackRequest));
-        }
+        applicationEventPublisher.publishEvent(new StandardDirectionsOrderIssuedEvent(callbackRequest));
     }
 
     private JudgeAndLegalAdvisor prepareJudge(CaseData caseData) {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/StandardDirectionsOrderController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/StandardDirectionsOrderController.java
@@ -207,7 +207,7 @@ public class StandardDirectionsOrderController {
         caseDetails.getData().remove("dateOfIssue");
 
         if (order.getOrderStatus() == SEALED) {
-            caseDetails.getData().put("state", State.CASE_MANAGEMENT.getValue());
+            caseDetails.getData().put("state", State.CASE_MANAGEMENT);
         }
 
         return AboutToStartOrSubmitCallbackResponse.builder()

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/enums/State.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/enums/State.java
@@ -21,7 +21,9 @@ public enum State {
 
     // State label renamed to 'Case management' as of FPLA-1920.
     // State ID remains 'PREPARE_FOR_HEARING' to avoid breaking existing cases.
+    @JsonProperty("PREPARE_FOR_HEARING")
     CASE_MANAGEMENT("PREPARE_FOR_HEARING"),
+
     CLOSED("CLOSED"),
 
     @JsonProperty("Deleted")


### PR DESCRIPTION
### JIRA link (if applicable) ###

[FPLA-2157](https://tools.hmcts.net/jira/browse/FPLA-2157)

### Change description ###

Removed the state change for SDO being dependant on another event and just done it in the about to submit of the controller instead.
Updated tests to reflect this change.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
