### PR TITLE
chore: Fix e2e, so that can be run on other envs

### DIFF
--- a/e2e/fixtures/caseData/mandatoryWithC2DocumentBundle.json
+++ b/e2e/fixtures/caseData/mandatoryWithC2DocumentBundle.json
@@ -182,9 +182,9 @@
           "type":"WITH_NOTICE",
           "author":"HMCTS",
           "document":{
-            "document_url":"http://dm-store:8080/documents/9e5d0a2c-8884-46ba-a147-dd0ca6b9e684",
+            "document_url":"${DM_STORE_URL}/documents/9e5d0a2c-8884-46ba-a147-dd0ca6b9e684",
             "document_filename":"mockFile.txt",
-            "document_binary_url":"http://dm-store:8080/documents/9e5d0a2c-8884-46ba-a147-dd0ca6b9e684/binary"
+            "document_binary_url":"${DM_STORE_URL}/documents/9e5d0a2c-8884-46ba-a147-dd0ca6b9e684/binary"
           },
           "pbaNumber":"PBA0082848",
           "clientCode":"8888",
@@ -200,9 +200,9 @@
           "type":"WITHOUT_NOTICE",
           "author":"HMCTS",
           "document":{
-            "document_url":"http://dm-store:8080/documents/a928c836-5d25-41d7-a6bd-d973f2c326b1",
+            "document_url":"${DM_STORE_URL}/documents/a928c836-5d25-41d7-a6bd-d973f2c326b1",
             "document_filename":"mockFile.txt",
-            "document_binary_url":"http://dm-store:8080/documents/a928c836-5d25-41d7-a6bd-d973f2c326b1/binary"
+            "document_binary_url":"${DM_STORE_URL}/documents/a928c836-5d25-41d7-a6bd-d973f2c326b1/binary"
           },
           "description":"Jessica Pearson C2",
           "usePbaPayment":"No",

--- a/e2e/helpers/case_helper.js
+++ b/e2e/helpers/case_helper.js
@@ -1,5 +1,6 @@
 const config = require('../config');
 const fetch = require('node-fetch');
+const lodash = require('lodash');
 
 const wait = duration => new Promise(resolve => setTimeout(resolve, duration));
 
@@ -28,13 +29,15 @@ const documentData = filename => {
   };
 };
 
-const updateCaseDataWithTodaysDateTime = (caseData) => {
+const updateCaseDataWithTodaysDateTime = (data) => {
+  let caseData = data.caseData;
   const dateTime = new Date().toISOString();
   caseData.dateSubmitted = dateTime.slice(0, 10);
   caseData.dateAndTimeSubmitted = dateTime.slice(0, -1);
 };
 
-const updateCaseDataWithDocuments = (caseData) => {
+const updateCaseDataWithDocuments = (data) => {
+  let caseData = data.caseData;
   caseData.submittedForm = documentData('mockSubmittedForm.pdf');
   caseData.documents_checklist_document.typeOfDocument = documentData('mockChecklist.pdf');
   caseData.documents_threshold_document.typeOfDocument = documentData('mockThreshold.pdf');
@@ -55,11 +58,13 @@ const updateCaseDataWithDocuments = (caseData) => {
       cmo.value.order = documentData('mockFile.pdf');
     }
   }
+
+  data.caseData = JSON.parse(lodash.template(JSON.stringify(caseData))({'DM_STORE_URL': config.dmStoreUrl}));
 };
 
 const populateWithData = async (caseId, data) => {
-  updateCaseDataWithTodaysDateTime(data.caseData);
-  updateCaseDataWithDocuments(data.caseData);
+  updateCaseDataWithTodaysDateTime(data);
+  updateCaseDataWithDocuments(data);
 
   const authToken = await getAuthToken();
   const url = `${config.fplServiceUrl}/testing-support/case/populate/${caseId}`;


### PR DESCRIPTION
ccd have validation on fields of document type. It checks if document url have domain that matches real dm store on env. Because of that current e2e are failing on aat env