### PR TITLE
ci: automate adding labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,5 @@
+ccd configuration:
+  - any: ['ccd-definition/**/*']
+
+docmosis:
+  - any: ['docker/docmosis/templates/*']

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,17 @@
+# This workflow will triage pull requests and apply a label based on the
+# paths that are modified in the pull request.
+#
+# To use this workflow, you will need to set up a .github/labeler.yml
+# file with configuration.  For more information, see:
+# https://github.com/actions/labeler
+name: "Pull Request Labeler"
+on: [pull_request]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@main
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        sync-labels: true


### PR DESCRIPTION
### JIRA link (if applicable) ###

FPLA-N/A

### Change description ###

Add a github action to automate the process of adding common labels to PRs.
At the moment this will just add the `ccd configuration` label to PRs that alter files in the `ccd-definition` directory, and the `docmosis` label to PRs that alter files in the `docker/docmosis/templates` directory.
It is set up so that the labels should remove themselves if the corresponding changes are reverted.

An example of a future label could be related to onboarding, from my understanding when we onboard a new LA we need to add an entry into the `ccd-definition/FixedLists/CareSupervision/AuthorityFixedList.json`

More can be read at the [action page](https://github.com/actions/labeler)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
