### PR TITLE
fix: message a judge recipient reset on mid event (FPLA-2683)

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/MessageJudgeService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/MessageJudgeService.java
@@ -78,8 +78,6 @@ public class MessageJudgeService {
             data.put("c2DynamicList", rebuildC2DynamicList(caseData, selectedC2Id));
         }
 
-        data.putAll(prePopulateRecipient());
-
         return data;
     }
 

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/MessageJudgeServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/MessageJudgeServiceTest.java
@@ -330,16 +330,6 @@ class MessageJudgeServiceTest {
     }
 
     @Test
-    void shouldPrePopulateRecipientWhenMessageIsInitiatedByJudge() {
-        when(userService.hasUserRole(UserRole.JUDICIARY)).thenReturn(true);
-
-        CaseData caseData = CaseData.builder().build();
-
-        assertThat(messageJudgeService.populateNewMessageFields(caseData)).containsExactly(
-            entry("judicialMessageMetaData", JudicialMessageMetaData.builder().recipient(COURT_EMAIL).build()));
-    }
-
-    @Test
     void shouldNotPrePopulateRecipientWhenMessageIsInitiatedNotByJudge() {
         when(userService.hasUserRole(UserRole.JUDICIARY)).thenReturn(false);
 


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] PR's title includes JIRA ticket number and follow [Conventional Commits](https://www.conventionalcommits.org/) specification
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FPLA-2683

### Change description ###
Fixed an issue where message recipient was being overwritten on the mid event. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
