### PR TITLE
chore: give possiblity to fetch user data for the e2e test purpose, so that user data can be asserted in env agnostic way

### DIFF
--- a/e2e/actors/base.js
+++ b/e2e/actors/base.js
@@ -2,7 +2,7 @@ const output = require('codeceptjs').output;
 const lodash = require('lodash');
 const config = require('../config');
 const moment = require('moment');
-const caseHelper = require('../helpers/case_helper.js');
+const apiHelper = require('../helpers/api_helper.js');
 
 const loginPage = require('../pages/login.page');
 const caseListPage = require('../pages/caseList.page');
@@ -270,7 +270,7 @@ module.exports = {
 
   async submitNewCaseWithData(data = mandatorySubmissionFields) {
     const caseId = await this.submitNewCase(config.swanseaLocalAuthorityUserOne);
-    await caseHelper.populateWithData(caseId, data);
+    await apiHelper.populateWithData(caseId, data);
     await this.refreshPage();
     output.print(`Case #${caseId} has been populated with data`);
 
@@ -280,7 +280,7 @@ module.exports = {
   async submitNewCase(user, name) {
     const caseName = name || `Test case (${moment().format('YYYY-MM-DD HH:MM')})`;
     const creator = user || config.swanseaLocalAuthorityUserOne;
-    const caseData = await caseHelper.createCase(creator, caseName);
+    const caseData = await apiHelper.createCase(creator, caseName);
     const caseId = caseData.id;
     output.print(`Case #${caseId} has been created`);
 

--- a/e2e/helpers/api_helper.js
+++ b/e2e/helpers/api_helper.js
@@ -88,6 +88,17 @@ const createCase = async (user, caseName) => {
   return await response.json();
 };
 
+const getUser = async (user) => {
+  const authToken = await getAuthToken();
+  const url = `${config.fplServiceUrl}/testing-support/user`;
+  const headers = {
+    'Content-Type': 'application/json',
+    'Authorization': `Bearer ${authToken}`,
+  };
+  let response = await post(url, user, headers);
+  return await response.json();
+};
+
 const getAuthToken = async (user=config.systemUpdateUser) => {
   const url = `${config.idamApiUrl}/loginUser?username=${user.email}&password=${user.password}`;
   const data = {};
@@ -103,4 +114,5 @@ const getAuthToken = async (user=config.systemUpdateUser) => {
 module.exports = {
   populateWithData,
   createCase,
+  getUser,
 };

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/testingsupport/controllers/TestingSupportController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/testingsupport/controllers/TestingSupportController.java
@@ -19,6 +19,8 @@ import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 import uk.gov.hmcts.reform.fpl.enums.State;
 import uk.gov.hmcts.reform.fpl.request.RequestData;
 import uk.gov.hmcts.reform.fpl.service.ccd.CoreCaseDataService;
+import uk.gov.hmcts.reform.idam.client.IdamClient;
+import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 
 import java.util.Map;
 
@@ -39,6 +41,7 @@ public class TestingSupportController {
     private final CoreCaseDataApiV2 coreCaseDataApiV2;
     private final RequestData requestData;
     private final AuthTokenGenerator authTokenGenerator;
+    private final IdamClient idamClient;
 
     @PostMapping(value = "/testing-support/case/create", produces = APPLICATION_JSON_VALUE)
     public Map createCase(@RequestBody Map<String, Object> requestBody) {
@@ -79,5 +82,11 @@ public class TestingSupportController {
             log.error(String.format("Populate case event failed: %s", e.contentUTF8()));
             throw e;
         }
+    }
+
+    @PostMapping("/testing-support/user")
+    public UserDetails getUser(@RequestBody Map<String, String> requestBody) {
+        final String token = idamClient.getAccessToken(requestBody.get("email"), requestBody.get("password"));
+        return idamClient.getUserDetails(token);
     }
 }


### PR DESCRIPTION
Usage:

const apiHelper = require('../helpers/api_helper.js');
const userDetails = await apiHelper.getUser(config.privateSolicitorOne);

userDetails looks like:
```
{
  "id": "3e93ba97-ba39-4229-80fd-a14561053eb6",
  "email": "solicitor1@solicitors.uk",
  "forename": "solicitor1@solicitors.uk",
  "surname": "External",
  "roles": [
    "caseworker-publiclaw",
    "pui-case-manager",
    "caseworker",
    "caseworker-publiclaw-solicitor"
  ],
  "fullName": "solicitor1@solicitors.uk External"
}
```