### PR TITLE
chore: Stop e2e test on case population failure

### DIFF
--- a/e2e/helpers/case_helper.js
+++ b/e2e/helpers/case_helper.js
@@ -12,12 +12,23 @@ const getAgent = function (url) {
   }
 };
 
-const post = async (url, data, headers) => {
+const wait = duration => new Promise(resolve => setTimeout(resolve, duration));
+
+const post = async (url, data, headers, retry = 2, backoff = 500) => {
   return fetch(url, {
     method: 'POST',
     body: JSON.stringify(data),
     headers: headers,
     agent: getAgent(url),
+  }).then(res => {
+    if (res.ok) {
+      return res;
+    } else {
+      if (retry > 0) {
+        return wait(backoff).then(() => post(url, data, headers, retry - 1, backoff * 1.5));
+      }
+      throw {message: `POST ${url} failed with ${res.status}`};
+    }
   });
 };
 


### PR DESCRIPTION
[1.parallel:chunk1:default] Case created #1599756253809091
[1.parallel:chunk1:default]   ✖ "before all" hook: BeforeSuite for "Different user in the same local authority can see case created" in 20196ms

[1.parallel:chunk1:default] -- FAILURES:

  1) Access segregation
       "before all" hook: BeforeSuite for "Different user in the same local authority can see case created":
     [Wrapped Error] {"message":"POST http://localhost:4000/testing-support222/case/populate/1599756253809091 failed with 404"}
  
  Run with --verbose flag to see NodeJS stacktrace


[1.parallel:chunk1:default]   FAIL  | 0 passed, 1 failed   // 22s
