### PR TITLE
Increase timeout after selectOption action

### DIFF
--- a/e2e/helpers/stepListener.js
+++ b/e2e/helpers/stepListener.js
@@ -6,7 +6,7 @@ const event = require('codeceptjs').event;
 const delays = {
   'click': 200,
   'doubleClick': 200,
-  'selectOption': 200,
+  'selectOption': 400,
   'fillField': 100,
   'checkOption': 200,
   'attachFile': 2000,

--- a/e2e/tests/noticeOfChange_test.js
+++ b/e2e/tests/noticeOfChange_test.js
@@ -108,7 +108,7 @@ const assertRepresentative = (I, user, organisation, index = 1) => {
   I.seeInTab(['Representative', 'Email address'], user.email);
 
   if (organisation) {
-    I.waitForText(organisation);
+    I.waitForText(organisation, 40);
     I.seeOrganisationInTab([`Respondents ${index}`, 'Representative', 'Name'], organisation);
   }
 };
@@ -127,7 +127,7 @@ const assertChangeOfRepresentative = (I, index, method, respondentName, actingUs
     I.seeInTab([representative, 'Added representative', 'First name'], addedUser.forename);
     I.seeInTab([representative, 'Added representative', 'Last name'], addedUser.surname);
     I.seeInTab([representative, 'Added representative', 'Email'], addedUser.email);
-    I.waitForText(addedUser.organisation);
+    I.waitForText(addedUser.organisation, 40);
     I.seeOrganisationInTab([representative, 'Added representative', 'Name'], addedUser.organisation);
   }
 
@@ -135,7 +135,7 @@ const assertChangeOfRepresentative = (I, index, method, respondentName, actingUs
     I.seeInTab([representative, 'Removed representative', 'First name'], removedUser.forename);
     I.seeInTab([representative, 'Removed representative', 'Last name'], removedUser.surname);
     I.seeInTab([representative, 'Removed representative', 'Email'], removedUser.email);
-    I.waitForText(removedUser.organisation);
+    I.waitForText(removedUser.organisation, 40);
     I.seeOrganisationInTab([representative, 'Removed representative', 'Name'], removedUser.organisation);
   }
 };


### PR DESCRIPTION
to fix issue that is frequently observed at nightly build. Selecting from dropdown 'steal' focus from input filed that is populated shortly after option is selected

<img width="847" alt="selectOption" src="https://user-images.githubusercontent.com/5861660/118786161-75201800-b889-11eb-8ab9-262c6baf3262.png">
