### PR TITLE
fix: Fix moment js error, when parsing non standard date

### DIFF
--- a/e2e/tests/hmctsSuperUserRemovesOrders_test.js
+++ b/e2e/tests/hmctsSuperUserRemovesOrders_test.js
@@ -60,7 +60,7 @@ Scenario('HMCTS super user removes a sdo from a case', async ({I, caseViewPage, 
   await caseViewPage.goToNewActions(config.superUserActions.removeOrder);
 
   let order = finalHearingCaseData.caseData.standardDirectionOrder;
-  const labelToSelect = 'Gatekeeping order - ' + moment(order.dateOfIssue).format('D MMMM YYYY');
+  const labelToSelect = `Gatekeeping order - ${moment(order.dateOfIssue, 'DDMMMMY').format('D MMMM YYYY')}`;
   removeOrderEventPage.selectOrderToRemove(labelToSelect);
   await I.goToNextPage();
   removeOrderEventPage.addRemoveOrderReason('Entered incorrect order');


### PR DESCRIPTION
Deprecation warning: value provided is not in a recognized RFC2822 or ISO format. moment construction falls back to js Date(), which is not reliable across all browsers and versions. Non RFC2822/ISO date formats are discouraged. Please refer to http://momentjs.com/guides/#/warnings/js-date/ for more info.
Arguments:
[0] _isAMomentObject: true, _isUTC: false, _useUTC: false, _l: undefined, _i: 28 April 2020, _f: undefined, _strict: undefined, _locale: [object Object]
Error
    at Function.createFromInputFallback (/Users/tomaszp/fpla/fpl-ccd-configuration/node_modules/moment/moment.js:319:25)
    at configFromString (/Users/tomaszp/fpla/fpl-ccd-configuration/node_modules/moment/moment.js:2536:19)
    at configFromInput (/Users/tomaszp/fpla/fpl-ccd-configuration/node_modules/moment/moment.js:2977:13)
    at prepareConfig (/Users/tomaszp/fpla/fpl-ccd-configuration/node_modules/moment/moment.js:2960:13)
    at createFromConfig (/Users/tomaszp/fpla/fpl-ccd-configuration/node_modules/moment/moment.js:2927:44)
    at createLocalOrUTC (/Users/tomaszp/fpla/fpl-ccd-configuration/node_modules/moment/moment.js:3021:16)
    at createLocal (/Users/tomaszp/fpla/fpl-ccd-configuration/node_modules/moment/moment.js:3025:16)
    at hooks (/Users/tomaszp/fpla/fpl-ccd-configuration/node_modules/moment/moment.js:16:29)
    at Test.<anonymous> (/Users/tomaszp/fpla/fpl-ccd-configuration/e2e/tests/hmctsSuperUserRemovesOrders_test.js:63:50)
    at processTicksAndRejections (internal/process/task_queues.js:88:5)