### PR TITLE
impr: remove cmo by label (FPLA-2492)

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/RemoveOrderController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/RemoveOrderController.java
@@ -14,11 +14,9 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.events.PopulateStandardDirectionsEvent;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.interfaces.RemovableOrder;
-import uk.gov.hmcts.reform.fpl.model.order.CaseManagementOrder;
 import uk.gov.hmcts.reform.fpl.service.removeorder.RemoveOrderService;
 import uk.gov.hmcts.reform.fpl.utils.CaseDetailsMap;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
@@ -58,11 +56,6 @@ public class RemoveOrderController extends CallbackController {
         // When dynamic lists are fixed this can be moved into the below method
         UUID removedOrderId = getDynamicListSelectedValue(caseData.getRemovableOrderList(), mapper);
         RemovableOrder removableOrder = service.getRemovedOrderByUUID(caseData, removedOrderId);
-
-        if (removableOrder instanceof CaseManagementOrder
-            && caseData.getHearingLinkedToCMO(removedOrderId).isEmpty()) {
-            return respond(caseDetailsMap, List.of(String.format(CMO_ERROR_MESSAGE, removedOrderId)));
-        }
 
         service.populateSelectedOrderFields(caseData, caseDetailsMap, removedOrderId, removableOrder);
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/RemoveOrderController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/RemoveOrderController.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.reform.fpl.events.cmo.CMORemovedEvent;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.StandardDirectionOrder;
 import uk.gov.hmcts.reform.fpl.model.interfaces.RemovableOrder;
+import uk.gov.hmcts.reform.fpl.model.order.CaseManagementOrder;
 import uk.gov.hmcts.reform.fpl.service.removeorder.RemoveOrderService;
 import uk.gov.hmcts.reform.fpl.utils.CaseDetailsMap;
 
@@ -101,9 +102,11 @@ public class RemoveOrderController extends CallbackController {
         CaseData caseDataBefore = getCaseDataBefore(callbackRequest);
 
         Optional<StandardDirectionOrder> removedSDO = service.getRemovedSDO(
-            caseData.getHiddenStandardDirectionOrders(), caseDataBefore.getHiddenStandardDirectionOrders());
+            caseData.getHiddenStandardDirectionOrders(), caseDataBefore.getHiddenStandardDirectionOrders()
+        );
         Optional<CaseManagementOrder> removedCMO = service.getRemovedCMO(
-            caseData.getHiddenCMOs(), caseDataBefore.getHiddenCMOs());
+            caseData.getHiddenCMOs(), caseDataBefore.getHiddenCMOs()
+        );
 
         if (removedSDO.isPresent()) {
             publishEvent(new PopulateStandardDirectionsEvent(callbackRequest));

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/exceptions/AboutToStartOrSubmitCallbackException.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/exceptions/AboutToStartOrSubmitCallbackException.java
@@ -4,7 +4,7 @@ public class AboutToStartOrSubmitCallbackException extends RuntimeException {
 
     private final String userMessage;
 
-    AboutToStartOrSubmitCallbackException(String userMessage, String message) {
+    protected AboutToStartOrSubmitCallbackException(String userMessage, String message) {
         super(message);
         this.userMessage = userMessage;
     }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/exceptions/removeorder/UnexpectedNumberOfCMOsRemovedException.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/exceptions/removeorder/UnexpectedNumberOfCMOsRemovedException.java
@@ -1,0 +1,15 @@
+package uk.gov.hmcts.reform.fpl.exceptions.removeorder;
+
+import uk.gov.hmcts.reform.fpl.exceptions.AboutToStartOrSubmitCallbackException;
+
+import java.util.UUID;
+
+public class UnexpectedNumberOfCMOsRemovedException extends AboutToStartOrSubmitCallbackException {
+
+    private static final String CMO_ERROR_MESSAGE = "Email the help desk at dcd-familypubliclawservicedesk@hmcts.net to"
+        + " remove this order. Quoting CMO %s, and the hearing it was added for.";
+
+    public UnexpectedNumberOfCMOsRemovedException(UUID removedOrderID, String message) {
+        super(String.format(CMO_ERROR_MESSAGE, removedOrderID), message);
+    }
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/removeorder/CMORemovalAction.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/removeorder/CMORemovalAction.java
@@ -2,17 +2,19 @@ package uk.gov.hmcts.reform.fpl.service.removeorder;
 
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.fpl.exceptions.CMONotFoundException;
-import uk.gov.hmcts.reform.fpl.exceptions.HearingNotFoundException;
+import uk.gov.hmcts.reform.fpl.exceptions.removeorder.UnexpectedNumberOfCMOsRemovedException;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.HearingBooking;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
 import uk.gov.hmcts.reform.fpl.model.interfaces.RemovableOrder;
 import uk.gov.hmcts.reform.fpl.model.order.CaseManagementOrder;
 import uk.gov.hmcts.reform.fpl.utils.CaseDetailsMap;
+import uk.gov.hmcts.reform.fpl.utils.IncrementalInteger;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
@@ -35,19 +37,20 @@ public class CMORemovalAction implements OrderRemovalAction {
         CaseManagementOrder caseManagementOrder = (CaseManagementOrder) removableOrder;
 
         List<Element<CaseManagementOrder>> sealedCMOs = caseData.getSealedCMOs();
-        boolean removed = sealedCMOs.remove(element(removedOrderId, caseManagementOrder));
-        if (!removed) {
+        Element<CaseManagementOrder> cmoElement = element(removedOrderId, caseManagementOrder);
+
+        if (!sealedCMOs.remove(cmoElement)) {
             throw new CMONotFoundException(format("Failed to find order matching id %s", removedOrderId));
         }
 
         caseManagementOrder.setRemovalReason(caseData.getReasonToRemoveOrder());
 
         List<Element<CaseManagementOrder>> hiddenCMOs = caseData.getHiddenCMOs();
-        hiddenCMOs.add(element(removedOrderId, caseManagementOrder));
+        hiddenCMOs.add(cmoElement);
 
         data.put("hiddenCaseManagementOrders", hiddenCMOs);
         data.putIfNotEmpty("sealedCMOs", sealedCMOs);
-        data.put("hearingDetails", removeHearingLinkedToCMO(caseData.getHearingDetails(), removedOrderId));
+        data.put("hearingDetails", removeHearingLinkedToCMO(caseData.getHearingDetails(), cmoElement));
     }
 
     @Override
@@ -60,7 +63,29 @@ public class CMORemovalAction implements OrderRemovalAction {
         Optional<Element<HearingBooking>> hearingBooking = caseData.getHearingLinkedToCMO(removableOrderId);
 
         if (hearingBooking.isEmpty()) {
-            throw new HearingNotFoundException(format("Could not find hearing matching id %s", removableOrderId));
+            IncrementalInteger counter = new IncrementalInteger();
+            Element<HearingBooking> foundHearing = null;
+
+            for (Element<HearingBooking> hearing : caseData.getHearingDetails()) {
+                if (hearing.getValue().toLabel().equals(caseManagementOrder.getHearing())) {
+                    foundHearing = hearing;
+                    if (counter.incrementAndGet() > 1) {
+                        // stop the loop early, already found too many
+                        break;
+                    }
+                }
+            }
+
+            // won't be null but stops nullable complaints later on
+            if (counter.getValue() != 1 || foundHearing == null) {
+                throw new UnexpectedNumberOfCMOsRemovedException(
+                    removableOrderId,
+                    format("CMO %s could not be linked to hearing by CMO id and there wasn't a unique link "
+                        + "(%s links found) to a hearing with the same label", removableOrderId, counter.getValue())
+                );
+            }
+
+            hearingBooking = Optional.of(foundHearing);
         }
 
         data.put("orderToBeRemoved", caseManagementOrder.getOrder());
@@ -70,18 +95,66 @@ public class CMORemovalAction implements OrderRemovalAction {
     }
 
     private List<Element<HearingBooking>> removeHearingLinkedToCMO(List<Element<HearingBooking>> hearings,
-                                                                  UUID removedOrderId) {
+                                                                   Element<CaseManagementOrder> cmoElement) {
+        // QUESTION: 03/12/2020 Do we need this empty check?
         if (isEmpty(hearings)) {
             return List.of();
         }
 
-        return hearings.stream()
-            .map(element -> {
-                HearingBooking hearingBooking = element.getValue();
-                if (removedOrderId.equals(hearingBooking.getCaseManagementOrderId())) {
-                    hearingBooking.setCaseManagementOrderId(null);
+        IncrementalInteger counter = new IncrementalInteger();
+        UUID id = cmoElement.getId();
+        CaseManagementOrder cmo = cmoElement.getValue();
+
+        List<Element<HearingBooking>> updatedHearings = updateOnCondition(
+            hearings,
+            hearing -> id.equals(hearing.getValue().getCaseManagementOrderId()),
+            counter
+        );
+
+        switch (counter.getValue()) {
+            case 0:
+                // use label instead
+                counter.reset();
+                updatedHearings = updateOnCondition(
+                    hearings,
+                    hearing -> cmo.getHearing().equals(hearing.getValue().toLabel()),
+                    counter
+                );
+
+                // QUESTION: 03/12/2020 are these additional checks required seeing as it should have been guarded in
+                //  the mid event?
+                if (counter.getValue() == 1) {
+                    return updatedHearings;
+                } else {
+                    throw new UnexpectedNumberOfCMOsRemovedException(
+                        id,
+                        format("CMO %s could not be linked to hearing by CMO id and there wasn't a unique link "
+                            + "(%s links found) to a hearing with the same label", id, counter.getValue())
+                    );
                 }
-                return element;
-            }).collect(Collectors.toList());
+            case 1:
+                return updatedHearings;
+            default:
+                // more than one hearing was linked to the cmo, situation should not occur but covers the default switch
+                throw new UnexpectedNumberOfCMOsRemovedException(
+                    id,
+                    format("CMO %s was linked to multiple hearings by id", id)
+                );
+        }
+    }
+
+    private List<Element<HearingBooking>> updateOnCondition(List<Element<HearingBooking>> hearings,
+                                                            Predicate<Element<HearingBooking>> linkTest,
+                                                            IncrementalInteger counter) {
+
+        return hearings.stream()
+            .map(hearing -> {
+                if (linkTest.test(hearing)) {
+                    counter.increment();
+                    hearing.getValue().setCaseManagementOrderId(null);
+                }
+                return hearing;
+            })
+            .collect(Collectors.toList());
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/removeorder/CMORemovalAction.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/removeorder/CMORemovalAction.java
@@ -57,30 +57,30 @@ public class CMORemovalAction implements OrderRemovalAction {
                                    RemovableOrder removableOrder) {
         CaseManagementOrder caseManagementOrder = (CaseManagementOrder) removableOrder;
 
-        Element<HearingBooking> hearing = getHearingToUnlink(caseData, removableOrderId, caseManagementOrder);
+        HearingBooking hearing = getHearingToUnlink(caseData, removableOrderId, caseManagementOrder);
 
         data.put("orderToBeRemoved", caseManagementOrder.getOrder());
         data.put("orderTitleToBeRemoved", "Case management order");
-        data.put("hearingToUnlink", hearing.getValue().toLabel());
+        data.put("hearingToUnlink", hearing.toLabel());
         data.put("showRemoveCMOFieldsFlag", YES.getValue());
     }
 
     private List<Element<HearingBooking>> removeHearingLinkedToCMO(CaseData caseData,
                                                                    Element<CaseManagementOrder> cmoElement) {
 
-        Element<HearingBooking> hearingToUnlink = getHearingToUnlink(
+        HearingBooking hearingToUnlink = getHearingToUnlink(
             caseData,
             cmoElement.getId(),
             cmoElement.getValue()
         );
 
         // this will still be the same reference as the one in the case data list so just update it
-        hearingToUnlink.getValue().setCaseManagementOrderId(null);
+        hearingToUnlink.setCaseManagementOrderId(null);
 
         return caseData.getHearingDetails();
     }
 
-    private Element<HearingBooking> getHearingToUnlink(CaseData caseData, UUID cmoId, CaseManagementOrder cmo) {
+    private HearingBooking getHearingToUnlink(CaseData caseData, UUID cmoId, CaseManagementOrder cmo) {
 
         Optional<Element<HearingBooking>> hearingBooking = caseData.getHearingLinkedToCMO(cmoId);
 
@@ -98,8 +98,8 @@ public class CMORemovalAction implements OrderRemovalAction {
                 );
             }
 
-            return matchingLabel.get(0);
+            return matchingLabel.get(0).getValue();
         }
-        return hearingBooking.get();
+        return hearingBooking.get().getValue();
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/utils/IncrementalInteger.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/utils/IncrementalInteger.java
@@ -19,6 +19,14 @@ public class IncrementalInteger {
         return ++value;
     }
 
+    public void increment() {
+        value++;
+    }
+
+    public void reset() {
+        value = 0;
+    }
+
     public int getValue() {
         return value;
     }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/utils/IncrementalInteger.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/utils/IncrementalInteger.java
@@ -19,14 +19,6 @@ public class IncrementalInteger {
         return ++value;
     }
 
-    public void increment() {
-        value++;
-    }
-
-    public void reset() {
-        value = 0;
-    }
-
     public int getValue() {
         return value;
     }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/removeorder/CMORemovalActionTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/removeorder/CMORemovalActionTest.java
@@ -3,7 +3,7 @@ package uk.gov.hmcts.reform.fpl.service.removeorder;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.exceptions.CMONotFoundException;
-import uk.gov.hmcts.reform.fpl.exceptions.HearingNotFoundException;
+import uk.gov.hmcts.reform.fpl.exceptions.removeorder.UnexpectedNumberOfCMOsRemovedException;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.HearingBooking;
 import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
@@ -18,12 +18,15 @@ import java.util.Map;
 import java.util.UUID;
 
 import static com.google.common.collect.Lists.newArrayList;
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static uk.gov.hmcts.reform.fpl.enums.HearingType.CASE_MANAGEMENT;
 import static uk.gov.hmcts.reform.fpl.enums.YesNo.YES;
 import static uk.gov.hmcts.reform.fpl.utils.CaseDetailsMap.caseDetailsMap;
+import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.DATE;
+import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.formatLocalDateTimeBaseUsingFormat;
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.element;
 
 class CMORemovalActionTest {
@@ -35,6 +38,7 @@ class CMORemovalActionTest {
     private static final UUID ANOTHER_CASE_MANAGEMENT_ORDER_ID = UUID.randomUUID();
     private static final UUID HEARING_ID = UUID.randomUUID();
     private static final UUID ANOTHER_HEARING_ID = UUID.randomUUID();
+    private static final LocalDateTime HEARING_START_DATE = LocalDateTime.now();
 
     private final CMORemovalAction underTest = new CMORemovalAction();
 
@@ -49,56 +53,67 @@ class CMORemovalActionTest {
     }
 
     @Test
-    void shouldNotRemoveHearingAssociationWithARemovedCaseManagementOrderWhenCannotMatchAssociatedHearing() {
+    void shouldNotRemoveOrderWhenUniqueHearingAssociationCannotBeDetermined() {
+        CaseManagementOrder cmoToRemove = cmo(HEARING_START_DATE);
         CaseData caseData = CaseData.builder()
             .reasonToRemoveOrder(REASON)
-            .sealedCMOs(newArrayList(element(TO_REMOVE_ORDER_ID, CaseManagementOrder.builder().build())))
-            .hiddenCaseManagementOrders(newArrayList(element(ALREADY_REMOVED_ORDER_ID,
-                CaseManagementOrder.builder().build())))
+            .sealedCMOs(newArrayList(element(TO_REMOVE_ORDER_ID, cmoToRemove)))
+            .hiddenCaseManagementOrders(newArrayList(element(ALREADY_REMOVED_ORDER_ID, cmo())))
             .hearingDetails(List.of(
-                element(HEARING_ID,
-                    HearingBooking.builder()
-                        .caseManagementOrderId(CASE_MANAGEMENT_ORDER_ID)
-                        .build()),
-                element(ANOTHER_HEARING_ID,
-                    HearingBooking.builder()
-                        .caseManagementOrderId(ANOTHER_CASE_MANAGEMENT_ORDER_ID)
-                        .build())))
+                element(HEARING_ID, hearing(CASE_MANAGEMENT_ORDER_ID)),
+                element(ANOTHER_HEARING_ID, hearing(ANOTHER_CASE_MANAGEMENT_ORDER_ID))
+            ))
             .build();
 
         CaseDetailsMap caseDetailsMap = caseDetailsMap(CaseDetails.builder()
             .data(Map.of())
             .build());
 
-        underTest.remove(caseData, caseDetailsMap, TO_REMOVE_ORDER_ID, CaseManagementOrder.builder().build());
-
-        assertThat(caseDetailsMap).isEqualTo(Map.of(
-            "hearingDetails", List.of(
-                element(
-                    HEARING_ID,
-                    HearingBooking.builder()
-                        .caseManagementOrderId(CASE_MANAGEMENT_ORDER_ID)
-                        .build()),
-                element(
-                    ANOTHER_HEARING_ID,
-                    HearingBooking.builder()
-                        .caseManagementOrderId(ANOTHER_CASE_MANAGEMENT_ORDER_ID)
-                        .build())),
-            "hiddenCaseManagementOrders", List.of(
-                element(ALREADY_REMOVED_ORDER_ID, CaseManagementOrder.builder().build()),
-                element(TO_REMOVE_ORDER_ID, CaseManagementOrder.builder().removalReason(REASON).build())
-            )
-        ));
-
+        assertThatThrownBy(() -> underTest.remove(caseData, caseDetailsMap, TO_REMOVE_ORDER_ID, cmoToRemove))
+            .usingRecursiveComparison()
+            .isEqualTo(unexpectedNumberOfCMOsRemovedException(TO_REMOVE_ORDER_ID, 2));
     }
 
     @Test
-    void shouldRemovedCaseManagementOrderWhenOtherOtherCMOisPresent() {
+    void shouldRemoveOrderWhenNoMatchingIDButMatchingHearingLabel() {
+        LocalDateTime differentStartDate = HEARING_START_DATE.plusDays(3);
+        CaseManagementOrder cmoToRemove = cmo(differentStartDate);
+        CaseData caseData = CaseData.builder()
+            .reasonToRemoveOrder(REASON)
+            .sealedCMOs(newArrayList(element(TO_REMOVE_ORDER_ID, cmoToRemove)))
+            .hiddenCaseManagementOrders(newArrayList(element(ALREADY_REMOVED_ORDER_ID, cmo())))
+            .hearingDetails(List.of(
+                element(HEARING_ID, hearing(CASE_MANAGEMENT_ORDER_ID, differentStartDate)),
+                element(ANOTHER_HEARING_ID, hearing(ANOTHER_CASE_MANAGEMENT_ORDER_ID))
+            ))
+            .build();
+
+        CaseDetailsMap caseDetailsMap = caseDetailsMap(CaseDetails.builder()
+            .data(Map.of())
+            .build());
+
+        underTest.remove(caseData, caseDetailsMap, TO_REMOVE_ORDER_ID, cmoToRemove);
+
+        assertThat(caseDetailsMap).isEqualTo(Map.of(
+            "hearingDetails", List.of(
+                element(HEARING_ID, hearing(null, differentStartDate)),
+                element(ANOTHER_HEARING_ID, hearing(ANOTHER_CASE_MANAGEMENT_ORDER_ID))
+            ),
+            "hiddenCaseManagementOrders", List.of(
+                element(ALREADY_REMOVED_ORDER_ID, cmo()),
+                element(TO_REMOVE_ORDER_ID, cmo(differentStartDate, REASON))
+            ))
+        );
+    }
+
+    @Test
+    void shouldRemovedCaseManagementOrderWhenOtherCMOisPresent() {
         CaseData caseData = CaseData.builder()
             .reasonToRemoveOrder(REASON)
             .sealedCMOs(newArrayList(
-                element(TO_REMOVE_ORDER_ID, CaseManagementOrder.builder().build()),
-                element(ANOTHER_CASE_MANAGEMENT_ORDER_ID, CaseManagementOrder.builder().build())))
+                element(TO_REMOVE_ORDER_ID, cmo()),
+                element(ANOTHER_CASE_MANAGEMENT_ORDER_ID, cmo())
+            ))
             .hiddenCaseManagementOrders(null)
             .hearingDetails(null)
             .build();
@@ -107,16 +122,12 @@ class CMORemovalActionTest {
             .data(Map.of())
             .build());
 
-        underTest.remove(caseData, caseDetailsMap, TO_REMOVE_ORDER_ID, CaseManagementOrder.builder().build());
+        underTest.remove(caseData, caseDetailsMap, TO_REMOVE_ORDER_ID, cmo());
 
         Map<String, List<?>> expectedData = new HashMap<>();
         expectedData.put("hearingDetails", List.of());
-        expectedData.put("hiddenCaseManagementOrders", List.of(
-            element(TO_REMOVE_ORDER_ID, CaseManagementOrder.builder().removalReason(REASON).build())
-        ));
-        expectedData.put("sealedCMOs", List.of(
-            element(ANOTHER_CASE_MANAGEMENT_ORDER_ID, CaseManagementOrder.builder().build()))
-        );
+        expectedData.put("hiddenCaseManagementOrders", List.of(element(TO_REMOVE_ORDER_ID, cmoWithRemovalReason())));
+        expectedData.put("sealedCMOs", List.of(element(ANOTHER_CASE_MANAGEMENT_ORDER_ID, cmo())));
 
         assertThat(caseDetailsMap).isEqualTo(expectedData);
     }
@@ -125,9 +136,8 @@ class CMORemovalActionTest {
     void shouldRemovedCaseManagementOrderWhenNoHearing() {
         CaseData caseData = CaseData.builder()
             .reasonToRemoveOrder(REASON)
-            .sealedCMOs(newArrayList(element(TO_REMOVE_ORDER_ID, CaseManagementOrder.builder().build())))
-            .hiddenCaseManagementOrders(newArrayList(element(ALREADY_REMOVED_ORDER_ID,
-                CaseManagementOrder.builder().build())))
+            .sealedCMOs(newArrayList(element(TO_REMOVE_ORDER_ID, cmo())))
+            .hiddenCaseManagementOrders(newArrayList(element(ALREADY_REMOVED_ORDER_ID, cmo())))
             .hearingDetails(null)
             .build();
 
@@ -135,13 +145,13 @@ class CMORemovalActionTest {
             .data(Map.of())
             .build());
 
-        underTest.remove(caseData, caseDetailsMap, TO_REMOVE_ORDER_ID, CaseManagementOrder.builder().build());
+        underTest.remove(caseData, caseDetailsMap, TO_REMOVE_ORDER_ID, cmo());
 
         Map<String, List<?>> expectedData = new HashMap<>();
         expectedData.put("hearingDetails", List.of());
         expectedData.put("hiddenCaseManagementOrders", List.of(
-            element(ALREADY_REMOVED_ORDER_ID, CaseManagementOrder.builder().build()),
-            element(TO_REMOVE_ORDER_ID, CaseManagementOrder.builder().removalReason(REASON).build())
+            element(ALREADY_REMOVED_ORDER_ID, cmo()),
+            element(TO_REMOVE_ORDER_ID, cmoWithRemovalReason())
         ));
 
         assertThat(caseDetailsMap).isEqualTo(expectedData);
@@ -151,48 +161,34 @@ class CMORemovalActionTest {
     void shouldRemoveHearingAssociationWithARemovedCaseManagementOrder() {
         CaseData caseData = CaseData.builder()
             .reasonToRemoveOrder(REASON)
-            .sealedCMOs(newArrayList(element(TO_REMOVE_ORDER_ID, CaseManagementOrder.builder().build())))
-            .hiddenCaseManagementOrders(newArrayList(element(ALREADY_REMOVED_ORDER_ID,
-                CaseManagementOrder.builder().build())))
+            .sealedCMOs(newArrayList(element(TO_REMOVE_ORDER_ID, cmo())))
+            .hiddenCaseManagementOrders(newArrayList(element(ALREADY_REMOVED_ORDER_ID, cmo())))
             .hearingDetails(List.of(
-                element(HEARING_ID,
-                    HearingBooking.builder()
-                        .caseManagementOrderId(CASE_MANAGEMENT_ORDER_ID)
-                        .build()),
-                element(ANOTHER_HEARING_ID,
-                    HearingBooking.builder()
-                        .caseManagementOrderId(TO_REMOVE_ORDER_ID)
-                        .build())))
+                element(HEARING_ID, hearing(CASE_MANAGEMENT_ORDER_ID)),
+                element(ANOTHER_HEARING_ID, hearing(TO_REMOVE_ORDER_ID))))
             .build();
 
         CaseDetailsMap caseDetailsMap = caseDetailsMap(CaseDetails.builder()
             .data(Map.of())
             .build());
 
-        underTest.remove(caseData, caseDetailsMap, TO_REMOVE_ORDER_ID, CaseManagementOrder.builder().build());
+        underTest.remove(caseData, caseDetailsMap, TO_REMOVE_ORDER_ID, cmo());
 
         assertThat(caseDetailsMap).isEqualTo(Map.of(
             "hearingDetails", List.of(
-                element(
-                    HEARING_ID,
-                    HearingBooking.builder()
-                        .caseManagementOrderId(CASE_MANAGEMENT_ORDER_ID)
-                        .build()),
-                element(
-                    ANOTHER_HEARING_ID,
-                    HearingBooking.builder()
-                        .caseManagementOrderId(null)
-                        .build())),
+                element(HEARING_ID, hearing(CASE_MANAGEMENT_ORDER_ID)),
+                element(ANOTHER_HEARING_ID, hearing(null))
+            ),
             "hiddenCaseManagementOrders", List.of(
-                element(ALREADY_REMOVED_ORDER_ID, CaseManagementOrder.builder().build()),
-                element(TO_REMOVE_ORDER_ID, CaseManagementOrder.builder().removalReason(REASON).build())
+                element(ALREADY_REMOVED_ORDER_ID, cmo()),
+                element(TO_REMOVE_ORDER_ID, cmoWithRemovalReason())
             )
         ));
     }
 
     @Test
     void shouldThrowExceptionIfOrderNotFound() {
-        CaseManagementOrder emptyCaseManagementOrder = CaseManagementOrder.builder().build();
+        CaseManagementOrder emptyCaseManagementOrder = cmo();
 
         CaseData caseData = CaseData.builder()
             .reasonToRemoveOrder(REASON)
@@ -210,27 +206,19 @@ class CMORemovalActionTest {
     }
 
     @Test
-    void shouldPopulateCaseFieldsFromRemovedCMOAndUnlinkedHearing() {
+    void shouldPopulateCaseFieldsFromRemovedCMOAndHearingLinkedByCMOId() {
         DocumentReference orderDocument = DocumentReference.builder().build();
-        CaseManagementOrder removedOrder = CaseManagementOrder.builder()
-            .order(orderDocument)
-            .build();
+        CaseManagementOrder removedOrder = cmo(orderDocument);
 
-        HearingBooking hearingToBeUnlinked = HearingBooking.builder()
-            .type(CASE_MANAGEMENT)
-            .caseManagementOrderId(TO_REMOVE_ORDER_ID)
-            .startDate(LocalDateTime.now())
-            .build();
+        HearingBooking hearingToBeUnlinked = hearing(TO_REMOVE_ORDER_ID);
 
         CaseData caseData = CaseData.builder()
             .reasonToRemoveOrder(REASON)
             .sealedCMOs(newArrayList(element(TO_REMOVE_ORDER_ID, removedOrder)))
             .hearingDetails(List.of(
-                element(HEARING_ID,
-                    HearingBooking.builder()
-                        .caseManagementOrderId(ANOTHER_HEARING_ID)
-                        .build()),
-                element(UUID.randomUUID(), hearingToBeUnlinked)))
+                element(HEARING_ID, hearing(ANOTHER_HEARING_ID)),
+                element(UUID.randomUUID(), hearingToBeUnlinked)
+            ))
             .build();
 
         CaseDetailsMap caseDetailsMap = caseDetailsMap(CaseDetails.builder()
@@ -251,33 +239,113 @@ class CMORemovalActionTest {
     }
 
     @Test
-    void shouldThrowAnExceptionIfHearingBookingNotFound() {
+    void shouldPopulateCaseFieldsFromRemovedCMOAndHearingLinkedByLabel() {
         DocumentReference orderDocument = DocumentReference.builder().build();
-        CaseManagementOrder removedOrder = CaseManagementOrder.builder()
-            .order(orderDocument)
-            .build();
+        CaseManagementOrder removedOrder = cmo(orderDocument, HEARING_START_DATE);
+
+        HearingBooking hearingToBeUnlinked = hearing(TO_REMOVE_ORDER_ID);
 
         CaseData caseData = CaseData.builder()
             .reasonToRemoveOrder(REASON)
             .sealedCMOs(newArrayList(element(TO_REMOVE_ORDER_ID, removedOrder)))
             .hearingDetails(List.of(
-                element(HEARING_ID,
-                    HearingBooking.builder()
-                        .caseManagementOrderId(UUID.randomUUID())
-                        .build()),
-                element(ANOTHER_HEARING_ID,
-                    HearingBooking.builder()
-                        .caseManagementOrderId(UUID.randomUUID())
-                        .build())))
+                element(HEARING_ID, hearing(ANOTHER_HEARING_ID)),
+                element(UUID.randomUUID(), hearingToBeUnlinked)
+            ))
             .build();
 
         CaseDetailsMap caseDetailsMap = caseDetailsMap(CaseDetails.builder()
             .data(Map.of())
             .build());
 
-        assertThatThrownBy(() -> underTest.populateCaseFields(caseData, caseDetailsMap, ALREADY_REMOVED_ORDER_ID,
+        underTest.populateCaseFields(caseData, caseDetailsMap, TO_REMOVE_ORDER_ID, removedOrder);
+
+        assertThat(caseDetailsMap)
+            .extracting("orderToBeRemoved",
+                "orderTitleToBeRemoved",
+                "hearingToUnlink",
+                "showRemoveCMOFieldsFlag")
+            .containsExactly(orderDocument,
+                "Case management order",
+                hearingToBeUnlinked.toLabel(),
+                YES.getValue());
+    }
+
+    @Test
+    void shouldThrowAnExceptionIfUniqueHearingNotFound() {
+        CaseManagementOrder removedOrder = cmo(HEARING_START_DATE);
+
+        CaseData caseData = CaseData.builder()
+            .reasonToRemoveOrder(REASON)
+            .sealedCMOs(newArrayList(element(TO_REMOVE_ORDER_ID, removedOrder)))
+            .hearingDetails(List.of(
+                element(HEARING_ID, hearing(UUID.randomUUID())),
+                element(ANOTHER_HEARING_ID, hearing(UUID.randomUUID()))
+            ))
+            .build();
+
+        CaseDetailsMap caseDetailsMap = caseDetailsMap(CaseDetails.builder()
+            .data(Map.of())
+            .build());
+
+        assertThatThrownBy(() -> underTest.populateCaseFields(caseData, caseDetailsMap, TO_REMOVE_ORDER_ID,
             removedOrder))
-            .isInstanceOf(HearingNotFoundException.class)
-            .hasMessage("Could not find hearing matching id %s", ALREADY_REMOVED_ORDER_ID);
+            .usingRecursiveComparison()
+            .isEqualTo(unexpectedNumberOfCMOsRemovedException(TO_REMOVE_ORDER_ID, 2));
+    }
+
+    private HearingBooking hearing(UUID cmoId) {
+        return hearing(cmoId, HEARING_START_DATE);
+    }
+
+    private HearingBooking hearing(UUID cmoId, LocalDateTime startDate) {
+        return HearingBooking.builder()
+            .caseManagementOrderId(cmoId)
+            .type(CASE_MANAGEMENT)
+            .startDate(startDate)
+            .build();
+    }
+
+    private CaseManagementOrder cmoWithRemovalReason() {
+        return cmo(null, null, REASON);
+    }
+
+    private CaseManagementOrder cmo() {
+        return cmo(null, null, null);
+    }
+
+    private CaseManagementOrder cmo(DocumentReference order) {
+        return cmo(order, null, null);
+    }
+
+    private CaseManagementOrder cmo(LocalDateTime startDate) {
+        return cmo(null, startDate, null);
+    }
+
+    private CaseManagementOrder cmo(DocumentReference order, LocalDateTime startDate) {
+        return cmo(order, startDate, null);
+    }
+
+    private CaseManagementOrder cmo(LocalDateTime startDate, String removalReason) {
+        return cmo(null, startDate, removalReason);
+    }
+
+    private CaseManagementOrder cmo(DocumentReference order, LocalDateTime startDate, String removalReason) {
+        return CaseManagementOrder.builder()
+            .order(order)
+            .hearing(startDate != null
+                ? "Case management hearing, " + formatLocalDateTimeBaseUsingFormat(startDate, DATE)
+                : null)
+            .removalReason(removalReason)
+            .build();
+    }
+
+    private UnexpectedNumberOfCMOsRemovedException unexpectedNumberOfCMOsRemovedException(UUID id, int links) {
+        return new UnexpectedNumberOfCMOsRemovedException(
+            id,
+            format("CMO %s could not be linked to hearing by CMO id and there wasn't a unique link (%d links found) to "
+                    + "a hearing with the same label",
+                id, links)
+        );
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

[FPLA-2492](https://tools.hmcts.net/jira/browse/FPLA-2492)

### Change description ###

Add check for label when removing cmos, will only remove if one is found, 0 or multiple will throw an error.

#### Scenarios

| action | expected outcome | additional testing needs |
|-------|--------------------|-------------------------|
| cmo with linked hearing through cmo id | can remove cmo | none |
| cmo with linked hearing through label (link through cmo id lost) | can remove cmo | db edit will be required to unlink through id |
| cmo with multiple hearings that have the same label (link through cmo id lost) | error message to user | db edit will be required to unlink through id |

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
