### PR TITLE
fix: Add isRelatedToC2 case field to judicial messages

### DIFF
--- a/ccd-definition/ComplexTypes/CareSupervision/JudicialMessage/JudicialMessage.json
+++ b/ccd-definition/ComplexTypes/CareSupervision/JudicialMessage/JudicialMessage.json
@@ -105,6 +105,15 @@
   {
     "LiveFrom": "01/01/2017",
     "ID": "JudicialMessage",
+    "ListElementCode": "isRelatedToC2",
+    "FieldType": "YesOrNo",
+    "ElementLabel": " ",
+    "SecurityClassification": "Public",
+    "FieldShowCondition": "relatedDocuments=\"DO_NOT_SHOW\""
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "JudicialMessage",
     "ListElementCode": "applicationType",
     "FieldType": "Text",
     "ElementLabel": "Application",


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Add isRelatedToC2 case field to fix the issue of the judicial messages with legacy case data

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
