### PR TITLE
chore(deps): bump pdfbox from 2.0.20 to 2.0.23

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -193,7 +193,7 @@ def versions = [
   springBoot      : springBoot.class.package.implementationVersion,
   springfoxSwagger: '2.9.2',
   log4j           : '2.13.2',
-  pdfbox          : '2.0.20',
+  pdfbox          : '2.0.23',
   mockito         : '3.7.7',
   serenity        : '2.3.4'
 ]


### PR DESCRIPTION
### Change description ###

Update pdfbox to fix [CVE-2021-27807](https://nvd.nist.gov/vuln/detail/CVE-2021-27807) and [CVE-2021-27906](https://nvd.nist.gov/vuln/detail/CVE-2021-27906) as recommended by [Apache](https://pdfbox.apache.org/)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
