### PR TITLE
fix: Add document and hearing fields to ReviewDecision.json

### DIFF
--- a/ccd-definition/ComplexTypes/CareSupervision/HearingOrders/ReviewDecision.json
+++ b/ccd-definition/ComplexTypes/CareSupervision/HearingOrders/ReviewDecision.json
@@ -2,6 +2,22 @@
   {
     "LiveFrom": "01/01/2017",
     "ID": "ReviewDecision",
+    "ListElementCode": "hearing",
+    "FieldType": "Text",
+    "ElementLabel": " ",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "ReviewDecision",
+    "ListElementCode": "document",
+    "FieldType": "Document",
+    "ElementLabel": " ",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "ReviewDecision",
     "ListElementCode": "decision",
     "FieldType": "FixedRadioList",
     "ElementLabel": "Is this order ready to be sealed and issued?",


### PR DESCRIPTION
### JIRA link (if applicable) ###
NO JIRA


### Change description ###
Update case summary nightly job failed as the ReviewDecision fields removed in [PR-2213 for draft orders release](https://github.com/hmcts/fpl-ccd-configuration/pull/2213/files#diff-678b3b78b0694a463dd13ab9ffefe60d462a310247755ab4724d72d3ac00732e) 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
