### PR TITLE
fix: allow adjourned-hearing-CMOs to be approved (FPLA-2523)

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/CaseData.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/CaseData.java
@@ -62,6 +62,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.FormatStyle;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -552,6 +553,13 @@ public class CaseData {
     }
 
     @JsonIgnore
+    public List<Element<HearingBooking>> getAllHearings() {
+        return Stream.of(defaultIfNull(hearingDetails, new ArrayList<Element<HearingBooking>>()),
+            defaultIfNull(cancelledHearingDetails, new ArrayList<Element<HearingBooking>>()))
+            .flatMap(Collection::stream).collect(toList());
+    }
+
+    @JsonIgnore
     public List<Element<HearingBooking>> getPastHearings() {
         return defaultIfNull(hearingDetails, new ArrayList<Element<HearingBooking>>()).stream()
             .filter(hearingBooking -> !hearingBooking.getValue().startsAfterToday())
@@ -597,7 +605,7 @@ public class CaseData {
 
     @JsonIgnore
     public Optional<HearingBooking> getNextHearingAfterCmo(UUID cmoID) {
-        LocalDateTime currentCmoStartDate = unwrapElements(hearingDetails).stream()
+        LocalDateTime currentCmoStartDate = unwrapElements(getAllHearings()).stream()
             .filter(hearingBooking -> cmoID.equals(hearingBooking.getCaseManagementOrderId()))
             .map(HearingBooking::getStartDate)
             .findAny()


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FPLA-2523

### Change description ###

If a hearing is adjourned but that hearing has a draft CMO associated, the CMO cannot be approved by the judge. This change modifies method to search within all hearings and not just non-adjourned ones

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
