### PR TITLE
fix: show appropriate error when no C2s to support

### DIFF
--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ManageDocumentsControllerMidEventTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ManageDocumentsControllerMidEventTest.java
@@ -155,6 +155,16 @@ public class ManageDocumentsControllerMidEventTest extends AbstractControllerTes
     }
 
     @Test
+    void shouldReturnErrorWhenNoC2sOnCaseAndUserSelectsC2SupportingDocs() {
+        CaseData caseData = CaseData.builder().manageDocument(buildManagementDocument(C2)).build();
+        AboutToStartOrSubmitCallbackResponse callbackResponse = postMidEvent(caseData,
+            "initialise-manage-document-collections");
+
+        assertThat(callbackResponse.getErrors()).containsExactly(
+            "There are no C2s to associate supporting documents with");
+    }
+
+    @Test
     void shouldReturnValidationErrorsIfSupportingEvidenceDateTimeReceivedOnFurtherEvidenceIsInTheFuture() {
         LocalDateTime futureDate = LocalDateTime.now().plusDays(1);
         CaseDetails caseDetails = buildCaseDetails(TEMP_EVIDENCE_DOCUMENTS_COLLECTION_KEY, futureDate);

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/ManageDocumentsController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/ManageDocumentsController.java
@@ -78,6 +78,9 @@ public class ManageDocumentsController extends CallbackController {
                     caseData.getCorrespondenceDocuments());
                 break;
             case C2:
+                if (!caseData.hasC2DocumentBundle()) {
+                    return respond(caseDetails, List.of("There are no C2s to associate supporting documents with"));
+                }
                 caseDetails.getData().putAll(manageDocumentService.initialiseC2DocumentListAndLabel(caseData));
                 supportingEvidence = manageDocumentService.getC2SupportingEvidenceBundle(caseData);
                 break;


### PR DESCRIPTION
### Change description ###

Show error message to user in manage documents flow when no C2s to attach supporting docs to

Same as Manage Docs for LA journey

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
