### PR TITLE
fix: improve TLD validation in ValidateEmailService (FPLA-3032)

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/ValidateEmailService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/ValidateEmailService.java
@@ -36,7 +36,7 @@ public class ValidateEmailService {
     private static final Pattern HOSTNAME_PATTERN = compile(format(
         "^(xn-|[a-z0-9]{1,%1$d})(-[a-z0-9]{1,%1$d}){0,%1$d}$", HOST_PART_MAX_LENGTH), CASE_INSENSITIVE);
     private static final Pattern TLD_PATTERN = compile(format(
-        "^([a-z]{1,%1$d}|xn--([a-z0-9]{1,%1$d}-){0,%1$d}[a-z0-9]{1,%1$d})$", HOST_PART_MAX_LENGTH), CASE_INSENSITIVE);
+        "^([a-z]{2,%1$d}|xn--([a-z0-9]{1,%1$d}-){0,%1$d}[a-z0-9]{1,%1$d})$", HOST_PART_MAX_LENGTH), CASE_INSENSITIVE);
     private static final Pattern EMAIL_PATTERN = compile(format(
         "^[%s]{1,%2$d}@([^.@][^@\\s]{2,%2$d})$", LOCAL_CHARS, EMAIL_MAX_LENGTH));
 

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ValidateEmailServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ValidateEmailServiceTest.java
@@ -90,7 +90,7 @@ class ValidateEmailServiceTest {
     //See https://github.com/alphagov/notifications-utils/blob/master/tests/test_recipient_validation.py#L122-L152
     private static Stream<String> invalidEmailAddresses() {
         return Stream.of(
-            "incorrect@tld.co.k",
+            "invalid@tld.co.k",
             "<John Doe> johndoe@email.com",
             "very.unusual.”@”.unusual.com@example.com",
             "very.”(),:;<>[]”.VERY.”very@\\\\ \"very”.unusual@strange.example.com",

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ValidateEmailServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ValidateEmailServiceTest.java
@@ -90,6 +90,7 @@ class ValidateEmailServiceTest {
     //See https://github.com/alphagov/notifications-utils/blob/master/tests/test_recipient_validation.py#L122-L152
     private static Stream<String> invalidEmailAddresses() {
         return Stream.of(
+            "incorrect@tld.co.k",
             "<John Doe> johndoe@email.com",
             "very.unusual.”@”.unusual.com@example.com",
             "very.”(),:;<>[]”.VERY.”very@\\\\ \"very”.unusual@strange.example.com",


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FPLA-3032

### Change description ###

TLD regex pattern was not ported correctly from GOV Notify
https://github.com/alphagov/notifications-utils/blob/5e3985ec46892a3f3b02afbb42a438f13e289e42/notifications_utils/__init__.py#L12

Fix will now catch incorrect domains such as test@example.co.k (this example was raising status 400s in exceptions)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
