### PR TITLE
fix: Fix sonarcloud bugs (FPLA-2039)

### DIFF
--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/validation/validators/HasContactDirectionValidatorTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/validation/validators/HasContactDirectionValidatorTest.java
@@ -56,6 +56,6 @@ public class HasContactDirectionValidatorTest extends AbstractValidationTest {
 
         List<String> errorMessages = validate(applicantParty);
 
-        assertThat(errorMessages).doesNotContain(ERROR_MESSAGE);
+        assertThat(errorMessages).isNotEmpty().doesNotContain(ERROR_MESSAGE);
     }
 }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/validation/validators/HasContactDirectionValidatorTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/validation/validators/HasContactDirectionValidatorTest.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class HasContactDirectionValidatorTest extends AbstractValidationTest {
+class HasContactDirectionValidatorTest extends AbstractValidationTest {
 
     private static final String ERROR_MESSAGE = "Enter the contact's full name";
 

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/validation/validators/HasGenderValidatorTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/validation/validators/HasGenderValidatorTest.java
@@ -24,7 +24,7 @@ class HasGenderValidatorTest extends AbstractValidationTest {
 
         List<String> validationErrors = validate(child);
 
-        assertThat(validationErrors).doesNotContain(ERROR_MESSAGE);
+        assertThat(validationErrors).isNotEmpty().doesNotContain(ERROR_MESSAGE);
     }
 
     @Test
@@ -36,7 +36,7 @@ class HasGenderValidatorTest extends AbstractValidationTest {
 
         List<String> validationErrors = validate(child);
 
-        assertThat(validationErrors).doesNotContain(ERROR_MESSAGE);
+        assertThat(validationErrors).isNotEmpty().doesNotContain(ERROR_MESSAGE);
     }
 
     @Test

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/validation/validators/HasTelephoneOrMobileValidatorTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/validation/validators/HasTelephoneOrMobileValidatorTest.java
@@ -23,7 +23,7 @@ class HasTelephoneOrMobileValidatorTest extends AbstractValidationTest {
 
         List<String> errorMessages = validate(applicantParty);
 
-        assertThat(errorMessages).doesNotContain(ERROR_MESSAGE);
+        assertThat(errorMessages).isNotEmpty().doesNotContain(ERROR_MESSAGE);
     }
 
     @Test
@@ -36,7 +36,7 @@ class HasTelephoneOrMobileValidatorTest extends AbstractValidationTest {
 
         List<String> errorMessages = validate(applicantParty);
 
-        assertThat(errorMessages).doesNotContain(ERROR_MESSAGE);
+        assertThat(errorMessages).isNotEmpty().doesNotContain(ERROR_MESSAGE);
     }
 
     @Test
@@ -52,7 +52,7 @@ class HasTelephoneOrMobileValidatorTest extends AbstractValidationTest {
 
         List<String> errorMessages = validate(applicantParty);
 
-        assertThat(errorMessages).doesNotContain(ERROR_MESSAGE);
+        assertThat(errorMessages).isNotEmpty().doesNotContain(ERROR_MESSAGE);
     }
 
     @Test
@@ -68,7 +68,7 @@ class HasTelephoneOrMobileValidatorTest extends AbstractValidationTest {
 
         List<String> errorMessages = validate(applicantParty);
 
-        assertThat(errorMessages).doesNotContain(ERROR_MESSAGE);
+        assertThat(errorMessages).isNotEmpty().doesNotContain(ERROR_MESSAGE);
     }
 
     @Test

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/validation/validators/documents/HasAttachedDocumentValidatorTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/validation/validators/documents/HasAttachedDocumentValidatorTest.java
@@ -41,27 +41,27 @@ public class HasAttachedDocumentValidatorTest {
     void shouldNotReturnAnErrorWhenStatusIsAttachedAndDocumentIsAttached() {
         Document document = createDocumentWithStatus(ATTACHED);
         List<String> errorMessages = validateGroupService.validateGroup(document, UploadDocumentsGroup.class);
-        assertThat(errorMessages).doesNotContain(ERROR_MESSAGE);
+        assertThat(errorMessages).isEmpty();
     }
 
     @Test
     void shouldNotReturnAnErrorWhenDocumentIsAttachedWithoutStatus() {
         Document document = createDocumentWithStatus(null);
         List<String> errorMessages = validateGroupService.validateGroup(document, UploadDocumentsGroup.class);
-        assertThat(errorMessages).doesNotContain(ERROR_MESSAGE);
+        assertThat(errorMessages).isEmpty();
     }
 
     @Test
     void shouldNotReturnAnErrorWhenDocumentIsNotAttached() {
         Document document = Document.builder().build();
         List<String> errorMessages = validateGroupService.validateGroup(document, UploadDocumentsGroup.class);
-        assertThat(errorMessages).doesNotContain(ERROR_MESSAGE);
+        assertThat(errorMessages).isEmpty();
     }
 
     @Test
     void shouldNotReturnAnErrorWhenDocumentStatusIsNotAttached() {
         Document document = createDocumentWithStatus(TO_FOLLOW);
         List<String> errorMessages = validateGroupService.validateGroup(document, UploadDocumentsGroup.class);
-        assertThat(errorMessages).doesNotContain(ERROR_MESSAGE);
+        assertThat(errorMessages).isEmpty();
     }
 }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/validation/validators/documents/HasAttachedDocumentValidatorTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/validation/validators/documents/HasAttachedDocumentValidatorTest.java
@@ -18,7 +18,7 @@ import static uk.gov.hmcts.reform.fpl.enums.DocumentStatus.TO_FOLLOW;
 import static uk.gov.hmcts.reform.fpl.utils.CaseDataGeneratorHelper.createDocumentWithStatus;
 
 @ExtendWith(SpringExtension.class)
-public class HasAttachedDocumentValidatorTest {
+class HasAttachedDocumentValidatorTest {
     private Validator validator;
     private ValidateGroupService validateGroupService;
 

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/validation/validators/documents/HasDocumentsIncludedInSwetValidatorTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/validation/validators/documents/HasDocumentsIncludedInSwetValidatorTest.java
@@ -57,14 +57,14 @@ public class HasDocumentsIncludedInSwetValidatorTest {
             getDocument(testDocumentReference(), ATTACHED), getDocument(null, INCLUDED_IN_SWET));
 
         List<String> errorMessages = validateGroupService.validateGroup(caseData, UploadDocumentsGroup.class);
-        assertThat(errorMessages).doesNotContain(ERROR_MESSAGE);
+        assertThat(errorMessages).isEmpty();
     }
 
     @Test
     void shouldNotReturnAnErrorIfDocumentStatusIsNotIncludedInSwet() {
         CaseData caseData = getCaseData(null, getDocument(null, ATTACHED));
         List<String> errorMessages = validateGroupService.validateGroup(caseData, UploadDocumentsGroup.class);
-        assertThat(errorMessages).doesNotContain(ERROR_MESSAGE);
+        assertThat(errorMessages).isNotEmpty().doesNotContain(ERROR_MESSAGE);
     }
 
     private static Document getDocument(DocumentReference reference, DocumentStatus status) {

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/validation/validators/documents/HasDocumentsIncludedInSwetValidatorTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/validation/validators/documents/HasDocumentsIncludedInSwetValidatorTest.java
@@ -23,7 +23,7 @@ import static uk.gov.hmcts.reform.fpl.enums.DocumentStatus.TO_FOLLOW;
 import static uk.gov.hmcts.reform.fpl.utils.TestDataHelper.testDocumentReference;
 
 @ExtendWith(SpringExtension.class)
-public class HasDocumentsIncludedInSwetValidatorTest {
+class HasDocumentsIncludedInSwetValidatorTest {
     private Validator validator;
     private ValidateGroupService validateGroupService;
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FPLA-2039

### Change description ###
- Update assertions to verify if the collection is empty when verifying the collection elements
- Remove `public` class access modifier

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
