### PR TITLE
fix: Fix flaky e2e tests

### DIFF
--- a/e2e/tests/adminMangesHearings_test.js
+++ b/e2e/tests/adminMangesHearings_test.js
@@ -16,9 +16,9 @@ Feature('Hearing administration');
 BeforeSuite(async ({I}) => {
   caseId = await I.submitNewCaseWithData(mandatoryWithMultipleChildren);
   submittedAt = new Date();
-
-  await I.navigateToCaseDetailsAs(config.hmctsAdminUser, caseId);
 });
+
+Before(async ({I}) => await I.navigateToCaseDetailsAs(config.hmctsAdminUser, caseId));
 
 Scenario('HMCTS admin creates first hearings', async ({I, caseViewPage, manageHearingsEventPage}) => {
   hearingStartDate = moment().add(5,'m').toDate();


### PR DESCRIPTION
We have sequence of events:
- HMCTS admin creates first hearings
- HMCTS admin creates subsequent hearings

1st test select to send notice of hearing, which means that paper documents will be send to reps. Sending paper documents is done asynchronously (new event)

because internal event is async then it can overlap execution of 'HMCTS admin creates subsequent hearings'. In such situation 'HMCTS admin creates subsequent hearings' cannot submit its event as ccd reject it due to concurrent modification of same data by different users. 

Retries mechanism was meant to fix this issue, but the problem is that if something like this happens, test stays on submit event page, and retry starts test again with 
await caseViewPage.goToNewActions(config.administrationActions.manageHearings);

it waits until 'ccd-case-event-trigger' is present on a page, but it is (submit page from prev test run has it)

temp solution is to go to case details page each time before test happens
Ideally we should be able to avoid async procession or be able to detect such situation in a test, but it can be complex topic