### PR TITLE
Test owasp on node module

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -118,6 +118,7 @@ withPipeline(type, product, component) {
 
   after('checkout') {
     sh """ git submodule update --init """
+    sh("/usr/bin/yarn install")
   }
 
   before('test') {


### PR DESCRIPTION
To address:
[2021-02-22T16:37:05.491Z] Analyzing `/opt/jenkins/workspace/PL_fpl-ccd-configuration_PR-2282/package.json` - however, the node_modules directory does not exist. Please run `npm install` prior to running dependency-check