### PR TITLE
fix: create order document mid event not being triggered

### DIFF
--- a/ccd-definition/CaseEventToFields/CareSupervision/createOrder/createOrder.json
+++ b/ccd-definition/CaseEventToFields/CareSupervision/createOrder/createOrder.json
@@ -337,7 +337,8 @@
     "PageDisplayOrder": 13,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "Y",
-    "FieldShowCondition": "orderTypeAndDocument.type=\"CARE_ORDER\" AND orderTypeAndDocument.subtype=\"INTERIM\""
+    "FieldShowCondition": "orderTypeAndDocument.type=\"CARE_ORDER\" AND orderTypeAndDocument.subtype=\"INTERIM\"",
+    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/create-order/generate-document/mid-event"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -350,8 +351,7 @@
     "PageDisplayOrder": 13,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "Y",
-    "PageShowCondition": "orderTypeAndDocument.type!=\"BLANK_ORDER\" AND orderTypeAndDocument.type!=\"UPLOAD\"",
-    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/create-order/generate-document/mid-event"
+    "PageShowCondition": "orderTypeAndDocument.type!=\"BLANK_ORDER\" AND orderTypeAndDocument.type!=\"UPLOAD\""
   },
   {
     "LiveFrom": "01/01/2017",


### PR DESCRIPTION
### Change description ###

Fix create-order document mid event not being triggered on further directions page. Mid event callback must always be attached to first page element in CCD

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
