### PR TITLE
chore: Log e2e retry failures

### DIFF
--- a/e2e/helpers/event_listener.js
+++ b/e2e/helpers/event_listener.js
@@ -10,7 +10,15 @@ event.dispatcher.on(event.test.failed, function (test) {
   if (test._retries > 0) {
     let tryNum = test.retryNum === undefined ? 1 : test.retryNum + 1;
     output.print(`  ✖ ${test.title} (try ${tryNum}) failed:`);
-    output.print(`    ${test.steps}`);
+
+    let numberOfSteps = Math.min(test.steps.length, 20);
+
+    for(let i=0; i<numberOfSteps; i++){
+      output.print(`      ${test.steps[test.steps.length-1-i]}`);
+    }
+    if(numberOfSteps<test.steps.length){
+      output.print(`      (${test.steps.length - numberOfSteps} earlier steps skipped)`);
+    }
   }
 });
 


### PR DESCRIPTION
By default, when retry attempt fails error is not logged (it is logged only from last try) 

<img width="785" alt="Screenshot 2021-02-03 at 08 28 08" src="https://user-images.githubusercontent.com/5861660/106719119-d1706c00-65f9-11eb-8d36-2e5780ada3e2.png">
