### PR TITLE
chore: Remove custom await for readiness as it is handled by kuberenetes

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -84,10 +84,6 @@ task lintUserInterfaceTests(type: Exec, description: 'Runs linting of E2E tests.
   commandLine '/usr/bin/yarn', '--silent', 'lint'
 }
 
-task awaitApplicationReadiness(type: Exec, description: 'Awaits until application is ready.') {
-  commandLine '../bin/wait-for.sh', System.env.URL
-}
-
 task runSmokeTests(type: Exec, description: 'Runs smoke tests.') {
   onlyIf {
     return System.env.SKIP_SMOKE_TESTS == null || System.env.SKIP_SMOKE_TESTS == 'false'
@@ -120,11 +116,11 @@ def static inStrictOrder(Task... tasks) {
 }
 
 task smoke(description: 'Runs the smoke tests.') {
-  dependsOn(inStrictOrder(awaitApplicationReadiness, installDependencies, checkDependenciesIntegrity, lintUserInterfaceTests, runSmokeTests))
+  dependsOn(inStrictOrder(installDependencies, checkDependenciesIntegrity, lintUserInterfaceTests, runSmokeTests))
 }
 
 task functional(description: 'Runs the functional tests.') {
-  dependsOn(inStrictOrder(awaitApplicationReadiness, installDependencies, checkDependenciesIntegrity, lintUserInterfaceTests, runApiTests, runBrowserTests))
+  dependsOn(inStrictOrder(installDependencies, checkDependenciesIntegrity, lintUserInterfaceTests, runApiTests, runBrowserTests))
 }
 
 checkstyle {


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] PR's title includes JIRA ticket number and follow [Conventional Commits](https://www.conventionalcommits.org/) specification
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
