### PR TITLE
fix: cmo progression e2e in AAT

### DIFF
--- a/e2e/fixtures/finalHearing.json
+++ b/e2e/fixtures/finalHearing.json
@@ -335,11 +335,7 @@
       {
         "id": "749f29dc-c200-4377-9e12-a5b4bad631b3",
         "value": {
-          "order":{
-            "document_url":"http://dm-store:8080/documents/7196dcc4-dd17-49ba-9924-7480b91e620e",
-            "document_filename":"mockFile.pdf",
-            "document_binary_url":"http://dm-store:8080/documents/7196dcc4-dd17-49ba-9924-7480b91e620e/binary"
-          },
+          "order":"TO BE FILLED WITH VALID DATA",
           "status": "APPROVED",
           "hearing": "Case management hearing, 1 January 2020",
           "dateSent": "2020-08-27",

--- a/e2e/fixtures/issueResolution.json
+++ b/e2e/fixtures/issueResolution.json
@@ -319,11 +319,7 @@
       {
         "id": "749f29dc-c200-4377-9e12-a5b4bad631b3",
         "value": {
-          "order":{
-            "document_url":"http://dm-store:8080/documents/7196dcc4-dd17-49ba-9924-7480b91e620e",
-            "document_filename":"mockFile.pdf",
-            "document_binary_url":"http://dm-store:8080/documents/7196dcc4-dd17-49ba-9924-7480b91e620e/binary"
-          },
+          "order":"TO BE FILLED WITH VALID DATA",
           "status": "APPROVED",
           "hearing": "Case management hearing, 1 January 2020",
           "dateSent": "2020-08-27",

--- a/e2e/helpers/case_helper.js
+++ b/e2e/helpers/case_helper.js
@@ -51,6 +51,11 @@ const updateCaseDataWithDocuments = (caseData) => {
       order.value.document = documentData(order.value.type + '.pdf');
     }
   }
+  if (caseData.sealedCMOs) {
+    for (const cmo of caseData.sealedCMOs) {
+      cmo.value.order = documentData('mockFile.pdf');
+    }
+  }
 };
 
 const populateWithData = async (caseId, data) => {

--- a/e2e/pages/caseList.page.js
+++ b/e2e/pages/caseList.page.js
@@ -19,6 +19,8 @@ module.exports = {
   },
 
   changeStateFilter(desiredState) {
+    I.selectOption(this.fields.jurisdiction, config.definition.jurisdictionFullDesc);
+    I.selectOption(this.fields.caseType, config.definition.caseTypeFullDesc);
     I.selectOption(this.fields.caseState, desiredState);
     I.click(this.fields.search);
   },


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###

Allow for documents to be generated for the sealed cmos so that the doc store urls are valid in AAT.
Select the correct jurisdiction and case type when in AAT (only case type was noticed being wrong but best to double check)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
