### PR TITLE
fix: document download link in order notifications (FPLA-2499)

### DIFF
--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/utils/OrderIssuedNotificationTestHelper.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/utils/OrderIssuedNotificationTestHelper.java
@@ -41,7 +41,7 @@ public class OrderIssuedNotificationTestHelper {
             "orderType", orderType.toLowerCase(),
             "callout", withCallout ? callout : "",
             "courtName", EXAMPLE_COURT,
-            "documentLink", jsonFileObject,
+            "documentLink", jsonFileObject.toMap(),
             "caseUrl", formatCaseUrl("http://fake-url", 12345L, "OrdersTab"),
             "respondentLastName", "Jones");
     }
@@ -56,7 +56,7 @@ public class OrderIssuedNotificationTestHelper {
             .orderType(orderType.toLowerCase())
             .callout(withCallout ? callout : "")
             .courtName(EXAMPLE_COURT)
-            .documentLink(jsonFileObject)
+            .documentLink(jsonFileObject.toMap())
             .caseUrl(formatCaseUrl("http://fake-url", 12345L, "OrdersTab"))
             .respondentLastName("Jones")
             .build();
@@ -72,7 +72,7 @@ public class OrderIssuedNotificationTestHelper {
             .orderType(orderType.toLowerCase())
             .callout(withCallout ? callout : "")
             .courtName(EXAMPLE_COURT)
-            .documentLink(jsonFileObject)
+            .documentLink(jsonFileObject.toMap())
             .respondentLastName("Jones")
             .build();
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FPLA-2499

### Change description ###

Quicker fix than previous PR - converts JSONObject to a map so GOVNotify can process it properly and display the download link

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
