### PR TITLE
fix: catch date time parsing exception for additional applications (FPLA-NA)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 
 plugins {
   id 'java'
-  id 'org.owasp.dependencycheck' version '6.1.5' apply true
+  id 'org.owasp.dependencycheck' version '6.1.6' apply true
 }
 
 allprojects {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/CaseData.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/CaseData.java
@@ -79,6 +79,7 @@ import uk.gov.hmcts.reform.fpl.validation.interfaces.time.TimeNotMidnight;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
 import java.time.format.FormatStyle;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -110,6 +111,7 @@ import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
 import static uk.gov.hmcts.reform.fpl.enums.CMOStatus.SEND_TO_JUDGE;
 import static uk.gov.hmcts.reform.fpl.enums.YesNo.YES;
 import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.DATE_TIME;
+import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.TIME_DATE;
 import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.formatLocalDateToString;
 import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.parseLocalDateTimeFromStringUsingFormat;
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.asDynamicList;
@@ -345,7 +347,7 @@ public class CaseData {
         List<Element<ApplicationsBundle>> applicationsBundles = getAllApplicationsBundles();
 
         Comparator<Element<ApplicationsBundle>> reverseChronological = comparing((Element<ApplicationsBundle> bundle) ->
-            parseLocalDateTimeFromStringUsingFormat(bundle.getValue().getUploadedDateTime(), DATE_TIME))
+            parseLocalDateTimeFromStringUsingFormat(bundle.getValue().getUploadedDateTime(), DATE_TIME, TIME_DATE))
             .reversed();
 
         applicationsBundles.sort(Comparator

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/CaseData.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/CaseData.java
@@ -79,7 +79,6 @@ import uk.gov.hmcts.reform.fpl.validation.interfaces.time.TimeNotMidnight;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeParseException;
 import java.time.format.FormatStyle;
 import java.util.ArrayList;
 import java.util.Collection;

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/utils/DateFormatterHelper.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/utils/DateFormatterHelper.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.fpl.utils;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.format.FormatStyle;
 import java.util.Locale;
 
@@ -35,8 +36,12 @@ public class DateFormatterHelper {
         return LocalDate.parse(date, DateTimeFormatter.ofPattern(format, Locale.UK));
     }
 
-    public static LocalDateTime parseLocalDateTimeFromStringUsingFormat(String date, String format) {
-        return LocalDateTime.parse(date, DateTimeFormatter.ofPattern(format, Locale.UK));
+    public static LocalDateTime parseLocalDateTimeFromStringUsingFormat(String date, String main, String alternative) {
+        try {
+            return LocalDateTime.parse(date, DateTimeFormatter.ofPattern(main, Locale.UK));
+        } catch (DateTimeParseException e) {
+            return LocalDateTime.parse(date, DateTimeFormatter.ofPattern(alternative, Locale.UK));
+        }
     }
 
     public static String getDayOfMonthSuffix(int day) {

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/utils/DateFormatterHelperTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/utils/DateFormatterHelperTest.java
@@ -16,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.DATE;
 import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.DATE_TIME;
+import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.TIME_DATE;
 import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.formatLocalDateTimeBaseUsingFormat;
 import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.formatLocalDateToString;
 import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.getDayOfMonthSuffix;
@@ -25,6 +26,7 @@ import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.parseLocalDateTi
 class DateFormatterHelperTest {
     private static final String JANUARY_2019 = "1 January 2019";
     private static final String JANUARY_2019_TIME = "1 January 2019, 12:00pm";
+    private static final String TIME_JANUARY_2019 = "12:00pm, 1 January 2019";
 
     private static Stream<Arguments> dayOfMonthSuffixSource() {
         return Stream.of(
@@ -106,26 +108,32 @@ class DateFormatterHelperTest {
     }
 
     @Test
-    void shouldParseAFormattedDateTimeToLocalDateTimeWhenGivenCorrectFormat() {
-        LocalDateTime parsed = parseLocalDateTimeFromStringUsingFormat(JANUARY_2019_TIME, DATE_TIME);
+    void shouldParseAFormattedDateTimeToLocalDateTimeWhenGivenMainFormat() {
+        LocalDateTime parsed = parseLocalDateTimeFromStringUsingFormat(JANUARY_2019_TIME, DATE_TIME, TIME_DATE);
+        assertThat(parsed).isEqualTo(createDateTime());
+    }
+
+    @Test   
+    void shouldParseAFormattedDateTimeToLocalDateTimeWhenGivenAlternativeFormat() {
+        LocalDateTime parsed = parseLocalDateTimeFromStringUsingFormat(TIME_JANUARY_2019, DATE_TIME, TIME_DATE);
         assertThat(parsed).isEqualTo(createDateTime());
     }
 
     @Test
-    void shouldThrowExceptionWhenFormatDoesNotMatchDateTime() {
+    void shouldThrowExceptionWhenDateTimeDoesNotMatchEitherFormat() {
         assertThrows(DateTimeParseException.class,
-            () -> parseLocalDateTimeFromStringUsingFormat(JANUARY_2019_TIME, "d MM y"));
+            () -> parseLocalDateTimeFromStringUsingFormat(JANUARY_2019_TIME, "d MM y", "h:mma, yyyy"));
     }
 
     @Test
     void shouldThrowExceptionWhenDateTimeIsNull() {
-        assertThrows(NullPointerException.class, () -> parseLocalDateTimeFromStringUsingFormat(null, DATE));
+        assertThrows(NullPointerException.class, () -> parseLocalDateTimeFromStringUsingFormat(null, DATE, DATE));
     }
 
     @Test
-    void shouldThrowExceptionWhenDateTimeFormatFormatIsNull() {
+    void shouldThrowExceptionWhenBothFormatsAreNull() {
         assertThrows(NullPointerException.class,
-            () -> parseLocalDateTimeFromStringUsingFormat(JANUARY_2019_TIME, null));
+            () -> parseLocalDateTimeFromStringUsingFormat(JANUARY_2019_TIME, null, null));
     }
 
     private LocalDate createDate() {


### PR DESCRIPTION
### Change description ###

Old cases have date in TIME_DATE format, new use DATE_TIME format, and thus there is parsing exception for old application documents. This was a result of FPLA-2981 which now sorts application list based on date

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
