### PR TITLE
fix: remove asterisks from fields that are not mandatory

### DIFF
--- a/ccd-definition/CaseEventToComplexTypes/respondents/enterRespondents.json
+++ b/ccd-definition/CaseEventToComplexTypes/respondents/enterRespondents.json
@@ -25,7 +25,6 @@
     "CaseEventID": "enterRespondents",
     "CaseFieldID": "respondents1",
     "ListElementCode": "party.dateOfBirth",
-    "EventElementLabel": "*Date of birth",
     "FieldDisplayOrder": 3,
     "DisplayContext": "OPTIONAL"
   },
@@ -35,7 +34,6 @@
     "CaseEventID": "enterRespondents",
     "CaseFieldID": "respondents1",
     "ListElementCode": "party.gender",
-    "EventElementLabel": "*Gender",
     "FieldDisplayOrder": 4,
     "DisplayContext": "OPTIONAL"
   },
@@ -45,7 +43,6 @@
     "CaseEventID": "enterRespondents",
     "CaseFieldID": "respondents1",
     "ListElementCode": "party.genderIdentification",
-    "EventElementLabel": "*What gender do they identify with?",
     "FieldDisplayOrder": 5,
     "DisplayContext": "OPTIONAL"
   },
@@ -55,7 +52,6 @@
     "CaseEventID": "enterRespondents",
     "CaseFieldID": "respondents1",
     "ListElementCode": "party.address",
-    "EventElementLabel": "*Current address",
     "FieldDisplayOrder": 6,
     "DisplayContext": "OPTIONAL"
   },


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Due to an oversight, asterisks were added to the date of birth, gender and address field labels for the Resondent's details although these fields are not mandatory.

This change will remove those asterisks so we do not indicate those fields are mandatory


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
