### PR TITLE
chore(e2e): update success selector

### DIFF
--- a/e2e/pages/eventSummary.page.js
+++ b/e2e/pages/eventSummary.page.js
@@ -12,7 +12,7 @@ module.exports = {
     I.fillField(this.fields.description, description);
   },
 
-  async submit(button, locator = '.alert-success') {
+  async submit(button, locator = '.hmcts-banner--success') {
     await I.retryUntilExists(() => I.click(button), locator);
   },
 };

--- a/e2e/steps_file.js
+++ b/e2e/steps_file.js
@@ -85,7 +85,7 @@ module.exports = function () {
       return caseId;
     },
 
-    async completeEvent(button, changeDetails, confirmationPage = false, selector = '.alert-success') {
+    async completeEvent(button, changeDetails, confirmationPage = false, selector = '.hmcts-banner--success') {
       await this.retryUntilExists(() => this.click('Continue'), '.check-your-answers');
       if (changeDetails != null) {
         eventSummaryPage.provideSummary(changeDetails.summary, changeDetails.description);
@@ -104,7 +104,7 @@ module.exports = function () {
         await eventSummaryPage.submit(button, selector);
       } else {
         await eventSummaryPage.submit(button, '#confirmation-body');
-        await this.retryUntilExists(() => this.click('Close and Return to case details'), '.alert-success');
+        await this.retryUntilExists(() => this.click('Close and Return to case details'), '.hmcts-banner--success');
       }
     },
 

--- a/e2e/tests/uploadDraftOrders_test.js
+++ b/e2e/tests/uploadDraftOrders_test.js
@@ -146,7 +146,7 @@ Scenario('Local authority makes changes requested by the judge', async ({I, case
   I.dontSee(linkLabel);
 });
 
-Scenario('Judge seals and sends draft orders to parties', async ({I, caseViewPage, reviewAgreedCaseManagementOrderEventPage}) => {
+Scenario('Judge seals and sends draft orders for no hearing to parties', async ({I, caseViewPage, reviewAgreedCaseManagementOrderEventPage}) => {
   await I.navigateToCaseDetailsAs(config.judicaryUser, caseId);
 
   await caseViewPage.goToNewActions(config.applicationActions.approveOrders);
@@ -157,7 +157,21 @@ Scenario('Judge seals and sends draft orders to parties', async ({I, caseViewPag
 
   await I.completeEvent('Save and continue');
 
+  caseViewPage.selectTab(caseViewPage.tabs.orders);
+  assertSealedC21(I, 1, draftOrder3);
+
+  caseViewPage.selectTab(caseViewPage.tabs.draftOrders);
+  I.dontSee(noHearing);
+
+  caseViewPage.selectTab(caseViewPage.tabs.documentsSentToParties);
+  assertDocumentSentToParties(I);
+});
+
+Scenario('Judge seals and sends draft orders for hearing to parties', async ({I, caseViewPage, reviewAgreedCaseManagementOrderEventPage}) => {
+  await I.navigateToCaseDetailsAs(config.judicaryUser, caseId);
+
   await caseViewPage.goToNewActions(config.applicationActions.approveOrders);
+
   reviewAgreedCaseManagementOrderEventPage.selectSealCmo();
   reviewAgreedCaseManagementOrderEventPage.selectSealC21(1);
   reviewAgreedCaseManagementOrderEventPage.selectSealC21(2);
@@ -168,7 +182,6 @@ Scenario('Judge seals and sends draft orders to parties', async ({I, caseViewPag
 
   assertSealedCMO(I, 1, hearing2);
   assertSealedCMO(I, 2, hearing1);
-  assertSealedC21(I, 1, draftOrder3);
   assertSealedC21(I, 2, draftOrder2);
   assertSealedC21(I, 3, draftOrder1Updated);
 
@@ -177,18 +190,17 @@ Scenario('Judge seals and sends draft orders to parties', async ({I, caseViewPag
   I.dontSee(hearing1);
   I.dontSee(hearing2);
   I.see(hearing3);
-  I.dontSee(noHearing);
 
   caseViewPage.selectTab(caseViewPage.tabs.documentsSentToParties);
   assertDocumentSentToParties(I);
-});
+}).retry(1); // Async case update in prev test
 
 const assertDraftOrders = function (I, collectionId, hearingName, orders, title, status, supportingDocs) {
   const hearing = `Hearing ${collectionId}`;
 
   I.seeInTab([hearing, 'Hearing'], hearingName);
 
-  if(hearingName !== noHearing) {
+  if (hearingName !== noHearing) {
     I.seeInTab([hearing, 'Judge'], 'Her Honour Judge Reed');
   }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

FPLA-N/A

### Change description ###

updated the success selector from `.alert-success` to `.hmcts-banner--success` following xui update,
updated approved order test to take into account async actions

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
