### PR TITLE
fix: sdo regression

### DIFF
--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/AbstractControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/AbstractControllerTest.java
@@ -236,6 +236,13 @@ abstract class AbstractControllerTest {
             .build();
     }
 
+    CallbackRequest toCallBackRequest(CaseDetails caseDetails, CaseDetails caseDetailsBefore) {
+        return CallbackRequest.builder()
+            .caseDetails(caseDetails)
+            .caseDetailsBefore(caseDetailsBefore)
+            .build();
+    }
+
     LocalDateTime now() {
         return time.now();
     }

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/StandardDirectionsOrderControllerUploadRouteMidEventTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/StandardDirectionsOrderControllerUploadRouteMidEventTest.java
@@ -5,6 +5,7 @@ import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.ActiveProfiles;
 import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse;
+import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.StandardDirectionOrder;
 import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
@@ -28,30 +29,29 @@ public class StandardDirectionsOrderControllerUploadRouteMidEventTest extends Ab
             .preparedSDO(DOCUMENT)
             .build();
 
-        AboutToStartOrSubmitCallbackResponse response = postMidEvent(asCaseDetails(caseData), "upload-route");
+        CallbackRequest request = toCallBackRequest(asCaseDetails(caseData), asCaseDetails(CaseData.builder().build()));
+        AboutToStartOrSubmitCallbackResponse response = postMidEvent(request, "upload-route");
 
         StandardDirectionOrder expectedOrder = StandardDirectionOrder.builder().orderDoc(DOCUMENT).build();
-        StandardDirectionOrder builtOrder = mapper.convertValue(
-            response.getData().get("standardDirectionOrder"),
-            StandardDirectionOrder.class
-        );
+        StandardDirectionOrder builtOrder = extractCaseData(response).getStandardDirectionOrder();
 
         assertThat(builtOrder).isEqualTo(expectedOrder);
     }
 
     @Test
     void shouldAddAlreadyUploadedDocumentToConstructedStandardDirectionOrder() {
-        CaseData caseData = CaseData.builder()
+        CaseData caseDataBefore = CaseData.builder()
             .standardDirectionOrder(StandardDirectionOrder.builder().orderDoc(DOCUMENT).build())
             .build();
 
-        AboutToStartOrSubmitCallbackResponse response = postMidEvent(asCaseDetails(caseData), "upload-route");
+        CallbackRequest request = toCallBackRequest(
+            asCaseDetails(CaseData.builder().build()),
+            asCaseDetails(caseDataBefore)
+        );
+        AboutToStartOrSubmitCallbackResponse response = postMidEvent(request, "upload-route");
 
         StandardDirectionOrder expectedOrder = StandardDirectionOrder.builder().orderDoc(DOCUMENT).build();
-        StandardDirectionOrder builtOrder = mapper.convertValue(
-            response.getData().get("standardDirectionOrder"),
-            StandardDirectionOrder.class
-        );
+        StandardDirectionOrder builtOrder = extractCaseData(response).getStandardDirectionOrder();
 
         assertThat(builtOrder).isEqualTo(expectedOrder);
     }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/StandardDirectionsOrderController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/StandardDirectionsOrderController.java
@@ -179,12 +179,15 @@ public class StandardDirectionsOrderController extends CallbackController {
     @PostMapping("/upload-route/mid-event")
     public CallbackResponse handleUploadMidEvent(@RequestBody CallbackRequest request) {
         CaseDetails caseDetails = request.getCaseDetails();
-        Map<String, Object> data = caseDetails.getData();
         CaseData caseData = getCaseData(caseDetails);
+        CaseData caseDataBefore = getCaseDataBefore(request);
 
-        StandardDirectionOrder order = sdoService.buildTemporarySDO(caseData);
+        StandardDirectionOrder order = sdoService.buildTemporarySDO(
+            caseData,
+            caseDataBefore.getStandardDirectionOrder()
+        );
 
-        data.put("standardDirectionOrder", order);
+        caseDetails.getData().put("standardDirectionOrder", order);
 
         return respond(caseDetails);
     }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/sdo/StandardDirectionsOrderService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/sdo/StandardDirectionsOrderService.java
@@ -37,14 +37,14 @@ public class StandardDirectionsOrderService {
         return dateOfIssue;
     }
 
-    public StandardDirectionOrder buildTemporarySDO(CaseData caseData) {
+    public StandardDirectionOrder buildTemporarySDO(CaseData caseData, StandardDirectionOrder previousSDO) {
         DocumentReference document = caseData.getPreparedSDO();
 
         if (document == null) {
             // been through once, either pull from replacement doc or SDO if that isn't present
             document = defaultIfNull(
                 caseData.getReplacementSDO(),
-                caseData.getStandardDirectionOrder().getOrderDoc()
+                previousSDO.getOrderDoc()
             );
         }
         return StandardDirectionOrder.builder()

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/sdo/StandardDirectionsOrderServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/sdo/StandardDirectionsOrderServiceTest.java
@@ -74,7 +74,7 @@ class StandardDirectionsOrderServiceTest {
             .preparedSDO(PDF_DOC)
             .build();
 
-        StandardDirectionOrder order = service.buildTemporarySDO(caseData);
+        StandardDirectionOrder order = service.buildTemporarySDO(caseData, null);
 
         StandardDirectionOrder expectedOrder = StandardDirectionOrder.builder().orderDoc(PDF_DOC).build();
 
@@ -86,10 +86,11 @@ class StandardDirectionsOrderServiceTest {
         CaseData caseData = CaseData.builder()
             .preparedSDO(null)
             .replacementSDO(WORD_DOC)
-            .standardDirectionOrder(StandardDirectionOrder.builder().build())
             .build();
 
-        StandardDirectionOrder order = service.buildTemporarySDO(caseData);
+        StandardDirectionOrder previousSDO = StandardDirectionOrder.builder().build();
+
+        StandardDirectionOrder order = service.buildTemporarySDO(caseData, previousSDO);
 
         StandardDirectionOrder expectedOrder = StandardDirectionOrder.builder().orderDoc(WORD_DOC).build();
 
@@ -98,15 +99,16 @@ class StandardDirectionsOrderServiceTest {
 
     @Test
     void shouldUseCurrentSDODocumentForTemporaryStandardDirectionOrder() {
+        StandardDirectionOrder previousSDO = StandardDirectionOrder.builder()
+            .orderDoc(SEALED_DOC)
+            .build();
+
         CaseData caseData = CaseData.builder()
             .preparedSDO(null)
             .replacementSDO(null)
-            .standardDirectionOrder(StandardDirectionOrder.builder()
-                .orderDoc(SEALED_DOC)
-                .build())
             .build();
 
-        StandardDirectionOrder order = service.buildTemporarySDO(caseData);
+        StandardDirectionOrder order = service.buildTemporarySDO(caseData, previousSDO);
 
         StandardDirectionOrder expectedOrder = StandardDirectionOrder.builder().orderDoc(SEALED_DOC).build();
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

FPLA-N/A

### Change description ###

Use case details before instead of current case data. CCD now removes fields that appear on the next screen after a mid event (see [ccd-data-store](https://github.com/hmcts/ccd-data-store-api/blob/24b7e06f8b195867e03e7909bda94662c9d5a14d/src/main/java/uk/gov/hmcts/ccd/domain/service/createevent/MidEventCallback.java#L78))

#### Scenarios
- goes through event once
- goes though event twice + uploads new on second pass
- goes though event twice + keeps current doc on second pass (nothing uploaded)

Will need to check if anything breaks with old SDO flow; hopefully we can trust e2e though, it spotted this issue for us.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
