### PR TITLE
fix: give cafcass permissions for documents tab (FPLA-NA)

### DIFF
--- a/ccd-definition/AuthorisationCaseField/CareSupervision/cafcass-solicitor.json
+++ b/ccd-definition/AuthorisationCaseField/CareSupervision/cafcass-solicitor.json
@@ -369,5 +369,33 @@
     "CaseFieldID": "sealedCMOs",
     "UserRole": "[CAFCASSSOLICITOR]",
     "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseFieldID": "documentTabFurtherEvidenceHeading",
+    "UserRole": "[CAFCASSSOLICITOR]",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseFieldID": "documentTabApplicationHeading",
+    "UserRole": "[CAFCASSSOLICITOR]",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseFieldID": "applicationDocuments",
+    "UserRole": "[CAFCASSSOLICITOR]",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseFieldID": "applicationDocumentsToFollowReason",
+    "UserRole": "[CAFCASSSOLICITOR]",
+    "CRUD": "R"
   }
 ]

--- a/ccd-definition/AuthorisationCaseField/CareSupervision/cafcass.json
+++ b/ccd-definition/AuthorisationCaseField/CareSupervision/cafcass.json
@@ -426,5 +426,33 @@
     "CaseFieldID": "orderCollection",
     "UserRole": "caseworker-publiclaw-cafcass",
     "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseFieldID": "documentTabFurtherEvidenceHeading",
+    "UserRole": "caseworker-publiclaw-cafcass",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseFieldID": "documentTabApplicationHeading",
+    "UserRole": "caseworker-publiclaw-cafcass",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseFieldID": "applicationDocuments",
+    "UserRole": "caseworker-publiclaw-cafcass",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseFieldID": "applicationDocumentsToFollowReason",
+    "UserRole": "caseworker-publiclaw-cafcass",
+    "CRUD": "R"
   }
 ]


### PR DESCRIPTION
### Change description ###

Cafcass roles missing some permissions. Gave them to CAFCASSSOLICITOR too, even though they should be fine (they have solicitor idam role, I think)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
