### PR TITLE
feat: Email notifications for CMO and SDO removals (FPLA-2413)

### DIFF
--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/RemoveOrderControllerSubmittedTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/RemoveOrderControllerSubmittedTest.java
@@ -1,0 +1,255 @@
+package uk.gov.hmcts.reform.fpl.controllers;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.fpl.enums.GeneratedOrderType;
+import uk.gov.hmcts.reform.fpl.model.CaseData;
+import uk.gov.hmcts.reform.fpl.model.Child;
+import uk.gov.hmcts.reform.fpl.model.ChildParty;
+import uk.gov.hmcts.reform.fpl.model.Respondent;
+import uk.gov.hmcts.reform.fpl.model.RespondentParty;
+import uk.gov.hmcts.reform.fpl.model.StandardDirectionOrder;
+import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
+import uk.gov.hmcts.reform.fpl.model.common.Element;
+import uk.gov.hmcts.reform.fpl.model.common.EmailAddress;
+import uk.gov.hmcts.reform.fpl.model.order.CaseManagementOrder;
+import uk.gov.hmcts.reform.fpl.model.order.generated.GeneratedOrder;
+import uk.gov.hmcts.reform.fpl.service.ccd.CoreCaseDataService;
+import uk.gov.hmcts.reform.fpl.utils.TestDataHelper;
+import uk.gov.service.notify.NotificationClient;
+import uk.gov.service.notify.NotificationClientException;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static uk.gov.hmcts.reform.fpl.NotifyTemplates.CMO_REMOVAL_NOTIFICATION_TEMPLATE;
+import static uk.gov.hmcts.reform.fpl.NotifyTemplates.SDO_REMOVAL_NOTIFICATION_TEMPLATE;
+import static uk.gov.hmcts.reform.fpl.enums.CMOStatus.APPROVED;
+import static uk.gov.hmcts.reform.fpl.enums.OrderStatus.SEALED;
+import static uk.gov.hmcts.reform.fpl.utils.AssertionHelper.checkThat;
+import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.element;
+import static uk.gov.hmcts.reform.fpl.utils.OrderHelper.getFullOrderType;
+import static uk.gov.hmcts.reform.fpl.utils.matchers.JsonMatcher.eqJson;
+
+@ActiveProfiles("integration-test")
+@WebMvcTest(RemoveOrderController.class)
+@OverrideAutoConfiguration(enabled = true)
+class RemoveOrderControllerSubmittedTest extends AbstractControllerTest {
+
+    private static final long CASE_ID = 12345L;
+    private static final String LOCAL_AUTHORITY_CODE = "example";
+    private static final String LOCAL_AUTHORITY_EMAIL_ADDRESS = "local-authority@local-authority.com";
+    private static final String GATEKEEPER_EMAIL_ADDRESS = "FamilyPublicLaw+gatekeeper@gmail.com";
+    private static final String NOTIFICATION_REFERENCE = "localhost/" + CASE_ID;
+
+    private static final DocumentReference DOCUMENT_REFERENCE = TestDataHelper.testDocumentReference();
+    private static final String REMOVAL_REASON = "The order was removed because incorrect data was entered";
+    private static final String RESPONDENT_LAST_NAME = "Smith";
+    public static final Respondent RESPONDENT = Respondent.builder()
+        .party(RespondentParty.builder().lastName(RESPONDENT_LAST_NAME).build())
+        .build();
+
+    @MockBean
+    private NotificationClient notificationClient;
+
+    @MockBean
+    private CoreCaseDataService coreCaseDataService;
+
+    RemoveOrderControllerSubmittedTest() {
+        super("remove-order");
+    }
+
+    @Test
+    void shouldNotSendNotificationsWhenBlankOrderIsRemoved() {
+        Element<CaseManagementOrder> cmo = buildApprovedCMOElement(false);
+
+        Element<GeneratedOrder> blankOrder = element(buildBlankOrder());
+
+        CaseDetails caseDetailsBefore = buildCaseDetails(singletonList(blankOrder), singletonList(cmo), null);
+        CaseDetails caseDetailsAfter = buildCaseDetails(emptyList(), singletonList(cmo), null);
+
+        CallbackRequest callbackRequest = CallbackRequest.builder()
+            .caseDetails(caseDetailsAfter)
+            .caseDetailsBefore(caseDetailsBefore).build();
+
+        postSubmittedEvent(callbackRequest);
+
+        checkThat(() -> verify(notificationClient, never()).sendEmail(any(), any(), any(), any()));
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+        value = GeneratedOrderType.class,
+        names = {"EMERGENCY_PROTECTION_ORDER", "CARE_ORDER", "SUPERVISION_ORDER"}
+    )
+    void shouldNotSendNotificationsWhenGeneratedOrderIsRemoved(GeneratedOrderType generatedOrderType) {
+        Element<GeneratedOrder> order = element(buildOrder(generatedOrderType));
+        Element<GeneratedOrder> blankOrder = element(buildBlankOrder());
+
+        CaseDetails caseDetailsBefore = buildCaseDetails(List.of(blankOrder, order), emptyList(), null);
+        CaseDetails caseDetailsAfter = buildCaseDetails(singletonList(blankOrder), emptyList(), null);
+
+        CallbackRequest callbackRequest = CallbackRequest.builder()
+            .caseDetails(caseDetailsAfter)
+            .caseDetailsBefore(caseDetailsBefore).build();
+
+        postSubmittedEvent(callbackRequest);
+
+        checkThat(() -> verify(notificationClient, never()).sendEmail(any(), any(), any(), any()));
+    }
+
+    @Test
+    void shouldSendNotificationsToLocalAuthorityWhenCMOIsRemoved() throws NotificationClientException {
+        Element<CaseManagementOrder> cmo = buildApprovedCMOElement(true);
+        Element<GeneratedOrder> blankOrder = element(buildBlankOrder());
+
+        CaseDetails caseDetailsBefore = buildCaseDetails(singletonList(blankOrder), singletonList(cmo), null);
+        CaseDetails caseDetailsAfter = buildCaseDetails(singletonList(blankOrder), emptyList(), null);
+
+        CallbackRequest callbackRequest = CallbackRequest.builder()
+            .caseDetails(caseDetailsAfter)
+            .caseDetailsBefore(caseDetailsBefore).build();
+
+        postSubmittedEvent(callbackRequest);
+
+        verify(notificationClient).sendEmail(
+            eq(CMO_REMOVAL_NOTIFICATION_TEMPLATE),
+            eq(LOCAL_AUTHORITY_EMAIL_ADDRESS),
+            eqJson(expectedOrderRemovalTemplateParameters()),
+            eq(NOTIFICATION_REFERENCE));
+    }
+
+    @Test
+    void shouldSendNotificationsToLocalAuthorityWhenMultipleCMOsExistAndOneOfThemIsRemoved()
+        throws NotificationClientException {
+        Element<CaseManagementOrder> cmo1 = buildApprovedCMOElement(false);
+        Element<CaseManagementOrder> cmo2 = buildApprovedCMOElement(true);
+
+        Element<GeneratedOrder> blankOrder = element(buildBlankOrder());
+
+        CaseDetails caseDetailsBefore = buildCaseDetails(singletonList(blankOrder), List.of(cmo1, cmo2), null);
+        CaseDetails caseDetailsAfter = buildCaseDetails(singletonList(blankOrder), singletonList(cmo1), null);
+
+        CallbackRequest callbackRequest = CallbackRequest.builder()
+            .caseDetails(caseDetailsAfter)
+            .caseDetailsBefore(caseDetailsBefore).build();
+
+        postSubmittedEvent(callbackRequest);
+
+        verify(notificationClient).sendEmail(
+            eq(CMO_REMOVAL_NOTIFICATION_TEMPLATE),
+            eq(LOCAL_AUTHORITY_EMAIL_ADDRESS),
+            eqJson(expectedOrderRemovalTemplateParameters()),
+            eq(NOTIFICATION_REFERENCE));
+    }
+
+    @Disabled
+    @Test
+    void shouldSendNotificationsToGatekeeperWhenSDOIsRemoved() throws NotificationClientException {
+        Element<CaseManagementOrder> cmo = buildApprovedCMOElement(false);
+        StandardDirectionOrder sdo = buildSDOElement();
+
+        Element<GeneratedOrder> blankOrder = element(buildBlankOrder());
+
+        CaseDetails caseDetailsBefore = buildCaseDetails(singletonList(blankOrder), singletonList(cmo), sdo);
+        CaseDetails caseDetailsAfter = buildCaseDetails(singletonList(blankOrder), singletonList(cmo), null);
+
+        CallbackRequest callbackRequest = CallbackRequest.builder()
+            .caseDetails(caseDetailsAfter)
+            .caseDetailsBefore(caseDetailsBefore).build();
+
+        postSubmittedEvent(callbackRequest);
+
+        verify(notificationClient).sendEmail(
+            eq(SDO_REMOVAL_NOTIFICATION_TEMPLATE),
+            eq(GATEKEEPER_EMAIL_ADDRESS),
+            eqJson(expectedOrderRemovalTemplateParameters()),
+            eq(NOTIFICATION_REFERENCE));
+    }
+
+    private Map<String, Object> expectedOrderRemovalTemplateParameters() {
+        return ImmutableMap.of(
+            "caseReference", String.valueOf(CASE_ID),
+            "caseUrl", "http://fake-url/cases/case-details/12345",
+            "respondentLastName", RESPONDENT_LAST_NAME,
+            "returnedNote", REMOVAL_REASON
+        );
+    }
+
+    private Element<CaseManagementOrder> buildApprovedCMOElement(boolean buildCmoWithRemovalReason) {
+        UUID removedOrderId = UUID.randomUUID();
+
+        return element(removedOrderId, CaseManagementOrder.builder()
+            .status(APPROVED)
+            .removalReason(buildCmoWithRemovalReason ? REMOVAL_REASON : null)
+            .build());
+    }
+
+    private StandardDirectionOrder buildSDOElement() {
+        return StandardDirectionOrder.builder()
+            .orderStatus(SEALED)
+            .orderDoc(DOCUMENT_REFERENCE)
+            //.removalReason(REMOVAL_REASON) TODO: add reason
+            .build();
+    }
+
+    private GeneratedOrder buildBlankOrder() {
+        return GeneratedOrder.builder()
+            .type("Blank order (C21)")
+            .title("order")
+            .dateOfIssue("12 March 1234")
+            .removalReason(REMOVAL_REASON)
+            .build();
+    }
+
+    private GeneratedOrder buildOrder(GeneratedOrderType type) {
+        List<Element<Child>> childrenList = List.of(
+            element(UUID.randomUUID(), Child.builder()
+                .finalOrderIssued("Yes")
+                .finalOrderIssuedType("Some type")
+                .party(ChildParty.builder().build())
+                .build()));
+
+        return GeneratedOrder.builder()
+            .type(getFullOrderType(type))
+            .children(childrenList)
+            .removalReason(REMOVAL_REASON)
+            .build();
+    }
+
+    private CaseDetails buildCaseDetails(
+        List<Element<GeneratedOrder>> orders,
+        List<Element<CaseManagementOrder>> cmoList,
+        StandardDirectionOrder sdo
+    ) {
+        return asCaseDetails(
+            CaseData.builder()
+                .id(CASE_ID)
+                .orderCollection(orders)
+                .sealedCMOs(cmoList)
+                .standardDirectionOrder(sdo)
+                .reasonToRemoveOrder(REMOVAL_REASON)
+                .respondents1(singletonList(element(RESPONDENT)))
+                .caseLocalAuthority(LOCAL_AUTHORITY_CODE)
+                .gatekeeperEmails(
+                    singletonList(element(EmailAddress.builder().email(GATEKEEPER_EMAIL_ADDRESS).build()))
+                ).build()
+        );
+    }
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/NotifyTemplates.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/NotifyTemplates.java
@@ -49,4 +49,6 @@ public final class NotifyTemplates {
     public static final String SDO_AND_NOP_ISSUED_LA = "3a1d72c7-61cf-4cf9-8fbd-071ffe90dbf0";
     public static final String SDO_AND_NOP_ISSUED_CAFCASS = "a84e75e9-a468-442d-a8c5-c7981d9fdc7c";
     public static final String TEMP_JUDGE_ALLOCATED_TO_HEARING_TEMPLATE = "eeb3a6f5-af49-48aa-a52a-a29a7be2bc38";
+    public static final String CMO_REMOVAL_NOTIFICATION_TEMPLATE = "cd114602-4343-42ce-ab60-1be88b797cd2";
+    public static final String SDO_REMOVAL_NOTIFICATION_TEMPLATE = "8f66e70f-e328-4a22-aa17-f52f44e69d45";
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/events/StandardDirectionsOrderRemovedEvent.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/events/StandardDirectionsOrderRemovedEvent.java
@@ -1,0 +1,12 @@
+package uk.gov.hmcts.reform.fpl.events;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import uk.gov.hmcts.reform.fpl.model.CaseData;
+
+@Getter
+@RequiredArgsConstructor
+public class StandardDirectionsOrderRemovedEvent {
+    private final CaseData caseData;
+    private final String removalReason;
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/events/cmo/CMORemovedEvent.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/events/cmo/CMORemovedEvent.java
@@ -1,0 +1,12 @@
+package uk.gov.hmcts.reform.fpl.events.cmo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import uk.gov.hmcts.reform.fpl.model.CaseData;
+
+@Getter
+@RequiredArgsConstructor
+public class CMORemovedEvent {
+    private final CaseData caseData;
+    private final String removalReason;
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/StandardDirectionsOrderRemovedEventHandler.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/StandardDirectionsOrderRemovedEventHandler.java
@@ -1,0 +1,49 @@
+package uk.gov.hmcts.reform.fpl.handlers;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.fpl.events.StandardDirectionsOrderRemovedEvent;
+import uk.gov.hmcts.reform.fpl.model.CaseData;
+import uk.gov.hmcts.reform.fpl.model.common.Element;
+import uk.gov.hmcts.reform.fpl.model.common.EmailAddress;
+import uk.gov.hmcts.reform.fpl.model.notify.sdo.OrderRemovalTemplate;
+import uk.gov.hmcts.reform.fpl.service.email.NotificationService;
+import uk.gov.hmcts.reform.fpl.service.email.content.OrderRemovalEmailContentProvider;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static uk.gov.hmcts.reform.fpl.NotifyTemplates.SDO_REMOVAL_NOTIFICATION_TEMPLATE;
+import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.unwrapElements;
+
+@Service
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+public class StandardDirectionsOrderRemovedEventHandler {
+
+    private final NotificationService notificationService;
+    private final OrderRemovalEmailContentProvider orderRemovalEmailContentProvider;
+
+    @EventListener
+    public void notifyGatekeeperOfRemovedSDO(StandardDirectionsOrderRemovedEvent event) {
+        CaseData caseData = event.getCaseData();
+
+        OrderRemovalTemplate template =
+            orderRemovalEmailContentProvider.buildNotificationForOrderRemoval(caseData, event.getRemovalReason());
+
+        List<String> emailList = getDistinctGatekeeperEmails(caseData.getGatekeeperEmails());
+
+        notificationService.sendEmail(
+            SDO_REMOVAL_NOTIFICATION_TEMPLATE, emailList, template, String.valueOf(caseData.getId())
+        );
+    }
+
+    private List<String> getDistinctGatekeeperEmails(List<Element<EmailAddress>> emailCollection) {
+        return unwrapElements(emailCollection)
+            .stream()
+            .distinct()
+            .map(EmailAddress::getEmail)
+            .collect(Collectors.toList());
+    }
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/cmo/CMORemovedEventHandler.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/cmo/CMORemovedEventHandler.java
@@ -1,0 +1,41 @@
+package uk.gov.hmcts.reform.fpl.handlers.cmo;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.fpl.events.cmo.CMORemovedEvent;
+import uk.gov.hmcts.reform.fpl.model.CaseData;
+import uk.gov.hmcts.reform.fpl.model.notify.LocalAuthorityInboxRecipientsRequest;
+import uk.gov.hmcts.reform.fpl.model.notify.sdo.OrderRemovalTemplate;
+import uk.gov.hmcts.reform.fpl.service.InboxLookupService;
+import uk.gov.hmcts.reform.fpl.service.email.NotificationService;
+import uk.gov.hmcts.reform.fpl.service.email.content.OrderRemovalEmailContentProvider;
+
+import java.util.Set;
+
+import static uk.gov.hmcts.reform.fpl.NotifyTemplates.CMO_REMOVAL_NOTIFICATION_TEMPLATE;
+
+@Service
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+public class CMORemovedEventHandler {
+    private final InboxLookupService inboxLookupService;
+    private final NotificationService notificationService;
+    private final OrderRemovalEmailContentProvider orderRemovalEmailContentProvider;
+
+    @EventListener
+    public void notifyLocalAuthorityOfRemovedCMO(CMORemovedEvent event) {
+        CaseData caseData = event.getCaseData();
+
+        OrderRemovalTemplate template =
+            orderRemovalEmailContentProvider.buildNotificationForOrderRemoval(caseData, event.getRemovalReason());
+
+        Set<String> emailList = inboxLookupService.getRecipients(
+            LocalAuthorityInboxRecipientsRequest.builder().caseData(caseData).build()
+        );
+
+        notificationService.sendEmail(
+            CMO_REMOVAL_NOTIFICATION_TEMPLATE, emailList, template, String.valueOf(caseData.getId())
+        );
+    }
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/notify/sdo/OrderRemovalTemplate.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/notify/sdo/OrderRemovalTemplate.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.reform.fpl.model.notify.sdo;
+
+import lombok.Getter;
+import lombok.Setter;
+import uk.gov.hmcts.reform.fpl.model.notify.NotifyData;
+
+@Getter
+@Setter
+public class OrderRemovalTemplate implements NotifyData {
+    private String caseReference;
+    private String caseUrl;
+    private String respondentLastName;
+    private String returnedNote;
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/email/content/OrderRemovalEmailContentProvider.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/email/content/OrderRemovalEmailContentProvider.java
@@ -1,0 +1,26 @@
+package uk.gov.hmcts.reform.fpl.service.email.content;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.fpl.model.CaseData;
+import uk.gov.hmcts.reform.fpl.model.notify.sdo.OrderRemovalTemplate;
+import uk.gov.hmcts.reform.fpl.service.email.content.base.AbstractEmailContentProvider;
+
+import static uk.gov.hmcts.reform.fpl.utils.PeopleInCaseHelper.getFirstRespondentLastName;
+
+@Service
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+public class OrderRemovalEmailContentProvider extends AbstractEmailContentProvider {
+
+    public OrderRemovalTemplate buildNotificationForOrderRemoval(CaseData caseData, String removalReason) {
+        OrderRemovalTemplate template = new OrderRemovalTemplate();
+        template.setCaseReference(String.valueOf(caseData.getId()));
+        template.setCaseUrl(getCaseUrl(caseData.getId()));
+        template.setRespondentLastName(getFirstRespondentLastName(caseData.getRespondents1()));
+        template.setReturnedNote(removalReason);
+
+        return template;
+    }
+
+}

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/StandardDirectionsOrderRemovedEventHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/StandardDirectionsOrderRemovedEventHandlerTest.java
@@ -1,0 +1,67 @@
+package uk.gov.hmcts.reform.fpl.handlers;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.fpl.events.StandardDirectionsOrderRemovedEvent;
+import uk.gov.hmcts.reform.fpl.model.CaseData;
+import uk.gov.hmcts.reform.fpl.model.common.EmailAddress;
+import uk.gov.hmcts.reform.fpl.model.notify.sdo.OrderRemovalTemplate;
+import uk.gov.hmcts.reform.fpl.service.email.NotificationService;
+import uk.gov.hmcts.reform.fpl.service.email.content.OrderRemovalEmailContentProvider;
+
+import static java.util.Collections.singletonList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static uk.gov.hmcts.reform.fpl.NotifyTemplates.SDO_REMOVAL_NOTIFICATION_TEMPLATE;
+import static uk.gov.hmcts.reform.fpl.handlers.NotificationEventHandlerTestData.GATEKEEPER_EMAIL_ADDRESS;
+import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.element;
+
+@ExtendWith(MockitoExtension.class)
+class StandardDirectionsOrderRemovedEventHandlerTest {
+
+    private static final Long CASE_ID = 12345L;
+    private static final String FAKE_URL = "https://fake.url";
+
+    @Mock
+    private NotificationService notificationService;
+
+    @Mock
+    private OrderRemovalEmailContentProvider contentProvider;
+
+    @InjectMocks
+    private StandardDirectionsOrderRemovedEventHandler eventHandler;
+
+    @Test
+    void shouldSendEmailToGatekeepersWhenAddedToCase() {
+        final CaseData caseData = CaseData.builder()
+            .id(CASE_ID)
+            .gatekeeperEmails(singletonList(element(EmailAddress.builder().email(GATEKEEPER_EMAIL_ADDRESS).build())))
+            .build();
+
+        String removalReason = "test removal reason";
+
+        OrderRemovalTemplate expectedTemplate = expectedTemplate(removalReason);
+        given(contentProvider.buildNotificationForOrderRemoval(caseData, removalReason))
+            .willReturn(expectedTemplate);
+
+        eventHandler.notifyGatekeeperOfRemovedSDO(new StandardDirectionsOrderRemovedEvent(caseData, removalReason));
+
+        verify(notificationService).sendEmail(
+            SDO_REMOVAL_NOTIFICATION_TEMPLATE,
+            singletonList(GATEKEEPER_EMAIL_ADDRESS),
+            expectedTemplate,
+            String.valueOf(CASE_ID));
+    }
+
+    private OrderRemovalTemplate expectedTemplate(String removalReason) {
+        OrderRemovalTemplate template = new OrderRemovalTemplate();
+        template.setRespondentLastName("Smith");
+        template.setReturnedNote(removalReason);
+        template.setCaseReference(String.valueOf(CASE_ID));
+        template.setCaseUrl(FAKE_URL);
+        return template;
+    }
+}

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/cmo/CMORemovedEventHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/cmo/CMORemovedEventHandlerTest.java
@@ -1,0 +1,74 @@
+package uk.gov.hmcts.reform.fpl.handlers.cmo;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.fpl.events.cmo.CMORemovedEvent;
+import uk.gov.hmcts.reform.fpl.model.CaseData;
+import uk.gov.hmcts.reform.fpl.model.notify.LocalAuthorityInboxRecipientsRequest;
+import uk.gov.hmcts.reform.fpl.model.notify.sdo.OrderRemovalTemplate;
+import uk.gov.hmcts.reform.fpl.service.InboxLookupService;
+import uk.gov.hmcts.reform.fpl.service.email.NotificationService;
+import uk.gov.hmcts.reform.fpl.service.email.content.OrderRemovalEmailContentProvider;
+
+import java.util.Set;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static uk.gov.hmcts.reform.fpl.NotifyTemplates.CMO_REMOVAL_NOTIFICATION_TEMPLATE;
+import static uk.gov.hmcts.reform.fpl.utils.CoreCaseDataStoreLoader.caseData;
+
+@ExtendWith(MockitoExtension.class)
+class CMORemovedEventHandlerTest {
+
+    static final String LOCAL_AUTHORITY_EMAIL_ADDRESS = "FamilyPublicLaw+sa@gmail.com";
+    private static final Long CASE_ID = 12345L;
+    private static final String FAKE_URL = "https://fake.url";
+
+    @Mock
+    private InboxLookupService inboxLookupService;
+
+    @Mock
+    private NotificationService notificationService;
+
+    @Mock
+    private OrderRemovalEmailContentProvider contentProvider;
+
+    @InjectMocks
+    private CMORemovedEventHandler eventHandler;
+
+    @Test
+    void shouldSendEmailToPartiesWhenAddedToCase() {
+        CaseData caseData = caseData();
+        String removalReason = "removal reason details";
+
+        OrderRemovalTemplate expectedTemplate = expectedTemplate(removalReason);
+
+        given(inboxLookupService.getRecipients(
+            LocalAuthorityInboxRecipientsRequest.builder().caseData(caseData).build())
+        ).willReturn(Set.of(LOCAL_AUTHORITY_EMAIL_ADDRESS));
+
+        given(contentProvider.buildNotificationForOrderRemoval(caseData, removalReason))
+            .willReturn(expectedTemplate);
+
+        eventHandler.notifyLocalAuthorityOfRemovedCMO(new CMORemovedEvent(caseData, removalReason));
+
+        verify(notificationService).sendEmail(
+            CMO_REMOVAL_NOTIFICATION_TEMPLATE,
+            Set.of(LOCAL_AUTHORITY_EMAIL_ADDRESS),
+            expectedTemplate,
+            String.valueOf(CASE_ID)
+        );
+    }
+
+    private OrderRemovalTemplate expectedTemplate(String removalReason) {
+        OrderRemovalTemplate template = new OrderRemovalTemplate();
+        template.setRespondentLastName("Smith");
+        template.setReturnedNote(removalReason);
+        template.setCaseReference(String.valueOf(CASE_ID));
+        template.setCaseUrl(FAKE_URL);
+        return template;
+    }
+}

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/email/content/OrderRemovalEmailContentProviderTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/email/content/OrderRemovalEmailContentProviderTest.java
@@ -1,0 +1,71 @@
+package uk.gov.hmcts.reform.fpl.service.email.content;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import uk.gov.hmcts.reform.fpl.model.CaseData;
+import uk.gov.hmcts.reform.fpl.model.Respondent;
+import uk.gov.hmcts.reform.fpl.model.RespondentParty;
+import uk.gov.hmcts.reform.fpl.model.common.EmailAddress;
+import uk.gov.hmcts.reform.fpl.model.notify.sdo.OrderRemovalTemplate;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.element;
+import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.wrapElements;
+
+@ContextConfiguration(classes = {OrderRemovalEmailContentProvider.class})
+class OrderRemovalEmailContentProviderTest extends AbstractEmailContentProviderTest {
+
+    private static final Long CASE_ID = 12345L;
+    private static final String FAKE_URL = "http://fake-url/cases/case-details/12345";
+    private static final String REMOVAL_REASON = "removal reason test";
+    private static final String GATEKEEPER_EMAIL_ADDRESS = "FamilyPublicLaw+gatekeeper@gmail.com";
+
+    @Autowired
+    private OrderRemovalEmailContentProvider orderRemovalEmailContentProvider;
+
+    @Test
+    void shouldGetSDORemovedEmailNotificationParameters() {
+        final CaseData caseData = CaseData.builder()
+            .id(CASE_ID)
+            .respondents1(wrapElements(Respondent.builder()
+                .party(RespondentParty.builder().lastName("Smith").build())
+                .build()))
+            .gatekeeperEmails(singletonList(element(EmailAddress.builder().email(GATEKEEPER_EMAIL_ADDRESS).build())))
+            .build();
+
+        final OrderRemovalTemplate expectedTemplate = expectedTemplate();
+
+        assertThat(orderRemovalEmailContentProvider.buildNotificationForOrderRemoval(caseData, REMOVAL_REASON))
+            .usingRecursiveComparison()
+            .isEqualTo(expectedTemplate);
+    }
+
+    @Test
+    void shouldGetCMORemovedEmailNotificationParameters() {
+        final CaseData caseData = CaseData.builder()
+            .id(CASE_ID)
+            .caseLocalAuthority(LOCAL_AUTHORITY_CODE)
+            .respondents1(wrapElements(Respondent.builder()
+                .party(RespondentParty.builder().lastName("Smith").build())
+                .build()))
+            .build();
+
+        final OrderRemovalTemplate expectedTemplate = expectedTemplate();
+
+        assertThat(orderRemovalEmailContentProvider.buildNotificationForOrderRemoval(caseData, REMOVAL_REASON))
+            .usingRecursiveComparison()
+            .isEqualTo(expectedTemplate);
+    }
+
+    private OrderRemovalTemplate expectedTemplate() {
+        OrderRemovalTemplate template = new OrderRemovalTemplate();
+        template.setRespondentLastName("Smith");
+        template.setReturnedNote(REMOVAL_REASON);
+        template.setCaseReference(String.valueOf(CASE_ID));
+        template.setCaseUrl(FAKE_URL);
+        return template;
+    }
+
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FPLA-2413

### Change description ###
Send email notifications to Gatekeeper/LA when SDO/CMO is removed.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
