### PR TITLE
chore(migration): update existing docs to supporting new confidential permissions structure (FPLA-2722)

### DIFF
--- a/ccd-definition/AuthorisationCaseField/CareSupervision/system-update.json
+++ b/ccd-definition/AuthorisationCaseField/CareSupervision/system-update.json
@@ -516,5 +516,68 @@
     "CaseFieldID": "hearingOrdersBundlesDrafts",
     "UserRole": "caseworker-publiclaw-systemupdate",
     "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseFieldID": "hearingFurtherEvidenceDocuments",
+    "UserRole": "caseworker-publiclaw-systemupdate",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseFieldID": "correspondenceDocuments",
+    "UserRole": "caseworker-publiclaw-systemupdate",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseFieldID": "correspondenceDocumentsNC",
+    "UserRole": "caseworker-publiclaw-systemupdate",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseFieldID": "correspondenceDocumentsLA",
+    "UserRole": "caseworker-publiclaw-systemupdate",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseFieldID": "correspondenceDocumentsLANC",
+    "UserRole": "caseworker-publiclaw-systemupdate",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseFieldID": "furtherEvidenceDocuments",
+    "UserRole": "caseworker-publiclaw-systemupdate",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseFieldID": "furtherEvidenceDocumentsNC",
+    "UserRole": "caseworker-publiclaw-systemupdate",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseFieldID": "furtherEvidenceDocumentsLA",
+    "UserRole": "caseworker-publiclaw-systemupdate",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseFieldID": "furtherEvidenceDocumentsLANC",
+    "UserRole": "caseworker-publiclaw-systemupdate",
+    "CRUD": "CRU"
   }
 ]

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseControllerTest.java
@@ -14,7 +14,6 @@ import uk.gov.hmcts.reform.fpl.enums.HearingOrderType;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.HearingBooking;
 import uk.gov.hmcts.reform.fpl.model.SupportingEvidenceBundle;
-import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
 import uk.gov.hmcts.reform.fpl.model.order.HearingOrder;
 
@@ -29,10 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static uk.gov.hmcts.reform.fpl.enums.HearingType.CASE_MANAGEMENT;
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.element;
-import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.unwrapElements;
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.wrapElements;
-import static uk.gov.hmcts.reform.fpl.utils.OrderHelper.getFullOrderType;
-import static uk.gov.hmcts.reform.fpl.utils.TestDataHelper.testDocumentReference;
 
 @ActiveProfiles("integration-test")
 @WebMvcTest(MigrateCaseController.class)
@@ -370,124 +366,6 @@ class MigrateCaseControllerTest extends AbstractControllerTest {
                 .getRootCause()
                 .hasMessage("No draft case management orders in the case");
         }
-        @Nested
-        class Fpla2417 {
-            private static final String MIGRATION_ID = "FPLA-2722";
-
-            private final List<Element<SupportingEvidenceBundle>> supportingDocs = wrapElements(
-                SupportingEvidenceBundle.builder()
-                    .name("non confidential docs")
-                    .build()
-            );
-
-            private final List<Map<String, Object>> supportingDocsData = mapper.convertValue(
-                supportingDocs, new TypeReference<>() {}
-            );
-
-            @Test
-            void shouldNotUpdateCaseIfIncorrectMigrationId() {
-                CaseData caseData = CaseData.builder()
-                    .furtherEvidenceDocuments(supportingDocs)
-                    .build();
-
-                AboutToStartOrSubmitCallbackResponse response = postAboutToSubmitEvent(caseDetails(caseData, "some id"));
-
-                assertThat(response.getData()).doesNotContainKeys("furtherEvidenceDocsNC");
-            }
-
-            @Test
-            void shouldUpdateSupportingDocs() {
-                CaseData caseData = CaseData.builder()
-                    .furtherEvidenceDocuments(supportingDocs)
-                    .correspondenceDocuments(supportingDocs)
-                    .furtherEvidenceDocumentsLA(supportingDocs)
-                    .correspondenceDocumentsLA(supportingDocs)
-                    .build();
-
-                AboutToStartOrSubmitCallbackResponse response = postAboutToSubmitEvent(caseDetails(caseData, MIGRATION_ID));
-
-                assertThat(response.getData())
-                    .extracting(
-                        "furtherEvidenceDocumentsNC", "furtherEvidenceDocumentsLANC",
-                        "correspondenceDocumentsNC", "correspondenceDocumentsLANC"
-                    )
-                    .containsOnly(supportingDocsData);
-            }
-
-            @Test
-            void shouldUpdateFurtherHearingEvidence() {
-                UUID uuid = randomUUID();
-
-                Map<String, Object> data = Map.of(
-                    "hearingFurtherEvidenceDocuments", List.of(
-                        Map.of("id", uuid,
-                            "value", Map.of(
-                                "hearingName", "hearing name",
-                                "supportingEvidenceBundle", supportingDocs
-                            ))),
-                    "migrationId", MIGRATION_ID
-                );
-
-                CaseDetails caseDetails = CaseDetails.builder()
-                    .data(data)
-                    .build();
-
-                AboutToStartOrSubmitCallbackResponse response = postAboutToSubmitEvent(caseDetails);
-
-                List<Map<String, Object>> expectedData = List.of(
-                    Map.of("id", uuid.toString(),
-                        "value", Map.of(
-                            "hearingName", "hearing name",
-                            "supportingEvidenceBundle", supportingDocsData,
-                            "supportingEvidenceLA", supportingDocsData,
-                            "supportingEvidenceNC", supportingDocsData
-                        ))
-                );
-
-                assertThat(response.getData())
-                    .extracting("hearingFurtherEvidenceDocuments")
-                    .isEqualTo(expectedData);
-            }
-
-            @Test
-            void shouldUpdateC2DocumentBundle() {
-                UUID uuid = randomUUID();
-
-                Map<String, Object> data = Map.of(
-                    "c2DocumentBundle", List.of(
-                        Map.of("id", uuid,
-                            "value", Map.of(
-                                "supportingEvidenceBundle", supportingDocs
-                            ))),
-                    "migrationId", MIGRATION_ID
-                );
-
-                CaseDetails caseDetails = CaseDetails.builder()
-                    .data(data)
-                    .build();
-
-                AboutToStartOrSubmitCallbackResponse response = postAboutToSubmitEvent(caseDetails);
-
-                List<Map<String, Object>> expectedData = List.of(
-                    Map.of("id", uuid.toString(),
-                        "value", Map.of(
-                            "supportingEvidenceBundle", supportingDocsData,
-                            "supportingEvidenceLA", supportingDocsData,
-                            "supportingEvidenceNC", supportingDocsData
-                        ))
-                );
-
-                assertThat(response.getData())
-                    .extracting("c2DocumentBundle")
-                    .isEqualTo(expectedData);
-            }
-        }
-
-        private CaseDetails caseDetails(CaseData caseData, String migrationId) {
-            CaseDetails caseDetails = asCaseDetails(caseData);
-            caseDetails.getData().put("migrationId", migrationId);
-            return caseDetails;
-        }
 
 
         private CaseDetails caseDetails(String migrationId,
@@ -513,4 +391,122 @@ class MigrateCaseControllerTest extends AbstractControllerTest {
         }
     }
 
+    @Nested
+    class Fpla2417 {
+        private static final String MIGRATION_ID = "FPLA-2722";
+
+        private final List<Element<SupportingEvidenceBundle>> supportingDocs = wrapElements(
+            SupportingEvidenceBundle.builder()
+                .name("non confidential docs")
+                .build()
+        );
+
+        private final List<Map<String, Object>> supportingDocsData = mapper.convertValue(
+            supportingDocs, new TypeReference<>() {}
+        );
+
+        @Test
+        void shouldNotUpdateCaseIfIncorrectMigrationId() {
+            CaseData caseData = CaseData.builder()
+                .furtherEvidenceDocuments(supportingDocs)
+                .build();
+
+            AboutToStartOrSubmitCallbackResponse response = postAboutToSubmitEvent(caseDetails(caseData, "some id"));
+
+            assertThat(response.getData()).doesNotContainKeys("furtherEvidenceDocsNC");
+        }
+
+        @Test
+        void shouldUpdateSupportingDocs() {
+            CaseData caseData = CaseData.builder()
+                .furtherEvidenceDocuments(supportingDocs)
+                .correspondenceDocuments(supportingDocs)
+                .furtherEvidenceDocumentsLA(supportingDocs)
+                .correspondenceDocumentsLA(supportingDocs)
+                .build();
+
+            AboutToStartOrSubmitCallbackResponse response = postAboutToSubmitEvent(caseDetails(caseData, MIGRATION_ID));
+
+            assertThat(response.getData())
+                .extracting(
+                    "furtherEvidenceDocumentsNC", "furtherEvidenceDocumentsLANC",
+                    "correspondenceDocumentsNC", "correspondenceDocumentsLANC"
+                )
+                .containsOnly(supportingDocsData);
+        }
+
+        @Test
+        void shouldUpdateFurtherHearingEvidence() {
+            UUID uuid = randomUUID();
+
+            Map<String, Object> data = Map.of(
+                "hearingFurtherEvidenceDocuments", List.of(
+                    Map.of("id", uuid,
+                        "value", Map.of(
+                            "hearingName", "hearing name",
+                            "supportingEvidenceBundle", supportingDocs
+                        ))),
+                "migrationId", MIGRATION_ID
+            );
+
+            CaseDetails caseDetails = CaseDetails.builder()
+                .data(data)
+                .build();
+
+            AboutToStartOrSubmitCallbackResponse response = postAboutToSubmitEvent(caseDetails);
+
+            List<Map<String, Object>> expectedData = List.of(
+                Map.of("id", uuid.toString(),
+                    "value", Map.of(
+                        "hearingName", "hearing name",
+                        "supportingEvidenceBundle", supportingDocsData,
+                        "supportingEvidenceLA", supportingDocsData,
+                        "supportingEvidenceNC", supportingDocsData
+                    ))
+            );
+
+            assertThat(response.getData())
+                .extracting("hearingFurtherEvidenceDocuments")
+                .isEqualTo(expectedData);
+        }
+
+        @Test
+        void shouldUpdateC2DocumentBundle() {
+            UUID uuid = randomUUID();
+
+            Map<String, Object> data = Map.of(
+                "c2DocumentBundle", List.of(
+                    Map.of("id", uuid,
+                        "value", Map.of(
+                            "supportingEvidenceBundle", supportingDocs
+                        ))),
+                "migrationId", MIGRATION_ID
+            );
+
+            CaseDetails caseDetails = CaseDetails.builder()
+                .data(data)
+                .build();
+
+            AboutToStartOrSubmitCallbackResponse response = postAboutToSubmitEvent(caseDetails);
+
+            List<Map<String, Object>> expectedData = List.of(
+                Map.of("id", uuid.toString(),
+                    "value", Map.of(
+                        "supportingEvidenceBundle", supportingDocsData,
+                        "supportingEvidenceLA", supportingDocsData,
+                        "supportingEvidenceNC", supportingDocsData
+                    ))
+            );
+
+            assertThat(response.getData())
+                .extracting("c2DocumentBundle")
+                .isEqualTo(expectedData);
+        }
+    }
+
+    private CaseDetails caseDetails(CaseData caseData, String migrationId) {
+        CaseDetails caseDetails = asCaseDetails(caseData);
+        caseDetails.getData().put("migrationId", migrationId);
+        return caseDetails;
+    }
 }

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseControllerTest.java
@@ -392,7 +392,7 @@ class MigrateCaseControllerTest extends AbstractControllerTest {
     }
 
     @Nested
-    class Fpla2417 {
+    class Fpla2722 {
         private static final String MIGRATION_ID = "FPLA-2722";
 
         private final List<Element<SupportingEvidenceBundle>> supportingDocs = wrapElements(
@@ -418,21 +418,58 @@ class MigrateCaseControllerTest extends AbstractControllerTest {
 
         @Test
         void shouldUpdateSupportingDocs() {
+            List<Element<SupportingEvidenceBundle>> furtherEvidenceDocs = wrapElements(
+                SupportingEvidenceBundle.builder()
+                    .name("furtherEvidenceDocs")
+                    .build()
+            );
+            List<Element<SupportingEvidenceBundle>> furtherEvidenceDocsLA = wrapElements(
+                SupportingEvidenceBundle.builder()
+                    .name("furtherEvidenceDocsLA")
+                    .build()
+            );
+            List<Element<SupportingEvidenceBundle>> correspondenceDocs = wrapElements(
+                SupportingEvidenceBundle.builder()
+                    .name("correspondenceDocs")
+                    .build()
+            );
+            List<Element<SupportingEvidenceBundle>> correspondenceDocsLA = wrapElements(
+                SupportingEvidenceBundle.builder()
+                    .name("correspondenceDocsLA")
+                    .build()
+            );
+
             CaseData caseData = CaseData.builder()
-                .furtherEvidenceDocuments(supportingDocs)
-                .correspondenceDocuments(supportingDocs)
-                .furtherEvidenceDocumentsLA(supportingDocs)
-                .correspondenceDocumentsLA(supportingDocs)
+                .furtherEvidenceDocuments(furtherEvidenceDocs)
+                .furtherEvidenceDocumentsLA(furtherEvidenceDocsLA)
+                .correspondenceDocuments(correspondenceDocs)
+                .correspondenceDocumentsLA(correspondenceDocsLA)
                 .build();
 
             AboutToStartOrSubmitCallbackResponse response = postAboutToSubmitEvent(caseDetails(caseData, MIGRATION_ID));
 
+            List<Map<String, Object>> furtherEvidenceNCData = mapper.convertValue(
+                furtherEvidenceDocs, new TypeReference<>() {}
+            );
+            List<Map<String, Object>> furtherEvidenceLANCData = mapper.convertValue(
+                furtherEvidenceDocsLA, new TypeReference<>() {}
+            );
+            List<Map<String, Object>> correspondenceNCData = mapper.convertValue(
+                correspondenceDocs, new TypeReference<>() {}
+            );
+            List<Map<String, Object>> correspondenceLANCData = mapper.convertValue(
+                correspondenceDocsLA, new TypeReference<>() {}
+            );
+
             assertThat(response.getData())
-                .extracting(
-                    "furtherEvidenceDocumentsNC", "furtherEvidenceDocumentsLANC",
-                    "correspondenceDocumentsNC", "correspondenceDocumentsLANC"
-                )
-                .containsOnly(supportingDocsData);
+                .containsAllEntriesOf(
+                    Map.of(
+                        "furtherEvidenceDocumentsNC", furtherEvidenceNCData,
+                        "furtherEvidenceDocumentsLANC", furtherEvidenceLANCData,
+                        "correspondenceDocumentsNC", correspondenceNCData,
+                        "correspondenceDocumentsLANC", correspondenceLANCData
+                    )
+                );
         }
 
         @Test

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.fpl.controllers.support;
 import io.swagger.annotations.Api;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,19 +16,13 @@ import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.SupportingEvidenceBundle;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
 import uk.gov.hmcts.reform.fpl.model.order.HearingOrder;
-import uk.gov.hmcts.reform.fpl.model.order.HearingOrdersBundle;
-import uk.gov.hmcts.reform.fpl.model.order.generated.GeneratedOrder;
-import uk.gov.hmcts.reform.fpl.service.cmo.DraftOrderService;
 import uk.gov.hmcts.reform.fpl.service.document.ConfidentialDocumentsSplitter;
-import uk.gov.hmcts.reform.fpl.service.removeorder.GeneratedOrderRemovalAction;
 import uk.gov.hmcts.reform.fpl.service.removeorder.SealedCMORemovalAction;
 
 import java.util.List;
 import java.util.Map;
 
-import static java.lang.String.format;
 import static org.apache.commons.lang3.ObjectUtils.isEmpty;
-import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
 import static uk.gov.hmcts.reform.fpl.service.document.ManageDocumentLAService.CORRESPONDING_DOCUMENTS_COLLECTION_LA_KEY;
 import static uk.gov.hmcts.reform.fpl.service.document.ManageDocumentLAService.FURTHER_EVIDENCE_DOCUMENTS_COLLECTION_LA_KEY;
 import static uk.gov.hmcts.reform.fpl.service.document.ManageDocumentService.C2_DOCUMENTS_COLLECTION_KEY;
@@ -44,7 +37,6 @@ import static uk.gov.hmcts.reform.fpl.service.document.ManageDocumentService.HEA
 @Slf4j
 public class MigrateCaseController extends CallbackController {
     private static final String MIGRATION_ID_KEY = "migrationId";
-    private final GeneratedOrderRemovalAction generatedOrderRemovalAction;
     private final ConfidentialDocumentsSplitter splitter;
     private final SealedCMORemovalAction sealedCMORemovalAction;
 
@@ -99,7 +91,7 @@ public class MigrateCaseController extends CallbackController {
 
     private Map<String, Object> updateSupportingDocs(List<Element<SupportingEvidenceBundle>> supportingDocs,
                                                      String key) {
-        if (ObjectUtils.isEmpty(supportingDocs)) {
+        if (isEmpty(supportingDocs)) {
             return Map.of();
         }
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -79,13 +79,13 @@ public class MigrateCaseController extends CallbackController {
             caseData.getFurtherEvidenceDocuments(), FURTHER_EVIDENCE_DOCUMENTS_COLLECTION_KEY
         ));
         caseDetails.getData().putAll(updateSupportingDocs(
-            caseData.getFurtherEvidenceDocuments(), FURTHER_EVIDENCE_DOCUMENTS_COLLECTION_LA_KEY
+            caseData.getFurtherEvidenceDocumentsLA(), FURTHER_EVIDENCE_DOCUMENTS_COLLECTION_LA_KEY
         ));
         caseDetails.getData().putAll(updateSupportingDocs(
-            caseData.getFurtherEvidenceDocuments(), CORRESPONDING_DOCUMENTS_COLLECTION_KEY
+            caseData.getCorrespondenceDocuments(), CORRESPONDING_DOCUMENTS_COLLECTION_KEY
         ));
         caseDetails.getData().putAll(updateSupportingDocs(
-            caseData.getFurtherEvidenceDocuments(), CORRESPONDING_DOCUMENTS_COLLECTION_LA_KEY
+            caseData.getCorrespondenceDocumentsLA(), CORRESPONDING_DOCUMENTS_COLLECTION_LA_KEY
         ));
     }
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.fpl.controllers.support;
 import io.swagger.annotations.Api;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -13,18 +14,27 @@ import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.controllers.CallbackController;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
+import uk.gov.hmcts.reform.fpl.model.SupportingEvidenceBundle;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
 import uk.gov.hmcts.reform.fpl.model.order.HearingOrdersBundle;
 import uk.gov.hmcts.reform.fpl.model.order.generated.GeneratedOrder;
 import uk.gov.hmcts.reform.fpl.service.cmo.DraftOrderService;
+import uk.gov.hmcts.reform.fpl.service.document.ConfidentialDocumentsSplitter;
 import uk.gov.hmcts.reform.fpl.service.removeorder.GeneratedOrderRemovalAction;
 import uk.gov.hmcts.reform.fpl.utils.CaseDetailsMap;
 
 import java.util.List;
+import java.util.Map;
 
 import static java.lang.String.format;
 import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
+import static uk.gov.hmcts.reform.fpl.service.document.ManageDocumentLAService.CORRESPONDING_DOCUMENTS_COLLECTION_LA_KEY;
+import static uk.gov.hmcts.reform.fpl.service.document.ManageDocumentLAService.FURTHER_EVIDENCE_DOCUMENTS_COLLECTION_LA_KEY;
+import static uk.gov.hmcts.reform.fpl.service.document.ManageDocumentService.C2_DOCUMENTS_COLLECTION_KEY;
+import static uk.gov.hmcts.reform.fpl.service.document.ManageDocumentService.CORRESPONDING_DOCUMENTS_COLLECTION_KEY;
+import static uk.gov.hmcts.reform.fpl.service.document.ManageDocumentService.FURTHER_EVIDENCE_DOCUMENTS_COLLECTION_KEY;
+import static uk.gov.hmcts.reform.fpl.service.document.ManageDocumentService.HEARING_FURTHER_EVIDENCE_DOCUMENTS_COLLECTION_KEY;
 
 @Api
 @RestController
@@ -34,7 +44,7 @@ import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
 public class MigrateCaseController extends CallbackController {
     private static final String MIGRATION_ID_KEY = "migrationId";
     private final GeneratedOrderRemovalAction generatedOrderRemovalAction;
-
+    private final ConfidentialDocumentsSplitter splitter;
     private final DraftOrderService draftOrderService;
 
     private static final List<Long> casesWithUploadDraftCMOs = List.of(
@@ -83,8 +93,45 @@ public class MigrateCaseController extends CallbackController {
             }
         }
 
+        if ("FPLA-2722".equals(migrationId)) {
+            log.info("Performing migration ({}) for case {}", migrationId, caseDetails.getId());
+            run2417(caseDetails);
+        }
+
         caseDetails.getData().remove(MIGRATION_ID_KEY);
         return respond(caseDetails);
+    }
+
+    private void run2417(CaseDetails caseDetails) {
+        CaseData caseData = getCaseData(caseDetails);
+
+        caseDetails.getData().put(
+            HEARING_FURTHER_EVIDENCE_DOCUMENTS_COLLECTION_KEY, caseData.getHearingFurtherEvidenceDocuments()
+        );
+        caseDetails.getData().put(
+            C2_DOCUMENTS_COLLECTION_KEY, caseData.getC2DocumentBundle()
+        );
+        caseDetails.getData().putAll(updateSupportingDocs(
+            caseData.getFurtherEvidenceDocuments(), FURTHER_EVIDENCE_DOCUMENTS_COLLECTION_KEY
+        ));
+        caseDetails.getData().putAll(updateSupportingDocs(
+            caseData.getFurtherEvidenceDocuments(), FURTHER_EVIDENCE_DOCUMENTS_COLLECTION_LA_KEY
+        ));
+        caseDetails.getData().putAll(updateSupportingDocs(
+            caseData.getFurtherEvidenceDocuments(), CORRESPONDING_DOCUMENTS_COLLECTION_KEY
+        ));
+        caseDetails.getData().putAll(updateSupportingDocs(
+            caseData.getFurtherEvidenceDocuments(), CORRESPONDING_DOCUMENTS_COLLECTION_LA_KEY
+        ));
+    }
+
+    private Map<String, Object> updateSupportingDocs(List<Element<SupportingEvidenceBundle>> supportingDocs,
+                                                     String key) {
+        if (ObjectUtils.isEmpty(supportingDocs)) {
+            return Map.of();
+        }
+
+        return splitter.splitIntoAllAndNonConfidential(supportingDocs, key);
     }
 
     private void run2702(CaseDetails caseDetails) {


### PR DESCRIPTION
### JIRA link (if applicable) ###

[FPLA-2722](https://tools.hmcts.net/jira/browse/FPLA-2722)

### Change description ###

Update document collections to support the new confidential docs permissions structure.

Achieved by:
 - running the splitter over `furtherEvidenceDocuments(LA)` and `correspondenceDocuments(LA)` collections.
 - adding the deserialised version of `hearingFurtherEvidenceDocuments` and `c2DocumentBundle` back into the map so it is serialised with its' new fields.

**Migration tool**
https://github.com/hmcts/fpl-ccd-data-migration-tool/pull/62

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
