### PR TITLE
fix: suppress 9.0.x tomcat-embed-websocket/core 

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -20,4 +20,18 @@
     <cve>CVE-2020-10663</cve>
     <cve>CVE-2020-7712</cve>
   </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: tomcat-embed-core-9.0.38.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-core@.*$</packageUrl>
+    <cve>CVE-2020-13943</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: tomcat-embed-websocket-9.0.38.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-websocket@.*$</packageUrl>
+    <cve>CVE-2020-13943</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION


**Before creating a pull request make sure that:**

- [ ] PR's title includes JIRA ticket number and follow [Conventional Commits](https://www.conventionalcommits.org/) specification
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###
- no fix for 9.0.x available


**Does this PR introduce a breaking change?** (check one with "x")

```
[ x] Yes
[x ] No
```
