### PR TITLE
temp: Downgrade gradlew versions plugin until module issue for 0.38 is solved

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -15,7 +15,7 @@ plugins {
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.10.RELEASE'
   id 'org.springframework.boot' version '2.4.3'
-  id 'com.github.ben-manes.versions' version '0.38.0'
+  id 'com.github.ben-manes.versions' version '0.36.0'
   id 'org.sonarqube' version '3.1.1'
   id 'project-report'
   id "idea"


### PR DESCRIPTION
 https://artifactory.platform.hmcts.net/artifactory/maven-remotes/com/github/ben-manes/gradle-versions-plugin/0.38.0/gradle-versions-plugin-0.38.0.module
 is expected to be json, but is html, cannot be parsed, cause PR and nightly build failures:

https://build.platform.hmcts.net/blue/organizations/jenkins/HMCTS_FPL%2Ffpl-ccd-configuration/detail/PR-2337/1/pipeline

https://artifactory.platform.hmcts.net/artifactory/maven-remotes/com/github/ben-manes/gradle-versions-plugin/0.38.0/
https://artifactory.platform.hmcts.net/artifactory/maven-remotes/com/github/ben-manes/gradle-versions-plugin/0.36.0/