### PR TITLE
fix: hide correspondence tab if empty (FPLA-NA)

### DIFF
--- a/ccd-definition/CaseTypeTab/CareSupervision/8_Correspondence.json
+++ b/ccd-definition/CaseTypeTab/CareSupervision/8_Correspondence.json
@@ -7,8 +7,10 @@
     "TabLabel": "Correspondence",
     "TabDisplayOrder": 8,
     "CaseFieldID": "correspondenceTabHeading",
-    "TabFieldDisplayOrder": 1
-  },  {
+    "TabFieldDisplayOrder": 1,
+    "TabShowCondition": "correspondenceDocuments!=\"\" OR correspondenceDocumentsLA!=\"\""
+  },
+  {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
     "Channel": "CaseWorker",


### PR DESCRIPTION
### JIRA link (if applicable) ###

NOJIRA

### Change description ###

Hide the correspondence tab if there are no correspondence documents. Currently it is always shown because of the tab heading

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
