### PR TITLE
fix: migrate husky from v4 to v5

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+yarn lint

--- a/package.json
+++ b/package.json
@@ -25,10 +25,5 @@
     "test:functional": "MOCHAWESOME_REPORTFILENAME=functional codeceptjs run-multiple parallel --grep \"${TESTS_SELECTOR:=(?=.*)^(?!.*@smoke-tests)}\" --reporter mocha-multi",
     "test:smoke": "MOCHAWESOME_REPORTFILENAME=smoke codeceptjs run --grep \"${SMOKE_TESTS_SELECTOR:=@smoke-tests}\" --reporter mocha-multi"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "yarn lint"
-    }
-  },
   "license": "MIT"
 }


### PR DESCRIPTION
### Change description ###

Migrate husky call from v4 implementation to v5 as defined by the [husky documentation](https://typicode.github.io/husky/#/?id=package-scripts).

Related to https://github.com/hmcts/fpl-ccd-configuration/pull/2218

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
