### PR TITLE
chore: Provide custom implementation from grabAttributes as WebDerive one throws exception when attr not present

### DIFF
--- a/e2e/actors/base.js
+++ b/e2e/actors/base.js
@@ -22,7 +22,7 @@ let currentUser = {};
 
 module.exports = {
   async signIn(user) {
-    if (currentUser !== user) {
+    if (!(this.isPuppeteer() &&  (currentUser === user))) {
       output.debug(`Logging in as ${user.email}`);
       currentUser = {}; // reset in case the login fails
 

--- a/e2e/helpers/browser_helper.js
+++ b/e2e/helpers/browser_helper.js
@@ -7,9 +7,13 @@ module.exports = class BrowserHelpers extends Helper {
     return this.helpers['Puppeteer'] || this.helpers['WebDriver'];
   }
 
+  isPuppeteer(){
+    return this.helpers['Puppeteer'];
+  }
+
   clickBrowserBack() {
     const helper = this.getHelper();
-    if (this.helpers['Puppeteer']) {
+    if (this.isPuppeteer()) {
       return helper.page.goBack();
     } else {
       return helper.browser.back();
@@ -50,7 +54,7 @@ module.exports = class BrowserHelpers extends Helper {
     const helper = this.getHelper();
     const waitTimeout = sec ? sec * 1000 : helper.options.waitForTimeout;
     try {
-      if (this.helpers['Puppeteer']) {
+      if (this.isPuppeteer()) {
         const context = await helper._getContext();
         return await context.waitForSelector(locator, {timeout: waitTimeout});
       } else {
@@ -65,7 +69,7 @@ module.exports = class BrowserHelpers extends Helper {
     return this.waitForSelector([].concat(selectors).join(','), maxWaitInSecond);
   }
 
-  async canSee(selector){
+  async canSee(selector) {
     const helper = this.getHelper();
     try {
       const numVisible = await helper.grabNumberOfVisibleElements(selector);
@@ -90,6 +94,26 @@ module.exports = class BrowserHelpers extends Helper {
     const texts = elements.map(async (element) => {
       return (await element.getProperty('innerText')).jsonValue();
     });
+
+    if (texts.length > 1) {
+      throw new Error(`More than one element found for locator ${locator}`);
+    } else {
+      return texts[0];
+    }
+  }
+
+  async grabAttribute(locator, attr) {
+    const elements = await this.locateSelector(locator);
+
+    let getAttribute;
+
+    if(this.isPuppeteer()){
+      getAttribute = async (element, attr) =>  (await element.getProperty(attr)).jsonValue();
+    } else {
+      getAttribute = async (element, attr) => await element.getAttribute(attr);
+    }
+
+    const texts = elements.map(async element => getAttribute(element, attr));
 
     if (texts.length > 1) {
       throw new Error(`More than one element found for locator ${locator}`);

--- a/e2e/helpers/browser_helper.js
+++ b/e2e/helpers/browser_helper.js
@@ -117,11 +117,8 @@ module.exports = class BrowserHelpers extends Helper {
 
     if (texts.length > 1) {
       throw new Error(`More than one element found for locator ${locator}`);
-    } else if (texts.length === 1) {
-      return texts[0];
-    } else {
-      return undefined;
     }
+    return texts[0];
   }
 
   async runAccessibilityTest() {

--- a/e2e/pages/caseView.page.js
+++ b/e2e/pages/caseView.page.js
@@ -105,8 +105,8 @@ module.exports = {
 
   async checkTaskIsUnavailable(task) {
     this.checkTaskStatus(task, 'Cannot send yet');
-    const taskTarget = await I.grabAttributeFrom(`//p/a[text()="${task}"]`,'href');
-    assert.strictEqual(taskTarget, null);
+    const taskTarget = await I.grabAttribute(`//p/a[text()="${task}"]`, 'href');
+    assert.strictEqual(!!taskTarget, false);
   },
 
   async checkTasksHaveErrors(tasksErrors) {


### PR DESCRIPTION
To support cross browser tests:

from WebDriver.js
```
async grabAttributeFrom(locator, attr) {
    const attrs = await this.grabAttributeFromAll(locator, attr);
    assertElementExists(attrs, locator);
    if (attrs.length > 1) {
      this.debugSection('GrabAttribute', `Using first element out of ${attrs.length}`);
    }
    return attrs[0];
  }
```
and
```
function assertElementExists(res, locator, prefix, suffix) {
  if (!res || res.length === 0) {
    throw new ElementNotFound(locator, prefix, suffix);
  }
}

```

if element is found but attr not present then it throws ElementNotFound exception
