### PR TITLE
refactor: add waits on case list search

### DIFF
--- a/e2e/pages/caseList.page.js
+++ b/e2e/pages/caseList.page.js
@@ -46,7 +46,7 @@ module.exports = {
 
   searchForCase(state='Any') {
     // wait for initial filters to load
-    I.waitForVisible(this.fields.jurisdiction, 10);
+    I.waitForVisible(this.fields.jurisdiction, 20);
     I.selectOption(this.fields.jurisdiction, config.definition.jurisdictionFullDesc);
     I.selectOption(this.fields.caseType, config.definition.caseTypeFullDesc);
     I.selectOption(this.fields.caseState, state);

--- a/e2e/pages/caseList.page.js
+++ b/e2e/pages/caseList.page.js
@@ -19,16 +19,12 @@ module.exports = {
   },
 
   changeStateFilter(desiredState) {
-    I.selectOption(this.fields.jurisdiction, config.definition.jurisdictionFullDesc);
-    I.selectOption(this.fields.caseType, config.definition.caseTypeFullDesc);
-    I.selectOption(this.fields.caseState, desiredState);
+    this.searchForCase(desiredState);
     I.click(this.fields.search);
   },
 
   searchForCasesWithHandledEvidences(submittedAt, state='Any') {
-    I.selectOption(this.fields.jurisdiction, config.definition.jurisdictionFullDesc);
-    I.selectOption(this.fields.caseType, config.definition.caseTypeFullDesc);
-    I.selectOption(this.fields.caseState, state);
+    this.searchForCase(state);
     I.waitForElement(this.fields.evidenceHandled);
     I.fillDate(submittedAt);
     I.click(this.fields.evidenceHandled);
@@ -41,11 +37,19 @@ module.exports = {
   },
 
   searchForCasesWithName(caseName, state='Any') {
+    this.searchForCase(state);
+    // wait for our filters to load
+    I.waitForVisible(this.fields.caseName, 10);
+    I.fillField(this.fields.caseName, caseName);
+    I.click(this.fields.search);
+  },
+
+  searchForCase(state='Any') {
+    // wait for initial filters to load
+    I.waitForVisible(this.fields.jurisdiction, 10);
     I.selectOption(this.fields.jurisdiction, config.definition.jurisdictionFullDesc);
     I.selectOption(this.fields.caseType, config.definition.caseTypeFullDesc);
     I.selectOption(this.fields.caseState, state);
-    I.fillField(this.fields.caseName, caseName);
-    I.click(this.fields.search);
   },
 
   locateCase(caseId){

--- a/e2e/pages/events/openApplicationEvent.page.js
+++ b/e2e/pages/events/openApplicationEvent.page.js
@@ -4,9 +4,9 @@ const config = require('../../config');
 module.exports = {
 
   fields: {
-    jurisdiction: 'jurisdiction',
-    caseType: 'case-type',
-    event: 'event',
+    jurisdiction: '#cc-jurisdiction',
+    caseType: '#cc-case-type',
+    event: '#cc-event',
   },
   enterCaseNamePage: {
     caseName: '#caseName',
@@ -15,12 +15,12 @@ module.exports = {
   continueButton: 'Continue',
 
   async populateForm(caseName) {
-    await I.retryUntilExists(() => {
-      I.selectOption(this.fields.jurisdiction, config.definition.jurisdictionFullDesc);
-      I.selectOption(this.fields.caseType, config.definition.caseTypeFullDesc);
-      I.selectOption(this.fields.event, 'Start application');
-      I.click(this.startButton);
-    }, this.enterCaseNamePage.caseName);
+    // wait until the dropdown is populated
+    I.waitForElement(`${this.fields.jurisdiction} > option[value="${config.definition.jurisdiction}"]`, 10);
+    I.selectOption(this.fields.jurisdiction, config.definition.jurisdictionFullDesc);
+    I.selectOption(this.fields.caseType, config.definition.caseTypeFullDesc);
+    I.selectOption(this.fields.event, 'Start application');
+    await I.retryUntilExists(() => I.goToNextPage(this.startButton), this.enterCaseNamePage.caseName);
     this.enterCaseName(caseName);
   },
 

--- a/e2e/steps_file.js
+++ b/e2e/steps_file.js
@@ -74,7 +74,7 @@ module.exports = function () {
 
     async logInAndCreateCase(user, caseName) {
       await this.signIn(user);
-      await this.retryUntilExists(() => this.click('Create case'), `#cc-jurisdiction > option[value="${config.definition.jurisdiction}"]`);
+      await this.retryUntilExists(() => this.click('Create case'), openApplicationEventPage.fields.jurisdiction);
       await openApplicationEventPage.populateForm(caseName);
       await this.completeEvent('Save and continue');
       this.waitForElement('.markdown h2', 5);


### PR DESCRIPTION
### Change description ###

An attempt at improving the stability of the e2e tests in AAT.

Passed 5/5 times running
```bash
repeat 5 PARALLEL_CHUNKS=1 URL="https://manage-case.aat.platform.hmcts.net" IDAM_API_URL="https://idam-api.aat.platform.hmcts.net" CASE_SERVICE_URL="http://fpl-case-service-aat.service.core-compute-aat.internal" DM_STORE_URL="http://dm-store-aat.service.core-compute-aat.internal" yarn test -g @smoke-tests
```

Some of the timeouts might be considered quite long but the functions being called return as soon as the condition is met instead of waiting for the full time

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
