### PR TITLE
chore: removed summary tab on event LD toggle (FPLA-2755)

### DIFF
--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ApplicantSubmittedControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ApplicantSubmittedControllerTest.java
@@ -6,7 +6,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
-import uk.gov.hmcts.reform.fpl.service.FeatureToggleService;
 import uk.gov.hmcts.reform.fpl.service.ccd.CoreCaseDataService;
 
 import java.util.Map;
@@ -14,8 +13,6 @@ import java.util.Map;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.fpl.CaseDefinitionConstants.CASE_TYPE;
 import static uk.gov.hmcts.reform.fpl.CaseDefinitionConstants.JURISDICTION;
 
@@ -29,17 +26,12 @@ class ApplicantSubmittedControllerTest extends AbstractControllerTest {
     @MockBean
     private CoreCaseDataService coreCaseDataService;
 
-    @MockBean
-    private FeatureToggleService featureToggleService;
-
     ApplicantSubmittedControllerTest() {
         super("enter-applicant");
     }
 
     @Test
     void shouldUpdateTaskListAndSummary() {
-        when(featureToggleService.isSummaryTabOnEventEnabled()).thenReturn(true);
-
         postSubmittedEvent(CaseDetails.builder()
             .id(CASE_ID)
             .state("Open")
@@ -56,26 +48,4 @@ class ApplicantSubmittedControllerTest extends AbstractControllerTest {
             eq("internal-update-case-summary"), anyMap());
 
     }
-
-    @Test
-    void shouldUpdateTaskListAndSummaryToggledOff() {
-        when(featureToggleService.isSummaryTabOnEventEnabled()).thenReturn(false);
-
-        postSubmittedEvent(CaseDetails.builder()
-            .id(CASE_ID)
-            .state("Open")
-            .data(Map.of(
-                "solicitor", Map.of(
-                    "name", "John Smith"
-                )
-            )).build());
-
-        verify(coreCaseDataService).triggerEvent(eq(JURISDICTION), eq(CASE_TYPE), eq(CASE_ID),
-            eq("internal-update-task-list"), anyMap());
-
-        verifyNoMoreInteractions(coreCaseDataService);
-
-    }
-
-
 }

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ApproveDraftOrdersControllerSubmittedTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ApproveDraftOrdersControllerSubmittedTest.java
@@ -293,6 +293,7 @@ class ApproveDraftOrdersControllerSubmittedTest extends AbstractControllerTest {
                 .judgeTitle(JudgeOrMagistrateTitle.HER_HONOUR_JUDGE)
                 .judgeLastName("Judy")
                 .build())
+            .endDate(LocalDateTime.now())
             .caseManagementOrderId(cmoId)
             .build();
     }

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/CaseSubmissionControllerSubmittedTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/CaseSubmissionControllerSubmittedTest.java
@@ -27,7 +27,6 @@ import uk.gov.hmcts.reform.fpl.model.notify.SharedNotifyTemplate;
 import uk.gov.hmcts.reform.fpl.model.notify.submittedcase.SubmitCaseCafcassTemplate;
 import uk.gov.hmcts.reform.fpl.model.notify.submittedcase.SubmitCaseHmctsTemplate;
 import uk.gov.hmcts.reform.fpl.service.DocumentDownloadService;
-import uk.gov.hmcts.reform.fpl.service.FeatureToggleService;
 import uk.gov.hmcts.reform.fpl.service.ccd.CoreCaseDataService;
 import uk.gov.hmcts.reform.fpl.service.payment.PaymentService;
 import uk.gov.hmcts.reform.fpl.utils.TestDataHelper;
@@ -103,9 +102,6 @@ class CaseSubmissionControllerSubmittedTest extends AbstractControllerTest {
     @MockBean
     private CoreCaseDataService coreCaseDataService;
 
-    @MockBean
-    private FeatureToggleService featureToggleService;
-
     CaseSubmissionControllerSubmittedTest() {
         super("case-submission");
     }
@@ -113,8 +109,6 @@ class CaseSubmissionControllerSubmittedTest extends AbstractControllerTest {
     @BeforeEach
     void init() {
         when(documentDownloadService.downloadDocument(any())).thenReturn(DOCUMENT_CONTENT);
-        when(featureToggleService.isSummaryTabOnEventEnabled()).thenReturn(true);
-
     }
 
     @Test
@@ -157,24 +151,11 @@ class CaseSubmissionControllerSubmittedTest extends AbstractControllerTest {
 
     @Test
     void shouldUpdateTheCaseManagementSummary() {
-
         CaseDetails caseDetails = populatedCaseDetails(Map.of("id", CASE_ID));
 
         postSubmittedEvent(buildCallbackRequest(caseDetails, OPEN));
 
         verify(coreCaseDataService).triggerEvent(eq(JURISDICTION), eq(CASE_TYPE), eq(CASE_ID),
-            eq("internal-update-case-summary"), anyMap());
-    }
-
-    @Test
-    void shouldUpdateTheCaseManagementSummaryToggledOff() {
-        when(featureToggleService.isSummaryTabOnEventEnabled()).thenReturn(false);
-
-        CaseDetails caseDetails = populatedCaseDetails(Map.of("id", CASE_ID));
-
-        postSubmittedEvent(buildCallbackRequest(caseDetails, OPEN));
-
-        verify(coreCaseDataService,never()).triggerEvent(eq(JURISDICTION), eq(CASE_TYPE), eq(CASE_ID),
             eq("internal-update-case-summary"), anyMap());
     }
 

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/CaseSummaryControllerSubmittedTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/CaseSummaryControllerSubmittedTest.java
@@ -7,7 +7,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
-import uk.gov.hmcts.reform.fpl.service.FeatureToggleService;
 import uk.gov.hmcts.reform.fpl.service.ccd.CoreCaseDataService;
 
 import java.util.Map;
@@ -15,9 +14,7 @@ import java.util.Map;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.fpl.CaseDefinitionConstants.CASE_TYPE;
 import static uk.gov.hmcts.reform.fpl.CaseDefinitionConstants.JURISDICTION;
 
@@ -35,13 +32,8 @@ class CaseSummaryControllerSubmittedTest extends AbstractControllerTest {
     @MockBean
     private CoreCaseDataService coreCaseDataService;
 
-    @MockBean
-    private FeatureToggleService featureToggleService;
-
     @Test
     void shouldUpdateTaskList() {
-        when(featureToggleService.isSummaryTabOnEventEnabled()).thenReturn(true);
-
         postSubmittedEvent(CaseDetails.builder()
             .id(CASE_ID)
             .data(Map.of(
@@ -53,20 +45,5 @@ class CaseSummaryControllerSubmittedTest extends AbstractControllerTest {
         verify(coreCaseDataService).triggerEvent(eq(JURISDICTION), eq(CASE_TYPE), ArgumentMatchers.eq(CASE_ID),
             eq("internal-update-case-summary"), anyMap());
         verifyNoMoreInteractions(coreCaseDataService);
-    }
-
-    @Test
-    void shouldUpdateTaskListToggledOff() {
-        when(featureToggleService.isSummaryTabOnEventEnabled()).thenReturn(false);
-
-        postSubmittedEvent(CaseDetails.builder()
-            .id(CASE_ID)
-            .data(Map.of(
-                "solicitor", Map.of(
-                    "name", "John Smith"
-                )
-            )).build());
-
-        verifyNoInteractions(coreCaseDataService);
     }
 }

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/MessageJudgeControllerSubmittedTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/MessageJudgeControllerSubmittedTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.fpl.controllers;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
@@ -14,7 +13,6 @@ import uk.gov.hmcts.reform.fpl.model.Respondent;
 import uk.gov.hmcts.reform.fpl.model.RespondentParty;
 import uk.gov.hmcts.reform.fpl.model.judicialmessage.JudicialMessage;
 import uk.gov.hmcts.reform.fpl.model.summary.SyntheticCaseSummary;
-import uk.gov.hmcts.reform.fpl.service.FeatureToggleService;
 import uk.gov.hmcts.reform.fpl.service.ccd.CoreCaseDataService;
 import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.NotificationClientException;
@@ -25,7 +23,6 @@ import java.util.UUID;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.fpl.CaseDefinitionConstants.CASE_TYPE;
 import static uk.gov.hmcts.reform.fpl.CaseDefinitionConstants.JURISDICTION;
 import static uk.gov.hmcts.reform.fpl.NotifyTemplates.JUDICIAL_MESSAGE_ADDED_TEMPLATE;
@@ -51,19 +48,11 @@ class MessageJudgeControllerSubmittedTest extends AbstractControllerTest {
     @MockBean
     private CoreCaseDataService coreCaseDataService;
 
-    @MockBean
-    private FeatureToggleService featureToggleService;
-
     @Autowired
     private ObjectMapper objectMapper;
 
     MessageJudgeControllerSubmittedTest() {
         super("message-judge");
-    }
-
-    @BeforeEach
-    void setUp() {
-        when(featureToggleService.isSummaryTabOnEventEnabled()).thenReturn(true);
     }
 
     @Test
@@ -165,53 +154,6 @@ class MessageJudgeControllerSubmittedTest extends AbstractControllerTest {
             CASE_REFERENCE,
             "internal-update-case-summary",
             caseSummary("Yes"));
-    }
-
-    @Test
-    void shouldNotifyJudicialMessageRecipientToggleOff() throws NotificationClientException {
-        when(featureToggleService.isSummaryTabOnEventEnabled()).thenReturn(false);
-
-        JudicialMessage latestJudicialMessage = JudicialMessage.builder()
-            .recipient(JUDICIAL_MESSAGE_RECIPIENT)
-            .updatedTime(now().minusDays(1))
-            .status(OPEN)
-            .sender("sender@fpla.com")
-            .urgency("High")
-            .latestMessage(REPLY)
-            .messageHistory(MESSAGE + "/n" + REPLY)
-            .build();
-
-        CaseData caseData = CaseData.builder()
-            .id(CASE_REFERENCE)
-            .respondents1(List.of(
-                element(Respondent.builder()
-                    .party(RespondentParty.builder()
-                        .lastName(LAST_NAME)
-                        .build())
-                    .build())))
-            .judicialMessages(List.of(
-                element(SELECTED_DYNAMIC_LIST_ITEM_ID, latestJudicialMessage),
-                element(JudicialMessage.builder()
-                    .updatedTime(now().minusDays(3))
-                    .status(OPEN)
-                    .recipient("do_not_send@fpla.com")
-                    .sender("someOthersender@fpla.com")
-                    .urgency("High")
-                    .build())))
-            .build();
-
-        postSubmittedEvent(asCaseDetails(caseData));
-
-        Map<String, Object> expectedData = Map.of(
-            "respondentLastName", "Davidson",
-            "caseUrl", "http://fake-url/cases/case-details/12345#Judicial%20messages",
-            "callout", "^Davidson",
-            "latestMessage", REPLY
-        );
-
-        verify(notificationClient).sendEmail(
-            JUDICIAL_MESSAGE_REPLY_TEMPLATE, JUDICIAL_MESSAGE_RECIPIENT, expectedData, "localhost/12345");
-        verifyNoInteractions(coreCaseDataService);
     }
 
     @Test

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/RepresentativeSubmittedEventControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/RepresentativeSubmittedEventControllerTest.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.fpl.controllers;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
@@ -19,7 +18,6 @@ import uk.gov.hmcts.reform.fpl.model.Respondent;
 import uk.gov.hmcts.reform.fpl.model.RespondentParty;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
 import uk.gov.hmcts.reform.fpl.model.summary.SyntheticCaseSummary;
-import uk.gov.hmcts.reform.fpl.service.FeatureToggleService;
 import uk.gov.hmcts.reform.fpl.service.ccd.CoreCaseDataService;
 import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.NotificationClientException;
@@ -33,7 +31,6 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.fpl.CaseDefinitionConstants.CASE_TYPE;
 import static uk.gov.hmcts.reform.fpl.CaseDefinitionConstants.JURISDICTION;
 import static uk.gov.hmcts.reform.fpl.NotifyTemplates.PARTY_ADDED_TO_CASE_BY_EMAIL_NOTIFICATION_TEMPLATE;
@@ -60,11 +57,7 @@ class RepresentativeSubmittedEventControllerTest extends AbstractControllerTest 
     @Autowired
     private ObjectMapper objectMapper;
 
-    @MockBean
-    private FeatureToggleService featureToggleService;
-
     private static final Long CASE_ID = 12345L;
-    private static final String CASE_REFERENCE = "12345";
     private static final String RESPONDENT_SURNAME = "Watson";
     private static final SyntheticCaseSummary CASE_SUMMARY = SyntheticCaseSummary.builder()
         .caseSummaryFirstRespondentLegalRep(REPPRESENTATIVE_FULLNAME)
@@ -74,11 +67,6 @@ class RepresentativeSubmittedEventControllerTest extends AbstractControllerTest 
 
     RepresentativeSubmittedEventControllerTest() {
         super("manage-representatives");
-    }
-
-    @BeforeEach
-    void setUp() {
-        when(featureToggleService.isSummaryTabOnEventEnabled()).thenReturn(true);
     }
 
     @Test
@@ -134,32 +122,6 @@ class RepresentativeSubmittedEventControllerTest extends AbstractControllerTest 
             CASE_ID,
             "internal-update-case-summary",
             caseSummary());
-    }
-
-    @Test
-    void shouldSendNotificationWhenNewPartyIsAddedOrUpdatedToCaseThroughDigitalServiceToggledOff()
-        throws NotificationClientException {
-
-        when(featureToggleService.isSummaryTabOnEventEnabled()).thenReturn(false);
-
-        final UUID representativeId = UUID.randomUUID();
-
-        Respondent respondent = buildRespondent();
-
-        Representative representative = buildRepresentative(DIGITAL_SERVICE);
-
-        CaseDetails caseDetailsBefore = buildCaseData(respondent, emptyList(), emptyMap());
-        CaseDetails caseDetails = buildCaseData(respondent, List.of(element(representativeId, representative)),
-            emptyMap());
-
-        CallbackRequest callbackRequest = buildCallbackRequest(caseDetailsBefore, caseDetails);
-
-        postSubmittedEvent(callbackRequest);
-
-        verify(notificationClient).sendEmail(
-            PARTY_ADDED_TO_CASE_THROUGH_DIGITAL_SERVICE_NOTIFICATION_TEMPLATE, "test@test.com",
-            expectedTemplateParametersDigitalService(), NOTIFICATION_REFERENCE);
-        verifyNoInteractions(coreCaseDataService);
     }
 
     @Test

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/UploadDraftOrdersSubmittedControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/UploadDraftOrdersSubmittedControllerTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.fpl.controllers;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -15,7 +14,6 @@ import uk.gov.hmcts.reform.fpl.model.Judge;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
 import uk.gov.hmcts.reform.fpl.model.order.HearingOrder;
 import uk.gov.hmcts.reform.fpl.model.order.HearingOrdersBundle;
-import uk.gov.hmcts.reform.fpl.service.FeatureToggleService;
 import uk.gov.hmcts.reform.fpl.service.ccd.CoreCaseDataService;
 import uk.gov.hmcts.reform.fpl.utils.TestDataHelper;
 import uk.gov.service.notify.NotificationClient;
@@ -29,7 +27,6 @@ import static com.google.common.collect.Lists.newArrayList;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.fpl.CaseDefinitionConstants.CASE_TYPE;
 import static uk.gov.hmcts.reform.fpl.CaseDefinitionConstants.JURISDICTION;
 import static uk.gov.hmcts.reform.fpl.NotifyTemplates.DRAFT_ORDERS_UPLOADED_NOTIFICATION_TEMPLATE;
@@ -48,18 +45,10 @@ class UploadDraftOrdersSubmittedControllerTest extends AbstractUploadDraftOrders
     private static final LocalDateTime HEARING_DATE = LocalDateTime.of(2020, Month.NOVEMBER, 3, 0, 0, 0);
 
     @MockBean
-    private FeatureToggleService featureToggleService;
-
-    @MockBean
     private NotificationClient notificationClient;
 
     @MockBean
     private CoreCaseDataService coreCaseDataService;
-
-    @BeforeEach
-    void setUp() {
-        when(featureToggleService.isSummaryTabOnEventEnabled()).thenReturn(true);
-    }
 
     @Test
     void shouldSendNotificationsIfNewAgreedCMOUploaded() {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/AfterSubmissionCaseDataUpdatedEventHandler.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/AfterSubmissionCaseDataUpdatedEventHandler.java
@@ -8,7 +8,6 @@ import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.fpl.events.AfterSubmissionCaseDataUpdated;
 import uk.gov.hmcts.reform.fpl.model.summary.SyntheticCaseSummary;
-import uk.gov.hmcts.reform.fpl.service.FeatureToggleService;
 import uk.gov.hmcts.reform.fpl.service.ccd.CoreCaseDataService;
 import uk.gov.hmcts.reform.fpl.service.summary.CaseSummaryService;
 
@@ -25,28 +24,23 @@ public class AfterSubmissionCaseDataUpdatedEventHandler {
     private final CoreCaseDataService coreCaseDataService;
     private final CaseSummaryService caseSummaryService;
     private final ObjectMapper objectMapper;
-    private final FeatureToggleService featureToggleService;
 
     @EventListener
     public void handleCaseDataChange(final AfterSubmissionCaseDataUpdated event) {
+        Map<String, Object> originalSummaryFields = objectMapper.convertValue(
+            originalSyntheticCaseSummary(event),
+            new TypeReference<>() {});
 
-        if (featureToggleService.isSummaryTabOnEventEnabled()) {
-            Map<String, Object> originalSummaryFields = objectMapper.convertValue(
-                originalSyntheticCaseSummary(event),
-                new TypeReference<>() {});
+        Map<String, Object> updatedSummaryFields = caseSummaryService.generateSummaryFields(event.getCaseData());
 
-            Map<String, Object> updatedSummaryFields = caseSummaryService.generateSummaryFields(event.getCaseData());
-
-            if (fieldsHaveChanged(originalSummaryFields, updatedSummaryFields)) {
-                coreCaseDataService.triggerEvent(
-                    JURISDICTION,
-                    CASE_TYPE,
-                    event.getCaseData().getId(),
-                    "internal-update-case-summary",
-                    updatedSummaryFields);
-            }
+        if (fieldsHaveChanged(originalSummaryFields, updatedSummaryFields)) {
+            coreCaseDataService.triggerEvent(
+                JURISDICTION,
+                CASE_TYPE,
+                event.getCaseData().getId(),
+                "internal-update-case-summary",
+                updatedSummaryFields);
         }
-
     }
 
     private SyntheticCaseSummary originalSyntheticCaseSummary(AfterSubmissionCaseDataUpdated event) {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/FeatureToggleService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/FeatureToggleService.java
@@ -26,10 +26,6 @@ public class FeatureToggleService {
         this.environment = environment;
     }
 
-    public boolean isSummaryTabOnEventEnabled() {
-        return ldClient.boolVariation("summary-tab-on-event-update", createLDUser(), false);
-    }
-
     public boolean isCtscEnabled(String localAuthorityName) {
         return ldClient.boolVariation("CTSC",
             createLDUser(Map.of(LOCAL_AUTHORITY_NAME_KEY, LDValue.of(localAuthorityName))), false);

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/AfterSubmissionCaseDataUpdatedEventHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/AfterSubmissionCaseDataUpdatedEventHandlerTest.java
@@ -2,13 +2,11 @@ package uk.gov.hmcts.reform.fpl.handlers;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import uk.gov.hmcts.reform.fpl.events.AfterSubmissionCaseDataUpdated;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.summary.SyntheticCaseSummary;
-import uk.gov.hmcts.reform.fpl.service.FeatureToggleService;
 import uk.gov.hmcts.reform.fpl.service.ccd.CoreCaseDataService;
 import uk.gov.hmcts.reform.fpl.service.summary.CaseSummaryService;
 
@@ -44,33 +42,11 @@ class AfterSubmissionCaseDataUpdatedEventHandlerTest {
     private final CoreCaseDataService coreCaseDataService = mock(CoreCaseDataService.class);
     private final CaseSummaryService caseSummaryService = mock(CaseSummaryService.class);
     private final ObjectMapper objectMapper = mock(ObjectMapper.class);
-    private final FeatureToggleService featureToggleService = mock(FeatureToggleService.class);
 
     AfterSubmissionCaseDataUpdatedEventHandler underTest = new AfterSubmissionCaseDataUpdatedEventHandler(
         coreCaseDataService,
         caseSummaryService,
-        objectMapper,
-        featureToggleService);
-
-    @BeforeEach
-    void setUp() {
-        when(featureToggleService.isSummaryTabOnEventEnabled()).thenReturn(true);
-    }
-
-    @Test
-    void testIfToggleOff() {
-        when(featureToggleService.isSummaryTabOnEventEnabled()).thenReturn(false);
-
-        underTest.handleCaseDataChange(AfterSubmissionCaseDataUpdated.builder()
-            .caseData(CASE_DATA_WITH_SUMMARY)
-            .caseDataBefore(CaseData.builder()
-                .id(CASE_DATA_ID)
-                .syntheticCaseSummary(ANOTHER_SYNTHETIC_CASE_SUMMARY)
-                .build())
-            .build());
-
-        verifyNoInteractions(coreCaseDataService, caseSummaryService, objectMapper);
-    }
+        objectMapper);
 
     @Test
     void testIfNoCaseDataBefore() {

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/FeatureToggleServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/FeatureToggleServiceTest.java
@@ -45,18 +45,6 @@ class FeatureToggleServiceTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    void shouldMakeCorrectCallForIsSummaryTabOnEventEnabled(Boolean toggleState) {
-        givenToggle(toggleState);
-
-        assertThat(service.isSummaryTabOnEventEnabled()).isEqualTo(toggleState);
-        verify(ldClient).boolVariation(
-            eq("summary-tab-on-event-update"),
-            argThat(ldUser(ENVIRONMENT).build()),
-            eq(false));
-    }
-
-    @ParameterizedTest
-    @ValueSource(booleans = {true, false})
     void shouldMakeCorrectCallForCtsc(Boolean toggleState) {
         givenToggle(toggleState);
 


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] PR's title includes JIRA ticket number and follow [Conventional Commits](https://www.conventionalcommits.org/) specification
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FPLA-2755

### Change description ###
Removed usage of summary tab on event LD toggle. LD toggle will be removed once PR is merged and deployed.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
