### PR TITLE
chore:NOJIRA remove code for fpla-2885 migration

### DIFF
--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseControllerTest.java
@@ -1,129 +1,13 @@
 package uk.gov.hmcts.reform.fpl.controllers.support;
 
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.controllers.AbstractCallbackTest;
-import uk.gov.hmcts.reform.fpl.model.CaseData;
-import uk.gov.hmcts.reform.fpl.model.HearingBooking;
-import uk.gov.hmcts.reform.fpl.model.common.Element;
-
-import java.util.List;
-import java.util.UUID;
-
-import static java.util.UUID.randomUUID;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.element;
 
 @WebMvcTest(MigrateCaseController.class)
 @OverrideAutoConfiguration(enabled = true)
 class MigrateCaseControllerTest extends AbstractCallbackTest {
-
     MigrateCaseControllerTest() {
         super("migrate-case");
     }
-
-    @Nested
-    class Fpla2885 {
-        String migrationId = "FPLA-2885";
-        UUID idOne = randomUUID();
-        UUID idTwo = randomUUID();
-        UUID idThree = randomUUID();
-        UUID idFour = randomUUID();
-
-        @Test
-        void shouldMigrateExpectedListElementCodes() {
-            Element<HearingBooking> hearingOne
-                = element(idOne, hearingBookingWithCancellationReason("OT8"));
-
-            Element<HearingBooking> hearingTwo
-                = element(idTwo, hearingBookingWithCancellationReason("OT9"));
-
-            Element<HearingBooking> hearingThree
-                = element(idThree, hearingBookingWithCancellationReason("OT10"));
-
-            Element<HearingBooking> hearingFour
-                = element(idFour, hearingBookingWithCancellationReason("OT7"));
-
-            List<Element<HearingBooking>> cancelledHearingBookings = List.of(
-                hearingOne, hearingTwo, hearingThree, hearingFour);
-
-            CaseDetails caseDetails = caseDetails(migrationId, cancelledHearingBookings);
-            CaseData extractedCaseData = extractCaseData(postAboutToSubmitEvent(caseDetails));
-
-            assertThat(extractedCaseData.getCancelledHearingDetails()).containsExactly(
-                element(idOne, hearingBookingWithCancellationReason("IN1")),
-                element(idTwo, hearingBookingWithCancellationReason("OT8")),
-                element(idThree, hearingBookingWithCancellationReason("OT9")),
-                element(idFour, hearingBookingWithCancellationReason("OT7"))
-            );
-        }
-
-        @Test
-        void shouldNotUpdateListElementCodesWhenMigrationIsNotRequired() {
-            Element<HearingBooking> hearingOne
-                = element(idOne, hearingBookingWithCancellationReason("OT1"));
-
-            Element<HearingBooking> hearingTwo
-                = element(idTwo, hearingBookingWithCancellationReason("OT3"));
-
-            List<Element<HearingBooking>> cancelledHearingBookings = List.of(hearingOne, hearingTwo);
-
-            CaseDetails caseDetails = caseDetails(migrationId, cancelledHearingBookings);
-            CaseData extractedCaseData = extractCaseData(postAboutToSubmitEvent(caseDetails));
-
-            assertThat(extractedCaseData.getCancelledHearingDetails()).isEqualTo(cancelledHearingBookings);
-        }
-
-        @Test
-        void shouldNotChangeCaseIfNotExpectedMigrationId() {
-            String incorrectMigrationId = "FPLA-2222";
-
-            Element<HearingBooking> hearingOne
-                = element(idOne, hearingBookingWithCancellationReason("OT8"));
-
-            Element<HearingBooking> hearingTwo
-                = element(idTwo, hearingBookingWithCancellationReason("OT9"));
-
-            Element<HearingBooking> hearingThree
-                = element(idThree, hearingBookingWithCancellationReason("OT10"));
-
-            Element<HearingBooking> hearingFour
-                = element(idFour, hearingBookingWithCancellationReason("OT7"));
-
-            List<Element<HearingBooking>> cancelledHearingBookings = List.of(
-                hearingOne, hearingTwo, hearingThree, hearingFour);
-
-            CaseDetails caseDetails = caseDetails(incorrectMigrationId, cancelledHearingBookings);
-            CaseData extractedCaseData = extractCaseData(postAboutToSubmitEvent(caseDetails));
-
-            assertThat(extractedCaseData.getCancelledHearingDetails()).isEqualTo(cancelledHearingBookings);
-        }
-
-        @Test
-        void shouldThrowAnErrorIfCaseDoesNotContainCancelledHearingBookings() {
-            CaseDetails caseDetails = caseDetails(migrationId, null);
-
-            assertThatThrownBy(() -> postAboutToSubmitEvent(caseDetails))
-                .getRootCause()
-                .hasMessage("Case does not contain cancelled hearing bookings");
-        }
-
-        private HearingBooking hearingBookingWithCancellationReason(String reasonCode) {
-            return HearingBooking.builder().cancellationReason(reasonCode).build();
-        }
-
-        private CaseDetails caseDetails(String migrationId, List<Element<HearingBooking>> cancelledHearings) {
-            CaseDetails caseDetails = asCaseDetails(CaseData.builder()
-                .cancelledHearingDetails(cancelledHearings)
-                .build());
-
-            caseDetails.getData().put("migrationId", migrationId);
-            return caseDetails;
-        }
-    }
-
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -12,10 +12,6 @@ import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.controllers.CallbackController;
-import uk.gov.hmcts.reform.fpl.model.CaseData;
-import uk.gov.hmcts.reform.fpl.service.CaseAccessService;
-
-import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 
 @Api
 @RestController
@@ -24,44 +20,13 @@ import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 @Slf4j
 public class MigrateCaseController extends CallbackController {
     private static final String MIGRATION_ID_KEY = "migrationId";
-    private static final String FMN_ERROR_MESSAGE = "Unexpected FMN ";
-
-    private final CaseAccessService caseAccessService;
 
     @PostMapping("/about-to-submit")
     public AboutToStartOrSubmitCallbackResponse handleAboutToSubmit(@RequestBody CallbackRequest callbackRequest) {
         CaseDetails caseDetails = callbackRequest.getCaseDetails();
         Object migrationId = caseDetails.getData().get(MIGRATION_ID_KEY);
 
-        if ("FPLA-2885".equals(migrationId)) {
-            run2885(caseDetails);
-        }
-
         caseDetails.getData().remove(MIGRATION_ID_KEY);
         return respond(caseDetails);
-    }
-
-    private void run2885(CaseDetails caseDetails) {
-        CaseData caseData = getCaseData(caseDetails);
-
-        if (isEmpty(caseData.getCancelledHearingDetails())) {
-            throw new IllegalArgumentException("Case does not contain cancelled hearing bookings");
-        }
-
-        caseData.getCancelledHearingDetails().forEach(hearingBookingElement -> {
-            switch (hearingBookingElement.getValue().getCancellationReason()) {
-                case "OT8":
-                    hearingBookingElement.getValue().setCancellationReason("IN1");
-                    break;
-                case "OT9":
-                    hearingBookingElement.getValue().setCancellationReason("OT8");
-                    break;
-                case "OT10":
-                    hearingBookingElement.getValue().setCancellationReason("OT9");
-                    break;
-            }
-        });
-
-        caseDetails.getData().put("cancelledHearingDetails", caseData.getCancelledHearingDetails());
     }
 }


### PR DESCRIPTION
### Change description ###
chore: Remove unused code for fpla-2885 migration case. This code should never be re-executed as it will cause data issues on re-execution.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
