### PR TITLE
Revert "chore(deps): bump serenity-gradle-plugin from 2.3.13 to 2.3.31"

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath("net.serenity-bdd:serenity-gradle-plugin:2.3.31")
+    classpath("net.serenity-bdd:serenity-gradle-plugin:2.3.13")
   }
 }
 


### PR DESCRIPTION
Reverts hmcts/fpl-ccd-configuration#2284
as casue errors in report generation
e.g https://build.platform.hmcts.net/job/HMCTS_Nightly_FPL/job/fpl-ccd-configuration/job/master/610/

19:47:02  Failed to generate report for ResultReportingTask{reportName='a0dfa5d49e1a85d8759724739d8034ab3254439de5b527a399bb6b52a7d7ff83.html'} - java.util.concurrent.ExecutionException: java.lang.NoSuchMethodError: 'java.lang.Comparable kotlin.collections.CollectionsKt.minOrNull(java.lang.Iterable)'
19:47:02  net.serenitybdd.reports.model.DurationsKt.startToFinishTimeIn(Durations.kt:45)
19:47:02  java.util.concurrent.ExecutionException: java.lang.NoSuchMethodError: 'java.lang.Comparable kotlin.collections.CollectionsKt.minOrNull(java.lang.Iterable)'
19:47:02  	at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)
19:47:02  	at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:205)
19:47:02  	at net.thucydides.core.reports.html.Reporter.generateReports(Reporter.java:56)
19:47:02  	at net.thucydides.core.reports.html.Reporter.generateReportsFor(Reporter.java:32)
19:47:02  	at net.thucydides.core.reports.html.HtmlAggregateStoryReporter.generateReportsForTestResultsIn(HtmlAggregateStoryReporter.java:212)
19:47:02  	at 