### PR TITLE
FPLA-2735 Fix vacate hearing Null Pointer Exception

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/CaseData.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/CaseData.java
@@ -101,6 +101,7 @@ import static uk.gov.hmcts.reform.fpl.enums.YesNo.YES;
 import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.formatLocalDateToString;
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.asDynamicList;
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.findElement;
+import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.nullSafeList;
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.unwrapElements;
 
 @Data
@@ -615,7 +616,7 @@ public class CaseData {
 
     public Optional<Element<HearingOrder>> getDraftUploadedCMOWithId(UUID orderId) {
         return getDraftUploadedCMOs().stream()
-            .filter(draftCmoElement -> orderId.equals(draftCmoElement.getId()))
+            .filter(draftCmoElement -> draftCmoElement.getId().equals(orderId))
             .findFirst();
     }
 
@@ -633,7 +634,7 @@ public class CaseData {
     }
 
     public Optional<Element<HearingOrdersBundle>> getHearingOrderBundleThatContainsOrder(UUID orderId) {
-        return hearingOrdersBundlesDrafts.stream()
+        return nullSafeList(hearingOrdersBundlesDrafts).stream()
             .filter(hearingOrdersBundleElement
                 -> hearingOrdersBundleElement.getValue().getCaseManagementOrders().stream()
                 .anyMatch(orderElement -> orderElement.getId().equals(orderId)))

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/ManageHearingsService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/ManageHearingsService.java
@@ -60,6 +60,7 @@ import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.formatLocalDateT
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.element;
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.findElement;
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.getDynamicListSelectedValue;
+import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.nullSafeList;
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.unwrapElements;
 import static uk.gov.hmcts.reform.fpl.utils.JudgeAndLegalAdvisorHelper.buildAllocatedJudgeLabel;
 import static uk.gov.hmcts.reform.fpl.utils.JudgeAndLegalAdvisorHelper.formatJudgeTitleAndName;
@@ -482,10 +483,8 @@ public class ManageHearingsService {
 
         updateDocumentsBundleName(caseData, cancelledHearing);
 
-        if (caseData.getHearingOrdersBundlesDrafts() != null) {
+        if (isNotEmpty(cancelledHearing.getValue().getCaseManagementOrderId())) {
             updateHearingOrderBundles(caseData, cancelledHearing);
-        }
-        if (caseData.getDraftUploadedCMOs() != null) {
             updateDraftUploadedCaseManagementOrders(caseData, cancelledHearing);
         }
 
@@ -534,15 +533,16 @@ public class ManageHearingsService {
         Optional<Element<HearingOrdersBundle>> hearingBundleWithLinkedCMO =
             caseData.getHearingOrderBundleThatContainsOrder(linkedCmoId);
 
-        hearingBundleWithLinkedCMO.ifPresent(hearingOrdersBundleElement -> caseData.getHearingOrdersBundlesDrafts()
-            .forEach(hearingBundleElement -> {
-                    if (hearingOrdersBundleElement.getId().equals(hearingBundleElement.getId())) {
-                        hearingBundleElement.getValue().setHearingName(hearing.getValue().toLabel());
-                        hearingBundleElement.getValue().getOrders().forEach(
-                            order -> order.getValue().setHearing(hearing.getValue().toLabel()));
+        hearingBundleWithLinkedCMO.ifPresent(hearingOrdersBundleElement ->
+            nullSafeList(caseData.getHearingOrdersBundlesDrafts())
+                .forEach(hearingBundleElement -> {
+                        if (hearingOrdersBundleElement.getId().equals(hearingBundleElement.getId())) {
+                            hearingBundleElement.getValue().setHearingName(hearing.getValue().toLabel());
+                            hearingBundleElement.getValue().getOrders().forEach(
+                                order -> order.getValue().setHearing(hearing.getValue().toLabel()));
+                        }
                     }
-                }
-            ));
+                ));
     }
 
     private void reassignDocumentsBundle(CaseData caseData,

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/model/CaseDataTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/model/CaseDataTest.java
@@ -35,7 +35,6 @@ import static java.time.LocalDateTime.now;
 import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import static uk.gov.hmcts.reform.fpl.enums.CMOStatus.DRAFT;
 import static uk.gov.hmcts.reform.fpl.enums.CMOStatus.SEND_TO_JUDGE;
 import static uk.gov.hmcts.reform.fpl.enums.HearingOrderType.AGREED_CMO;
@@ -1279,6 +1278,17 @@ class CaseDataTest {
 
     @Nested
     class GetDraftUploadedCMOWithId {
+
+        @Test
+        void shouldReturnEmptyWhenCaseDataDoesNotHaveDraftUploadedCMOs() {
+            Element<HearingOrder> draftCMOOne = element(randomUUID(), buildHearingOrder(DRAFT_CMO));
+            CaseData caseData = CaseData.builder()
+                .draftUploadedCMOs(List.of(draftCMOOne, element(buildHearingOrder(DRAFT_CMO))))
+                .build();
+
+            assertThat(caseData.getDraftUploadedCMOWithId(null)).isEmpty();
+        }
+
         @Test
         void shouldReturnDraftCMOWhenDraftUploadedCMOsContainTheExpectedOrder() {
             Element<HearingOrder> draftCMOOne = element(randomUUID(), buildHearingOrder(DRAFT_CMO));
@@ -1334,6 +1344,16 @@ class CaseDataTest {
                 caseData.getHearingOrderBundleThatContainsOrder(draftCMOOne.getId());
 
             assertThat(matchingHearingOrderBundle).isPresent().contains(hearingOrdersBundleOne);
+        }
+
+        @Test
+        void shouldReturnEmptyWhenHearingOrdersBundlesDraftsIsNull() {
+            CaseData caseData = CaseData.builder().build();
+
+            Optional<Element<HearingOrdersBundle>> matchingHearingOrderBundle =
+                caseData.getHearingOrderBundleThatContainsOrder(randomUUID());
+
+            assertThat(matchingHearingOrderBundle).isEmpty();
         }
 
         @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FPLA-2735

### Change description ###
Fix the Null Pointer Exception which is being thrown when unlinking the CMO from a cancelled hearing.
Remove the CMO only when the cancelled hearing has a CMO linked.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
