### PR TITLE
feat: Mandatory email for Applicant Solicitor (FPLA-2824)

### DIFF
--- a/ccd-definition/CaseEventToComplexTypes/enterApplicant/Solicitor.json
+++ b/ccd-definition/CaseEventToComplexTypes/enterApplicant/Solicitor.json
@@ -1,0 +1,58 @@
+[
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "Solicitor",
+    "CaseEventID": "enterApplicant",
+    "CaseFieldID": "solicitor",
+    "ListElementCode": "solicitorLabel",
+    "DisplayContext": "OPTIONAL"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "Solicitor",
+    "CaseEventID": "enterApplicant",
+    "CaseFieldID": "solicitor",
+    "ListElementCode": "name",
+    "DisplayContext": "OPTIONAL"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "Solicitor",
+    "CaseEventID": "enterApplicant",
+    "CaseFieldID": "solicitor",
+    "ListElementCode": "mobile",
+    "DisplayContext": "OPTIONAL"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "Solicitor",
+    "CaseEventID": "enterApplicant",
+    "CaseFieldID": "solicitor",
+    "ListElementCode": "telephone",
+    "DisplayContext": "OPTIONAL"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "Solicitor",
+    "CaseEventID": "enterApplicant",
+    "CaseFieldID": "solicitor",
+    "ListElementCode": "email",
+    "DisplayContext": "MANDATORY"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "Solicitor",
+    "CaseEventID": "enterApplicant",
+    "CaseFieldID": "solicitor",
+    "ListElementCode": "dx",
+    "DisplayContext": "OPTIONAL"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "Solicitor",
+    "CaseEventID": "enterApplicant",
+    "CaseFieldID": "solicitor",
+    "ListElementCode": "reference",
+    "DisplayContext": "OPTIONAL"
+  }
+]

--- a/ccd-definition/CaseEventToFields/CareSupervision/enterApplicant.json
+++ b/ccd-definition/CaseEventToFields/CareSupervision/enterApplicant.json
@@ -18,7 +18,7 @@
     "CaseEventID": "enterApplicant",
     "CaseFieldID": "solicitor",
     "PageFieldDisplayOrder": 2,
-    "DisplayContext": "OPTIONAL",
+    "DisplayContext": "COMPLEX",
     "PageID": 1,
     "PageDisplayOrder": 1,
     "PageColumnNumber": 1,

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ApplicantMidEventControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ApplicantMidEventControllerTest.java
@@ -64,7 +64,7 @@ class ApplicantMidEventControllerTest extends AbstractCallbackTest {
                         .email(EmailAddress.builder().build())
                         .build())
                     .build()),
-                "solicitor", Solicitor.builder().build()))
+                "solicitor", Solicitor.builder().email("email@example.com").build()))
             .build();
 
         AboutToStartOrSubmitCallbackResponse callbackResponse = postMidEvent(caseDetails);
@@ -129,7 +129,7 @@ class ApplicantMidEventControllerTest extends AbstractCallbackTest {
                             .build())
                         .build())
                     .build()),
-                "solicitor", Solicitor.builder().build()))
+                "solicitor", Solicitor.builder().email("email@example.com").build()))
             .build();
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FPLA-2824


### Change description ###
Makes the solicitor's email a mandatory field when completing the applicant's details section


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
