### PR TITLE
fix: Fix NPE in removal order tool

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/order/HearingOrder.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/order/HearingOrder.java
@@ -19,6 +19,7 @@ import static uk.gov.hmcts.reform.fpl.enums.CMOStatus.APPROVED;
 import static uk.gov.hmcts.reform.fpl.enums.CMOStatus.DRAFT;
 import static uk.gov.hmcts.reform.fpl.enums.CMOStatus.SEND_TO_JUDGE;
 import static uk.gov.hmcts.reform.fpl.enums.HearingOrderType.AGREED_CMO;
+import static uk.gov.hmcts.reform.fpl.enums.HearingOrderType.C21;
 import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.DATE;
 import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.formatLocalDateToString;
 import static uk.gov.hmcts.reform.fpl.utils.JudgeAndLegalAdvisorHelper.formatJudgeTitleAndName;
@@ -61,7 +62,7 @@ public class HearingOrder implements RemovableOrder {
 
     @JsonIgnore
     public boolean isRemovable() {
-        return type.isCmo();
+        return type != C21;
     }
 
     public String asLabel() {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/removeorder/DraftCMORemovalAction.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/removeorder/DraftCMORemovalAction.java
@@ -37,8 +37,8 @@ public class DraftCMORemovalAction implements OrderRemovalAction {
 
     @Override
     public boolean isAccepted(RemovableOrder removableOrder) {
-        return removableOrder instanceof HearingOrder && Optional.ofNullable(((HearingOrder) removableOrder).getType())
-            .filter(HearingOrderType::isCmo)
+        return removableOrder instanceof HearingOrder && Optional.of((HearingOrder) removableOrder)
+            .filter(order -> order.getType() != HearingOrderType.C21)
             .isPresent();
     }
 

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/removeorder/DraftCMORemovalActionTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/removeorder/DraftCMORemovalActionTest.java
@@ -87,6 +87,13 @@ class DraftCMORemovalActionTest {
     }
 
     @Test
+    void isAcceptedWhenHearingOrderTypeIsNull() {
+        RemovableOrder order = HearingOrder.builder().build();
+
+        assertThat(underTest.isAccepted(order)).isTrue();
+    }
+
+    @Test
     void isNotAcceptedIfAnyOtherClass() {
         assertThat(underTest.isAccepted(mock(RemovableOrder.class))).isFalse();
     }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/removeorder/RemoveOrderServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/removeorder/RemoveOrderServiceTest.java
@@ -167,13 +167,14 @@ class RemoveOrderServiceTest {
 
         Element<HearingOrder> draftCMOOne = element(UUID.randomUUID(), buildPastHearingOrder(DRAFT_CMO));
         Element<HearingOrder> draftCMOTwo = element(UUID.randomUUID(), buildPastHearingOrder(DRAFT_CMO));
-        Element<HearingOrder> draftCMOThree = element(UUID.randomUUID(), buildPastHearingOrder(DRAFT_CMO));
+        Element<HearingOrder> legacyDraftCMO = element(UUID.randomUUID(),
+            HearingOrder.builder().dateSent(NOW.minusDays(1)).build());
 
         CaseData caseData = CaseData.builder()
             .state(state)
             .orderCollection(generatedOrders)
             .sealedCMOs(sealedCaseManagementOrders)
-            .draftUploadedCMOs(List.of(draftCMOTwo, draftCMOThree))
+            .draftUploadedCMOs(List.of(draftCMOTwo, legacyDraftCMO))
             .hearingOrdersBundlesDrafts(List.of(
                 element(HearingOrdersBundle.builder().orders(List.of(draftCMOOne)).build()),
                 element(HearingOrdersBundle.builder().orders(List.of(
@@ -195,7 +196,7 @@ class RemoveOrderServiceTest {
                     formatLocalDateToString(NOW.minusDays(1), "d MMMM yyyy"))),
                 buildListElement(draftCMOTwo.getId(), format("Draft case management order sent on %s",
                     formatLocalDateToString(NOW.minusDays(1), "d MMMM yyyy"))),
-                buildListElement(draftCMOThree.getId(), format("Draft case management order sent on %s",
+                buildListElement(legacyDraftCMO.getId(), format("Draft case management order sent on %s",
                     formatLocalDateToString(NOW.minusDays(1), "d MMMM yyyy")))))
             .build();
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A

### Change description ###
Fix the Null pointer exception while generating the dynamic list for legacy CMO data.
Fix the condition to check if the order is removable in `HearingOrder.isRemovable()` and also in `DraftOrderRemovalAction`.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
