### PR TITLE
chore: only update Saucelabs at the end of a test run with the overall test result

### DIFF
--- a/e2e/crossbrowser/supportedBrowsers.js
+++ b/e2e/crossbrowser/supportedBrowsers.js
@@ -1,4 +1,4 @@
-const LATEST_MAC = 'macOS 10.15';
+const LATEST_MAC = 'macOS 11.00';
 const LATEST_WINDOWS = 'Windows 10';
 
 const supportedBrowsers = {
@@ -25,7 +25,7 @@ const supportedBrowsers = {
   safari: {
     safari_mac_latest: {
       browserName: 'safari',
-      platformName: 'macOS 11.00',
+      platformName: LATEST_MAC,
       browserVersion: 'latest',
       'sauce:options': {
         name: 'FPLA: MAC_SAFARI',
@@ -41,7 +41,7 @@ const supportedBrowsers = {
       browserVersion: 'latest',
       'sauce:options': {
         name: 'FPLA: WIN_CHROME_LATEST',
-        screenResolution: '1400x1050',
+        screenResolution: '1600x1200',
       },
     },
     chrome_mac_latest: {
@@ -50,7 +50,7 @@ const supportedBrowsers = {
       browserVersion: 'latest',
       'sauce:options': {
         name: 'FPLA: MAC_CHROME_LATEST',
-        screenResolution: '1400x1050',
+        screenResolution: '1600x1200',
       },
     },
   },

--- a/e2e/crossbrowser/supportedBrowsers.js
+++ b/e2e/crossbrowser/supportedBrowsers.js
@@ -61,7 +61,7 @@ const supportedBrowsers = {
       browserVersion: 'latest',
       'sauce:options': {
         name: 'FPLA: WIN_FIREFOX_LATEST',
-        screenResolution: '1400x1050',
+        screenResolution: '1600x1200',
       },
     },
     firefox_mac_latest: {
@@ -70,7 +70,7 @@ const supportedBrowsers = {
       browserVersion: 'latest',
       'sauce:options': {
         name: 'FPLA: MAC_FIREFOX_LATEST',
-        screenResolution: '1400x1050',
+        screenResolution: '1600x1200',
       },
     },
   },

--- a/e2e/helpers/SauceLabsReportingHelper.js
+++ b/e2e/helpers/SauceLabsReportingHelper.js
@@ -13,17 +13,13 @@ module.exports = function () {
   let failedTests = [];
 
   event.dispatcher.on(event.test.passed, (test) => {
-    console.log('Test Passed:', test.title);    // deleteme before merge
-    console.log('Failed Tests Before:', failedTests);  // deleteme before merge
     if (failedTests.find(failedTest => failedTest === test.title)) {
       // Remove test from failedTests list once it passes
       failedTests = failedTests.filter(failedTest => failedTest !== test.title);
     }
-    console.log('Failed Tests After:', failedTests);  // deleteme before merge
   });
 
   event.dispatcher.on(event.test.failed, (test) => {
-    console.log('Test Failed:', test.title);    // deleteme before merge
     if (!failedTests.find(failedTest => failedTest === test.title)) {
       failedTests.push(test.title);
     }

--- a/e2e/helpers/SauceLabsReportingHelper.js
+++ b/e2e/helpers/SauceLabsReportingHelper.js
@@ -9,23 +9,31 @@ function updateSauceLabsResult(result, sessionId) {
   return 'curl -X PUT -s -d \'{"passed": ' + result + '}\' -u ' + process.env.SAUCE_USERNAME + ':' + process.env.SAUCE_ACCESS_KEY + ' https://eu-central-1.saucelabs.com/rest/v1/' + process.env.SAUCE_USERNAME + '/jobs/' + sessionId;
 }
 
-module.exports = function() {
-  let overallResult;
+module.exports = function () {
+  let failedTests = [];
 
-  event.dispatcher.on(event.test.passed, () => {
-    // skip if the test run has already failed
-    if (overallResult === undefined) {
-      overallResult = true;
+  event.dispatcher.on(event.test.passed, (test) => {
+    if (failedTests.find(failedTest => failedTest === test.title)) {
+      // Remove test from failedTests list once it passes
+      failedTests = failedTests.filter(failedTest => failedTest === test.title);
     }
   });
 
-  event.dispatcher.on(event.test.failed, () => {
-    overallResult = false;
+  event.dispatcher.on(event.test.failed, (test) => {
+    if (!failedTests.find(failedTest => failedTest === test.title)) {
+      failedTests.push(test.title);
+    }
   });
 
   // Setting overall test result on SauceLabs
   event.dispatcher.on(event.all.after, () => {
     const sessionId = container.helpers('WebDriver').browser.sessionId;
-    exec(updateSauceLabsResult(!!overallResult, sessionId));
+    const overallResult = failedTests.length === 0;
+    console.log(`Updating Saucelabs with overall result: ${overallResult ? 'PASS' : 'FAIL'}`);
+    if (!overallResult) {
+      console.log('Failed Tests:');
+      failedTests.forEach(test => console.log(`"${test}"`));
+    }
+    exec(updateSauceLabsResult(overallResult, sessionId));
   });
 };

--- a/e2e/helpers/SauceLabsReportingHelper.js
+++ b/e2e/helpers/SauceLabsReportingHelper.js
@@ -13,6 +13,8 @@ module.exports = function () {
   let failedTests = [];
 
   event.dispatcher.on(event.test.passed, (test) => {
+    console.log('Test Passed:', test.title);    // deleteme before merge
+    console.log('Failed Tests:', failedTests);  // deleteme before merge
     if (failedTests.find(failedTest => failedTest === test.title)) {
       // Remove test from failedTests list once it passes
       failedTests = failedTests.filter(failedTest => failedTest === test.title);
@@ -20,6 +22,7 @@ module.exports = function () {
   });
 
   event.dispatcher.on(event.test.failed, (test) => {
+    console.log('Test Failed:', test.title);    // deleteme before merge
     if (!failedTests.find(failedTest => failedTest === test.title)) {
       failedTests.push(test.title);
     }

--- a/e2e/helpers/SauceLabsReportingHelper.js
+++ b/e2e/helpers/SauceLabsReportingHelper.js
@@ -17,7 +17,7 @@ module.exports = function () {
     console.log('Failed Tests:', failedTests);  // deleteme before merge
     if (failedTests.find(failedTest => failedTest === test.title)) {
       // Remove test from failedTests list once it passes
-      failedTests = failedTests.filter(failedTest => failedTest === test.title);
+      failedTests = failedTests.filter(failedTest => failedTest !== test.title);
     }
     return test;
   });

--- a/e2e/helpers/SauceLabsReportingHelper.js
+++ b/e2e/helpers/SauceLabsReportingHelper.js
@@ -10,20 +10,22 @@ function updateSauceLabsResult(result, sessionId) {
 }
 
 module.exports = function() {
+  let overallResult;
 
-  // Setting test success on SauceLabs
   event.dispatcher.on(event.test.passed, () => {
-
-    const sessionId = container.helpers('WebDriver').browser.sessionId;
-    exec(updateSauceLabsResult('true', sessionId));
-
+    // skip if the test run has already failed
+    if (overallResult === undefined) {
+      overallResult = true;
+    }
   });
 
-  // Setting test failure on SauceLabs
   event.dispatcher.on(event.test.failed, () => {
+    overallResult = false;
+  });
 
+  // Setting overall test result on SauceLabs
+  event.dispatcher.on(event.all.after, () => {
     const sessionId = container.helpers('WebDriver').browser.sessionId;
-    exec(updateSauceLabsResult('false', sessionId));
-
+    exec(updateSauceLabsResult(!!overallResult, sessionId));
   });
 };

--- a/e2e/helpers/SauceLabsReportingHelper.js
+++ b/e2e/helpers/SauceLabsReportingHelper.js
@@ -14,12 +14,12 @@ module.exports = function () {
 
   event.dispatcher.on(event.test.passed, (test) => {
     console.log('Test Passed:', test.title);    // deleteme before merge
-    console.log('Failed Tests:', failedTests);  // deleteme before merge
+    console.log('Failed Tests Before:', failedTests);  // deleteme before merge
     if (failedTests.find(failedTest => failedTest === test.title)) {
       // Remove test from failedTests list once it passes
       failedTests = failedTests.filter(failedTest => failedTest !== test.title);
     }
-    return test;
+    console.log('Failed Tests After:', failedTests);  // deleteme before merge
   });
 
   event.dispatcher.on(event.test.failed, (test) => {
@@ -27,7 +27,6 @@ module.exports = function () {
     if (!failedTests.find(failedTest => failedTest === test.title)) {
       failedTests.push(test.title);
     }
-    return test;
   });
 
   // Setting overall test result on SauceLabs

--- a/e2e/helpers/SauceLabsReportingHelper.js
+++ b/e2e/helpers/SauceLabsReportingHelper.js
@@ -19,6 +19,7 @@ module.exports = function () {
       // Remove test from failedTests list once it passes
       failedTests = failedTests.filter(failedTest => failedTest === test.title);
     }
+    return test;
   });
 
   event.dispatcher.on(event.test.failed, (test) => {
@@ -26,6 +27,7 @@ module.exports = function () {
     if (!failedTests.find(failedTest => failedTest === test.title)) {
       failedTests.push(test.title);
     }
+    return test;
   });
 
   // Setting overall test result on SauceLabs

--- a/e2e/helpers/SauceLabsReportingHelper.js
+++ b/e2e/helpers/SauceLabsReportingHelper.js
@@ -6,29 +6,24 @@ const exec = require('child_process').exec;
 
 function updateSauceLabsResult(result, sessionId) {
   console.log('SauceOnDemandSessionID=' + sessionId + ' job-name=fpl-ccd-configuration');
-  return 'curl -X PUT -s -d \'{"passed": ' + result + '}\' -u ' + process.env.SAUCE_USERNAME + ':' + process.env.SAUCE_ACCESS_KEY + ' https://eu-central-1.saucelabs.com/rest/v1/' + process.env.SAUCE_USERNAME + '/jobs/' + sessionId;
+  return `curl -X PUT -s -d '{"passed": ${result}}' -u ${process.env.SAUCE_USERNAME}:${process.env.SAUCE_ACCESS_KEY} https://eu-central-1.saucelabs.com/rest/v1/${process.env.SAUCE_USERNAME}/jobs/${sessionId}`;
 }
 
 module.exports = function () {
-  let failedTests = [];
+  let failedTests = new Set();
 
   event.dispatcher.on(event.test.passed, (test) => {
-    if (failedTests.find(failedTest => failedTest === test.title)) {
-      // Remove test from failedTests list once it passes
-      failedTests = failedTests.filter(failedTest => failedTest !== test.title);
-    }
+    failedTests.delete(test.title);
   });
 
   event.dispatcher.on(event.test.failed, (test) => {
-    if (!failedTests.find(failedTest => failedTest === test.title)) {
-      failedTests.push(test.title);
-    }
+    failedTests.add(test.title);
   });
 
   // Setting overall test result on SauceLabs
   event.dispatcher.on(event.all.after, () => {
     const sessionId = container.helpers('WebDriver').browser.sessionId;
-    const overallResult = failedTests.length === 0;
+    const overallResult = failedTests.size === 0;
     console.log(`Updating Saucelabs with overall result: ${overallResult ? 'PASS' : 'FAIL'}`);
     if (!overallResult) {
       console.log('Failed Tests:');

--- a/e2e/helpers/dump_browser_logs_helper.js
+++ b/e2e/helpers/dump_browser_logs_helper.js
@@ -29,16 +29,19 @@ function stringify(value) {
 module.exports = class HooksHelpers extends Helper {
   async _failed(test) {
     const helper = this.helpers['Puppeteer'] || this.helpers['WebDriver'];
-    const logs = (await helper.grabBrowserLogs()).map(log => {
-      return {
-        type: log.type(),
-        message: log.text(),
-        location: log.location().url,
-      };
-    });
+    let logs = await helper.grabBrowserLogs();
+    if (logs !== undefined) {
+      logs = logs.map(log => {
+        return {
+          type: log.type(),
+          message: log.text(),
+          location: log.location().url,
+        };
+      });
 
-    if (logs.length > 0) {
-      fs.writeFileSync(`${buildOutputFileName(test)}.browser.log`, stringify(logs));
+      if (logs.length > 0) {
+        fs.writeFileSync(`${buildOutputFileName(test)}.browser.log`, stringify(logs));
+      }
     }
 
     const source = await helper.grabSource();

--- a/e2e/pages/caseView.page.js
+++ b/e2e/pages/caseView.page.js
@@ -71,6 +71,7 @@ module.exports = {
   },
 
   checkTaskStatus(task, status) {
+    I.waitForElement(locate(`//p/a[text()="${task}"]`), 10);
     if(status) {
       I.seeElement(locate(`//p/a[text()="${task}"]/../img`).withAttr({title: status}));
     } else {

--- a/saucelabs.conf.js
+++ b/saucelabs.conf.js
@@ -11,7 +11,6 @@ const defaultSauceOptions = {
   accessKey: process.env.SAUCE_ACCESS_KEY,
   tunnelIdentifier: process.env.TUNNEL_IDENTIFIER || 'reformtunnel',
   acceptSslCerts: true,
-  windowSize: '1600x900',
   tags: ['FPL'],
 };
 

--- a/saucelabs.conf.js
+++ b/saucelabs.conf.js
@@ -65,7 +65,7 @@ const setupConfig = {
     },
     DumpBrowserLogsHelper: {
       require: './e2e/helpers/dump_browser_logs_helper.js',
-    }
+    },
   },
   plugins: {
     retryFailedStep: {
@@ -75,6 +75,10 @@ const setupConfig = {
     autoDelay: {
       enabled: true,
       delayAfter: 2000,
+    },
+    screenshotOnFail: {
+      enabled: true,
+      fullPageScreenshots: true,
     },
   },
   include: {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FPLA-3049

### Change description ###

Only update Saucelabs at the end of a test run with the overall test result (i.e. any failed test marks the test). 

This is to avoid the current situation where one Saucelabs job is used for all test scenarios, but Codecept updates Saucelabs per scenario. This can result in a mis-match where Saucelabs shows the test run as green if the last scenario passes, even though a previous scenario might have failed.

Also includes:
- update Mac crossbrowser tests to run on Mac OS 11
- fix "Cannot read property 'map' of undefined" error in dump_browser_logs_helper.js
- `waitForElement()` before continuing in `checkTaskStatus()`

![image](https://user-images.githubusercontent.com/11600884/121549894-2851dc00-ca06-11eb-92ff-48800f64a881.png)

https://build.platform.hmcts.net/job/HMCTS_Nightly_FPL/job/fpl-ccd-configuration/job/PR-2724/

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
