### PR TITLE
EXUI regression test: verify hidden fields maintain value in hearing event

### DIFF
--- a/charts/fpl-case-service/values.preview.template.yaml
+++ b/charts/fpl-case-service/values.preview.template.yaml
@@ -51,8 +51,10 @@ xui-webapp:
   nodejs:
     imagePullPolicy: Always
     releaseNameOverride: ${SERVICE_NAME}-xui-webapp
-    image: hmctspublic.azurecr.io/xui/webapp:prod-95f45685
+    image: hmctspublic.azurecr.io/xui/webapp:latest
     ingressHost: xui-${SERVICE_FQDN}
+    memoryLimits: 1536Mi
+    cpuLimits: 1500m
     environment:
       HEALTH_CCD_COMPONENT_API: http://gateway-${SERVICE_FQDN}/health
       HEALTH_CCD_DATA_API: http://${SERVICE_NAME}-ccd-data-store-api/health
@@ -62,8 +64,16 @@ xui-webapp:
       SERVICES_TERMS_AND_CONDITIONS: http://xui-terms-and-conditions-${SERVICE_FQDN}.service.core-compute-preview.internal
       JURISDICTIONS: PUBLICLAW
       LAUNCH_DARKLY_CLIENT_ID: 5de6610b23ce5408280f2268
-      FEATURE_REDIS_ENABLED: "false"
+      FEATURE_REDIS_ENABLED: false
+      FEATURE_APP_INSIGHTS_ENABLED: false
+      FEATURE_SECURE_COOKIE_ENABLED: false
+      FEATURE_PROXY_ENABLED: false
+      FEATURE_TERMS_AND_CONDITIONS_ENABLED: false
+      FEATURE_HELMET_ENABLED: false
+      FEATURE_OIDC_ENABLED: false
+      NOW: false
       REDISCLOUD_URL: http://dummyrediscloudurl
+      UV_THREADPOOL_SIZE: 128
     keyVaults:
       rpx:
         resourceGroup: rpx
@@ -120,6 +130,8 @@ ccd:
         ELASTIC_SEARCH_DATA_NODES_HOSTS:  http://${SERVICE_NAME}-es-master:9200
       keyVaults: []
       ingressHost: ccd-data-store-api-${SERVICE_FQDN}
+      autoscaling:
+        enabled: false
   ccd-definition-store-api:
     java:
       imagePullPolicy: Always
@@ -142,6 +154,8 @@ ccd:
   postgresql:
     persistence:
       enabled: false
+    postgresConfig:
+      maxConnections: "200"
 
 elastic:
   enabled: true
@@ -178,7 +192,7 @@ logstash:
     port: 9200
   configTpl:
     xpack.monitoring.enabled: "false"
-    db.url: jdbc:postgresql://${SERVICE_NAME}-postgresql:5432/data-store?stringtype=unspecified
+    db.url: jdbc:postgresql://${SERVICE_NAME}-postgresql:5432/data-store?ssl=disable&stringtype=unspecified
     db.user: hmcts
     db.pwd: hmcts
     es.data.nodes.url: http://${SERVICE_NAME}-es-master:9200

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ManageHearingsControllerEditHearingMidEventTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ManageHearingsControllerEditHearingMidEventTest.java
@@ -79,7 +79,6 @@ class ManageHearingsControllerEditHearingMidEventTest extends ManageHearingsCont
         CaseData updatedCaseData = extractCaseData(postMidEvent(initialCaseData));
 
         assertThat(updatedCaseData.getHearingDateList()).isEqualTo(dynamicList(hearing1.getId(), hearing1, hearing2));
-        assertThat(updatedCaseData.getFirstHearingFlag()).isEqualTo("Yes");
         assertHearingCaseFields(updatedCaseData, hearing1.getValue());
     }
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/ManageHearingsController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/ManageHearingsController.java
@@ -114,11 +114,6 @@ public class ManageHearingsController extends CallbackController {
             caseDetails.getData().putAll(hearingsService.populateHearingCaseFields(
                 hearingBooking, caseData.getAllocatedJudge()));
 
-            if (hearingBookingId.equals(caseData.getHearingDetails().get(0).getId())
-                || hearingBooking.getPreviousHearingVenue() == null
-                || hearingBooking.getPreviousHearingVenue().getPreviousVenue() == null) {
-                caseDetails.getData().put(FIRST_HEARING_FLAG, "Yes");
-            }
         } else if (ADJOURN_HEARING == caseData.getHearingOption()) {
             UUID hearingBookingId = hearingsService.getSelectedHearingId(caseData);
 
@@ -144,7 +139,6 @@ public class ManageHearingsController extends CallbackController {
             caseDetails.getData().putAll(hearingsService.populateHearingCaseFields(
                 reListedHearingBooking, caseData.getAllocatedJudge()));
 
-            caseDetails.getData().put(FIRST_HEARING_FLAG, YES.getValue());
             caseDetails.getData().put(TO_RE_LIST_HEARING_LIST,
                 hearingsService.asDynamicList(caseData.getToBeReListedHearings(), hearingBookingId));
         }
@@ -169,8 +163,6 @@ public class ManageHearingsController extends CallbackController {
 
         caseDetails.getData().putAll(hearingsService.populateHearingCaseFields(
             reListedHearingBooking, caseData.getAllocatedJudge()));
-
-        caseDetails.getData().put(FIRST_HEARING_FLAG, YES.getValue());
 
         return respond(caseDetails);
     }


### PR DESCRIPTION
### Change description ###

firstHearingFlag only populated in about-to-start
If EXUI have fixed regression, this value should be maintained throughout event
Easiest way to check this is to add hearing in future, then go into event again, vacate hearing + relist it


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
