### PR TITLE
chore(submodules):Using relative URL for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "fpla-docker"]
 	path = fpla-docker
-	url = https://github.com/hmcts/fpla-docker
+	url = ../fpla-docker.git
 	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "fpla-docker"]
 	path = fpla-docker
-	url = ../fpla-docker.git
+	url = ../../hmcts/fpla-docker.git
 	branch = master


### PR DESCRIPTION
### Change description ###
The idea here is to make it easier to make changes to the submodule easier by using the same URL pattern used for the parent project.
This way, pushing changes will work whether you've used ssh or https to clone the parent project.

For example, I use ssh and therefore don't want to type my password to push changes to fpla-docker.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
