### PR TITLE
Revert "chore(deps): bump flyway-core from 6.5.7 to 7.1.1 (#1808)"

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -222,7 +222,7 @@ dependencies {
   implementation group: 'io.github.openfeign', name: 'feign-core', version: '11.0'
 
   implementation group: 'org.postgresql', name: 'postgresql', version: '42.2.18'
-  implementation group: 'org.flywaydb', name: 'flyway-core', version: '7.1.1'
+  implementation group: 'org.flywaydb', name: 'flyway-core', version: '6.5.7'
 
   implementation group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
   implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger


### PR DESCRIPTION
An attempt was made to call a method that does not exist. The attempt was made from the following location:

    org.springframework.boot.autoconfigure.flyway.FlywayMigrationInitializer.afterPropertiesSet(FlywayMigrationInitializer.java:65)

The following method did not exist:

    'int org.flywaydb.core.Flyway.migrate()'

The method's class, org.flywaydb.core.Flyway, is available from the following locations:

    jar:file:/opt/app/service.jar!/BOOT-INF/lib/flyway-core-7.1.1.jar!/org/flywaydb/core/Flyway.class

The class hierarchy was loaded from the following locations:

    org.flywaydb.core.Flyway: jar:file:/opt/app/service.jar!/BOOT-INF/lib/flyway-core-7.1.1.jar!/