### PR TITLE
refactor: remove unsused library

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -231,7 +231,6 @@ dependencies {
   compile group: 'uk.gov.hmcts.reform', name: 'logging', version: versions.reformLogging
   compile group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: versions.reformLogging
 
-  compile group: 'uk.gov.hmcts.reform', name: 'pdf-generator', version: '1.0.2'
   compile group: 'uk.gov.hmcts.reform', name: 'idam-client', version: 'v1.5.5'
   compile group: 'uk.gov.hmcts.reform', name: 'document-management-client', version: '7.0.0'
   compile group: 'uk.gov.hmcts.reform', name: 'core-case-data-store-client', version: '4.7.5'

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/UploadC2DocumentsService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/UploadC2DocumentsService.java
@@ -1,27 +1,25 @@
 package uk.gov.hmcts.reform.fpl.service;
 
 import lombok.RequiredArgsConstructor;
-import org.assertj.core.util.Lists;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.SupportingEvidenceBundle;
 import uk.gov.hmcts.reform.fpl.model.common.C2DocumentBundle;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 import uk.gov.hmcts.reform.fpl.service.time.Time;
 import uk.gov.hmcts.reform.fpl.utils.DocumentUploadHelper;
-import uk.gov.hmcts.reform.idam.client.IdamClient;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.DATE_TIME;
 import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.formatLocalDateTimeBaseUsingFormat;
+import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.element;
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.unwrapElements;
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.wrapElements;
 
@@ -29,15 +27,15 @@ import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.wrapElements;
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class UploadC2DocumentsService {
 
-    private final IdamClient idamClient;
     private final Time time;
-    private final RequestData requestData;
     private final SupportingEvidenceValidatorService validateSupportingEvidenceBundleService;
     private final DocumentUploadHelper documentUploadHelper;
 
     public List<Element<C2DocumentBundle>> buildC2DocumentBundle(CaseData caseData) {
-        List<Element<C2DocumentBundle>> c2DocumentBundle = defaultIfNull(caseData.getC2DocumentBundle(),
-            Lists.newArrayList());
+        List<Element<C2DocumentBundle>> c2DocumentBundle = defaultIfNull(
+            caseData.getC2DocumentBundle(), new ArrayList<>()
+        );
+
         String uploadedBy = documentUploadHelper.getUploadedDocumentUserDetails();
 
         List<SupportingEvidenceBundle> updatedSupportingEvidenceBundle =
@@ -55,10 +53,7 @@ public class UploadC2DocumentsService {
             .supportingEvidenceBundle(wrapElements(updatedSupportingEvidenceBundle))
             .type(caseData.getC2ApplicationType().get("type"));
 
-        c2DocumentBundle.add(Element.<C2DocumentBundle>builder()
-            .id(UUID.randomUUID())
-            .value(c2DocumentBundleBuilder.build())
-            .build());
+        c2DocumentBundle.add(element(c2DocumentBundleBuilder.build()));
 
         return c2DocumentBundle;
     }


### PR DESCRIPTION
### Change description ###

Remove unused library that was used in old C110a generation. This removes access for the assertJ libraries in the main code as well so it has been updated where used.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
