### PR TITLE
FPLA-1986: Docmosis generation testing

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -99,11 +99,8 @@ def setupSecretsForIntegrationTests(pipelineConf) {
     withTeamSecrets(pipelineConf, 'aat') {
       /* Setup Email template integration tests key with gov.notify */
       env.INTEGRATION_TEST_NOTIFY_SERVICE_KEY = "${INTEGRATION_TEST_NOTIFY_SERVICE_KEY}"
-    }
-    withTeamSecrets(pipelineConf, 'aat') {
       /* Setup Docmosis template integration tests key and url */
       env.INTEGRATION_TEST_DOCMOSIS_TORNADO_KEY = "${DOCMOSIS_API_KEY}"
-//      env.INTEGRATION_TEST_DOCMOSIS_TORNADO_KEY = "https://docmosis.${env}.platform.hmcts.net"
       env.INTEGRATION_TEST_DOCMOSIS_TORNADO_URL = "https://docmosis.aat.platform.hmcts.net"
     }
   }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -109,7 +109,7 @@ def setupSecretsForIntegrationTests(pipelineConf) {
 }
 
 def archiveExtraFilesForIntegrationTests() {
-  steps.archiveArtifacts artifacts: "${env.INTEGRATION_TEST_DOCMOSIS_TORNADO_OUTPUT_FOLDER}"
+  steps.archiveArtifacts allowEmptyArchive: true, artifacts: "${env.INTEGRATION_TEST_DOCMOSIS_TORNADO_OUTPUT_FOLDER}/**/*"
 }
 
 def teardownSecretsForIntegrationTests() {

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -109,7 +109,7 @@ def setupSecretsForIntegrationTests(pipelineConf) {
 }
 
 def archiveExtraFilesForIntegrationTests() {
-  steps.archiveArtifacts allowEmptyArchive: true, artifacts: "${env.INTEGRATION_TEST_DOCMOSIS_TORNADO_OUTPUT_FOLDER}/**/*"
+  steps.archiveArtifacts allowEmptyArchive: true, artifacts: "build/docmosis-generated/**/*"
 }
 
 def teardownSecretsForIntegrationTests() {

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -22,6 +22,9 @@ def serviceSecrets = [
 def integrationTestSecrets = [
   'fpl-aat': [
     secret('integration-test-notify-service-key', 'INTEGRATION_TEST_NOTIFY_SERVICE_KEY')
+  ],
+  'fpl-${env}': [
+    secret('docmosis-api-key', 'INTEGRATION_TEST_DOCMOSIS_TORNADO_KEY'),
   ]
 ]
 
@@ -100,7 +103,7 @@ def setupSecretsForIntegrationTests(pipelineConf) {
       /* Setup Email template integration tests key with gov.notify */
       env.INTEGRATION_TEST_NOTIFY_SERVICE_KEY = "${INTEGRATION_TEST_NOTIFY_SERVICE_KEY}"
       /* Setup Docmosis template integration tests key and url */
-      env.INTEGRATION_TEST_DOCMOSIS_TORNADO_KEY = "${DOCMOSIS_API_KEY}"
+      env.INTEGRATION_TEST_DOCMOSIS_TORNADO_KEY = "${INTEGRATION_TEST_DOCMOSIS_TORNADO_KEY}"
       env.INTEGRATION_TEST_DOCMOSIS_TORNADO_URL = "https://docmosis.aat.platform.hmcts.net"
     }
   }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -100,11 +100,19 @@ def setupSecretsForIntegrationTests(pipelineConf) {
       /* Setup Email template integration tests key with gov.notify */
       env.INTEGRATION_TEST_NOTIFY_SERVICE_KEY = "${INTEGRATION_TEST_NOTIFY_SERVICE_KEY}"
     }
+    withTeamSecrets(pipelineConf, 'aat') {
+      /* Setup Docmosis template integration tests key and url */
+      env.INTEGRATION_TEST_DOCMOSIS_TORNADO_KEY = "${DOCMOSIS_API_KEY}"
+//      env.INTEGRATION_TEST_DOCMOSIS_TORNADO_KEY = "https://docmosis.${env}.platform.hmcts.net"
+      env.INTEGRATION_TEST_DOCMOSIS_TORNADO_URL = "https://docmosis.aat.platform.hmcts.net"
+    }
   }
 }
 
 def teardownSecretsForIntegrationTests() {
   env.INTEGRATION_TEST_NOTIFY_SERVICE_KEY = ''
+  env.INTEGRATION_TEST_DOCMOSIS_TORNADO_KEY = ''
+  env.INTEGRATION_TEST_DOCMOSIS_TORNADO_URL = ''
 }
 
 

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -103,14 +103,20 @@ def setupSecretsForIntegrationTests(pipelineConf) {
       /* Setup Docmosis template integration tests key and url */
       env.INTEGRATION_TEST_DOCMOSIS_TORNADO_KEY = "${INTEGRATION_TEST_DOCMOSIS_TORNADO_KEY}"
       env.INTEGRATION_TEST_DOCMOSIS_TORNADO_URL = "https://docmosis.aat.platform.hmcts.net"
+      env.INTEGRATION_TEST_DOCMOSIS_TORNADO_OUTPUT_FOLDER = "${WORKSPACE}/build/docmosis-generated"
     }
   }
+}
+
+def archiveExtraFilesForIntegrationTests() {
+  steps.archiveArtifacts artifacts: "${env.INTEGRATION_TEST_DOCMOSIS_TORNADO_OUTPUT_FOLDER}"
 }
 
 def teardownSecretsForIntegrationTests() {
   env.INTEGRATION_TEST_NOTIFY_SERVICE_KEY = ''
   env.INTEGRATION_TEST_DOCMOSIS_TORNADO_KEY = ''
   env.INTEGRATION_TEST_DOCMOSIS_TORNADO_URL = ''
+  env.INTEGRATION_TEST_DOCMOSIS_TORNADO_OUTPUT_FOLDER = ''
 }
 
 
@@ -162,6 +168,7 @@ withPipeline(type, product, component) {
   }
 
   after('test') {
+    archiveExtraFilesForIntegrationTests()
     teardownSecretsForIntegrationTests()
   }
 

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -21,10 +21,8 @@ def serviceSecrets = [
 
 def integrationTestSecrets = [
   'fpl-aat': [
-    secret('integration-test-notify-service-key', 'INTEGRATION_TEST_NOTIFY_SERVICE_KEY')
-  ],
-  'fpl-${env}': [
-    secret('docmosis-api-key', 'INTEGRATION_TEST_DOCMOSIS_TORNADO_KEY'),
+    secret('integration-test-notify-service-key', 'INTEGRATION_TEST_NOTIFY_SERVICE_KEY'),
+    secret('docmosis-api-key', 'INTEGRATION_TEST_DOCMOSIS_TORNADO_KEY')
   ]
 ]
 

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -30,7 +30,8 @@ AppPipelineConfig pipelineConf;
 
 def integrationTestSecrets = [
   'fpl-aat': [
-    secret('integration-test-notify-service-key', 'INTEGRATION_TEST_NOTIFY_SERVICE_KEY')
+    secret('integration-test-notify-service-key', 'INTEGRATION_TEST_NOTIFY_SERVICE_KEY'),
+    secret('docmosis-api-key', 'INTEGRATION_TEST_DOCMOSIS_TORNADO_KEY')
   ]
 ]
 
@@ -47,12 +48,23 @@ def setupSecretsForIntegrationTests(pipelineConf) {
     withTeamSecrets(pipelineConf, 'aat') {
       /* Setup Email template integration tests key with gov.notify */
       env.INTEGRATION_TEST_NOTIFY_SERVICE_KEY = "${INTEGRATION_TEST_NOTIFY_SERVICE_KEY}"
+      /* Setup Docmosis template integration tests key and url */
+      env.INTEGRATION_TEST_DOCMOSIS_TORNADO_KEY = "${INTEGRATION_TEST_DOCMOSIS_TORNADO_KEY}"
+      env.INTEGRATION_TEST_DOCMOSIS_TORNADO_URL = "https://docmosis.aat.platform.hmcts.net"
+      env.INTEGRATION_TEST_DOCMOSIS_TORNADO_OUTPUT_FOLDER = "${WORKSPACE}/build/docmosis-generated"
     }
   }
 }
 
+def archiveExtraFilesForIntegrationTests() {
+  steps.archiveArtifacts allowEmptyArchive: true, artifacts: "build/docmosis-generated/**/*"
+}
+
 def teardownSecretsForIntegrationTests() {
   env.INTEGRATION_TEST_NOTIFY_SERVICE_KEY = ''
+  env.INTEGRATION_TEST_DOCMOSIS_TORNADO_KEY = ''
+  env.INTEGRATION_TEST_DOCMOSIS_TORNADO_URL = ''
+  env.INTEGRATION_TEST_DOCMOSIS_TORNADO_OUTPUT_FOLDER = ''
 }
 
 withNightlyPipeline(type, product, component) {
@@ -77,6 +89,7 @@ withNightlyPipeline(type, product, component) {
   }
 
   after('mutationTest') {
+    archiveExtraFilesForIntegrationTests()
     teardownSecretsForIntegrationTests()
   }
 

--- a/service/src/functionalTest/java/uk/gov/hmcts/reform/fpl/service/DocumentService.java
+++ b/service/src/functionalTest/java/uk/gov/hmcts/reform/fpl/service/DocumentService.java
@@ -2,30 +2,18 @@ package uk.gov.hmcts.reform.fpl.service;
 
 import lombok.RequiredArgsConstructor;
 import net.serenitybdd.rest.SerenityRest;
-import org.apache.pdfbox.pdmodel.PDDocument;
-import org.apache.pdfbox.pdmodel.PDPage;
-import org.apache.pdfbox.pdmodel.common.PDRectangle;
-import org.apache.pdfbox.text.PDFTextStripperByArea;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.fpl.model.User;
 import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
 
-import java.awt.geom.Rectangle2D;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-
 import static org.apache.http.HttpStatus.SC_OK;
+import static uk.gov.hmcts.reform.fpl.docmosis.DocmosisHelper.extractPdfContent;
+import static uk.gov.hmcts.reform.fpl.docmosis.DocmosisHelper.remove;
 
 @Service
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class DocumentService {
-
-    private static final float POINTS_PER_INCH = 72;
-    private static final float POINTS_PER_MM = 1 / (10 * 2.54f) * POINTS_PER_INCH;
-    private static final int FOOTER_HEIGHT_IN_MM = 15;
-    private static final int FOOTER_HEIGHT_IN_POINTS = Math.round(POINTS_PER_MM * FOOTER_HEIGHT_IN_MM);
-    private static final String DATA_REGION = "dataRegion";
 
     private final AuthenticationService authenticationService;
 
@@ -46,43 +34,6 @@ public class DocumentService {
             .statusCode(SC_OK)
             .extract()
             .asByteArray();
-    }
-
-    private String extractPdfContent(byte[] binaries) {
-
-        try (final PDDocument pdf = PDDocument.load(binaries)) {
-
-            final StringBuilder textBuilder = new StringBuilder();
-
-            for (int i = 0; i < pdf.getNumberOfPages(); i++) {
-                PDPage page = pdf.getPage(i);
-
-                PDRectangle dimensions = page.getCropBox();
-
-                Rectangle2D dataRegion = new Rectangle2D.Double(0, 0,
-                    dimensions.getWidth(), dimensions.getHeight() - FOOTER_HEIGHT_IN_POINTS);
-
-                PDFTextStripperByArea textStripper = new PDFTextStripperByArea();
-
-                textStripper.addRegion(DATA_REGION, dataRegion);
-                textStripper.extractRegions(page);
-
-                textBuilder.append(textStripper.getTextForRegion(DATA_REGION));
-            }
-
-            return textBuilder.toString();
-
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
-
-    private String remove(String text, String... ignores) {
-        String updatedText = text;
-        for (String ignore : ignores) {
-            updatedText = updatedText.replaceAll(ignore, "");
-        }
-        return updatedText;
     }
 
 }

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/docmosis/AbstractDocmosisTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/docmosis/AbstractDocmosisTest.java
@@ -21,7 +21,7 @@ import uk.gov.hmcts.reform.fpl.utils.captor.ResultsCaptor;
 import java.io.File;
 import java.io.IOException;
 
-@ActiveProfiles( {"integration-test", "docmosis-template-test"})
+@ActiveProfiles({"integration-test", "docmosis-template-test"})
 @OverrideAutoConfiguration(enabled = true)
 @Import(AbstractDocmosisTest.TestConfiguration.class)
 @SpringBootTest(classes = {

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/docmosis/AbstractDocmosisTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/docmosis/AbstractDocmosisTest.java
@@ -1,21 +1,38 @@
 package uk.gov.hmcts.reform.fpl.docmosis;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.FileUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.client.RestTemplate;
 import uk.gov.hmcts.reform.fpl.config.DocmosisConfiguration;
 import uk.gov.hmcts.reform.fpl.model.common.DocmosisDocument;
+import uk.gov.hmcts.reform.fpl.service.CaseDataExtractionService;
+import uk.gov.hmcts.reform.fpl.service.ChildrenService;
+import uk.gov.hmcts.reform.fpl.service.HearingVenueLookUpService;
+import uk.gov.hmcts.reform.fpl.service.docmosis.DocumentConversionService;
+import uk.gov.hmcts.reform.fpl.service.orders.generator.DocumentMerger;
 import uk.gov.hmcts.reform.fpl.utils.captor.ResultsCaptor;
 
 import java.io.File;
 import java.io.IOException;
 
-@ActiveProfiles({"integration-test", "docmosis-template-test"})
+@ActiveProfiles( {"integration-test", "docmosis-template-test"})
 @OverrideAutoConfiguration(enabled = true)
 @Import(AbstractDocmosisTest.TestConfiguration.class)
+@SpringBootTest(classes = {
+    ObjectMapper.class,
+    ChildrenService.class,
+    CaseDataExtractionService.class,
+    HearingVenueLookUpService.class,
+    DocumentMerger.class,
+    DocumentConversionService.class,
+    RestTemplate.class
+})
 public class AbstractDocmosisTest {
 
     protected ResultsCaptor<DocmosisDocument> resultsCaptor = new ResultsCaptor<>();

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/docmosis/AbstractDocmosisTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/docmosis/AbstractDocmosisTest.java
@@ -1,16 +1,27 @@
 package uk.gov.hmcts.reform.fpl.docmosis;
 
+import org.apache.commons.io.FileUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import uk.gov.hmcts.reform.fpl.config.DocmosisConfiguration;
+import uk.gov.hmcts.reform.fpl.model.common.DocmosisDocument;
+import uk.gov.hmcts.reform.fpl.utils.captor.ResultsCaptor;
+
+import java.io.File;
+import java.io.IOException;
 
 @ActiveProfiles({"integration-test", "docmosis-template-test"})
 @OverrideAutoConfiguration(enabled = true)
 @Import(AbstractDocmosisTest.TestConfiguration.class)
 public class AbstractDocmosisTest {
+
+    protected ResultsCaptor<DocmosisDocument> resultsCaptor = new ResultsCaptor<>();
+
+    @Value("${integration-test.docmosis.tornado.output.folder}")
+    private String outputFolder;
 
     public static class TestConfiguration {
 
@@ -22,5 +33,7 @@ public class AbstractDocmosisTest {
         }
     }
 
-
+    public void storeToOuputFolder(String fileName, byte[] bytes) throws IOException {
+        FileUtils.writeByteArrayToFile(new File(outputFolder + "/" + fileName), bytes);
+    }
 }

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/docmosis/AbstractDocmosisTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/docmosis/AbstractDocmosisTest.java
@@ -1,0 +1,26 @@
+package uk.gov.hmcts.reform.fpl.docmosis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import uk.gov.hmcts.reform.fpl.config.DocmosisConfiguration;
+
+@ActiveProfiles({"integration-test", "docmosis-template-test"})
+@OverrideAutoConfiguration(enabled = true)
+@Import(AbstractDocmosisTest.TestConfiguration.class)
+public class AbstractDocmosisTest {
+
+    public static class TestConfiguration {
+
+        @Bean
+        public DocmosisConfiguration docmosisConfiguration(
+            @Value("${integration-test.docmosis.tornado.key}") String key,
+            @Value("${integration-test.docmosis.tornado.url}") String url) {
+            return new DocmosisConfiguration(url, key);
+        }
+    }
+
+
+}

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/docmosis/AllOrdersDocmosisTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/docmosis/AllOrdersDocmosisTest.java
@@ -31,11 +31,13 @@ import uk.gov.hmcts.reform.fpl.service.orders.generator.C23EPODocumentParameterG
 import uk.gov.hmcts.reform.fpl.service.orders.generator.C32CareOrderDocumentParameterGenerator;
 import uk.gov.hmcts.reform.fpl.service.orders.generator.C33InterimCareOrderDocumentParameterGenerator;
 import uk.gov.hmcts.reform.fpl.service.orders.generator.C35aSupervisionOrderDocumentParameterGenerator;
+import uk.gov.hmcts.reform.fpl.service.orders.generator.C35bISODocumentParameterGenerator;
 import uk.gov.hmcts.reform.fpl.service.orders.generator.C47AAppointmentOfAChildrensGuardianParameterGenerator;
 import uk.gov.hmcts.reform.fpl.service.orders.generator.DocmosisCommonElementDecorator;
 import uk.gov.hmcts.reform.fpl.service.orders.generator.DocumentMerger;
 import uk.gov.hmcts.reform.fpl.service.orders.generator.OrderDocumentGenerator;
 import uk.gov.hmcts.reform.fpl.service.orders.generator.OrderDocumentGeneratorHolder;
+import uk.gov.hmcts.reform.fpl.service.orders.generator.common.OrderDetailsWithEndTypeGenerator;
 import uk.gov.hmcts.reform.fpl.utils.captor.ResultsCaptor;
 
 import java.util.Set;
@@ -73,6 +75,8 @@ import static uk.gov.hmcts.reform.fpl.utils.TestDataHelper.testDocument;
     C47AAppointmentOfAChildrensGuardianParameterGenerator.class,
     C33InterimCareOrderDocumentParameterGenerator.class,
     C23EPOAdditionalDocumentsCollector.class,
+    C35bISODocumentParameterGenerator.class,
+    OrderDetailsWithEndTypeGenerator.class,
     DocmosisDocumentGeneratorService.class,
     RestTemplate.class
 })
@@ -87,6 +91,7 @@ public class AllOrdersDocmosisTest extends AbstractDocmosisTest {
         Order.C32_CARE_ORDER,
         Order.C33_INTERIM_CARE_ORDER,
         Order.C35A_SUPERVISION_ORDER,
+        Order.C35B_INTERIM_SUPERVISION_ORDER,
         Order.C47A_APPOINTMENT_OF_A_CHILDRENS_GUARDIAN
     );
 

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/docmosis/AllOrdersDocmosisTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/docmosis/AllOrdersDocmosisTest.java
@@ -1,0 +1,143 @@
+package uk.gov.hmcts.reform.fpl.docmosis;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.hmcts.reform.fpl.config.HmctsCourtLookupConfiguration;
+import uk.gov.hmcts.reform.fpl.config.LocalAuthorityNameLookupConfiguration;
+import uk.gov.hmcts.reform.fpl.docmosis.generator.DocmosisOrderCaseDataGenerator;
+import uk.gov.hmcts.reform.fpl.enums.OrderStatus;
+import uk.gov.hmcts.reform.fpl.enums.docmosis.RenderFormat;
+import uk.gov.hmcts.reform.fpl.model.CaseData;
+import uk.gov.hmcts.reform.fpl.model.common.DocmosisDocument;
+import uk.gov.hmcts.reform.fpl.model.order.Order;
+import uk.gov.hmcts.reform.fpl.service.CaseDataExtractionService;
+import uk.gov.hmcts.reform.fpl.service.ChildrenService;
+import uk.gov.hmcts.reform.fpl.service.DocumentDownloadService;
+import uk.gov.hmcts.reform.fpl.service.HearingVenueLookUpService;
+import uk.gov.hmcts.reform.fpl.service.UploadDocumentService;
+import uk.gov.hmcts.reform.fpl.service.docmosis.DocmosisDocumentGeneratorService;
+import uk.gov.hmcts.reform.fpl.service.docmosis.DocumentConversionService;
+import uk.gov.hmcts.reform.fpl.service.orders.OrderCreationService;
+import uk.gov.hmcts.reform.fpl.service.orders.generator.C21BlankOrderDocumentParameterGenerator;
+import uk.gov.hmcts.reform.fpl.service.orders.generator.C23EPOAdditionalDocumentsCollector;
+import uk.gov.hmcts.reform.fpl.service.orders.generator.C23EPODocumentParameterGenerator;
+import uk.gov.hmcts.reform.fpl.service.orders.generator.C32CareOrderDocumentParameterGenerator;
+import uk.gov.hmcts.reform.fpl.service.orders.generator.C33InterimCareOrderDocumentParameterGenerator;
+import uk.gov.hmcts.reform.fpl.service.orders.generator.C35aSupervisionOrderDocumentParameterGenerator;
+import uk.gov.hmcts.reform.fpl.service.orders.generator.C47AAppointmentOfAChildrensGuardianParameterGenerator;
+import uk.gov.hmcts.reform.fpl.service.orders.generator.DocmosisCommonElementDecorator;
+import uk.gov.hmcts.reform.fpl.service.orders.generator.DocumentMerger;
+import uk.gov.hmcts.reform.fpl.service.orders.generator.OrderDocumentGenerator;
+import uk.gov.hmcts.reform.fpl.service.orders.generator.OrderDocumentGeneratorHolder;
+import uk.gov.hmcts.reform.fpl.utils.captor.ResultsCaptor;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.fpl.docmosis.DocmosisHelper.extractPdfContent;
+import static uk.gov.hmcts.reform.fpl.docmosis.DocmosisHelper.remove;
+import static uk.gov.hmcts.reform.fpl.utils.ResourceReader.readString;
+import static uk.gov.hmcts.reform.fpl.utils.TestDataHelper.testDocument;
+
+@SpringBootTest(classes = {
+    ObjectMapper.class,
+    OrderCreationService.class,
+    OrderDocumentGenerator.class,
+    ChildrenService.class,
+    OrderDocumentGenerator.class,
+    DocmosisDocumentGeneratorService.class,
+    OrderDocumentGeneratorHolder.class,
+    DocmosisCommonElementDecorator.class,
+    CaseDataExtractionService.class,
+    HearingVenueLookUpService.class,
+    DocumentMerger.class,
+    DocumentConversionService.class,
+    C21BlankOrderDocumentParameterGenerator.class,
+    C32CareOrderDocumentParameterGenerator.class,
+    C23EPODocumentParameterGenerator.class,
+    C35aSupervisionOrderDocumentParameterGenerator.class,
+    C47AAppointmentOfAChildrensGuardianParameterGenerator.class,
+    C33InterimCareOrderDocumentParameterGenerator.class,
+    C23EPOAdditionalDocumentsCollector.class,
+    DocmosisDocumentGeneratorService.class,
+    RestTemplate.class
+})
+
+public class AllOrdersDocmosisTest extends AbstractDocmosisTest {
+
+    private static final String LA_CODE = "LA_CODE";
+    private static final String LA_COURT = "La Court";
+
+    // TO implement before merge
+    private static final Set<Object> EXCLUDED_ORDERS = Set.of(
+        Order.C32_CARE_ORDER,
+        Order.C33_INTERIM_CARE_ORDER,
+        Order.C35A_SUPERVISION_ORDER,
+        Order.C47A_APPOINTMENT_OF_A_CHILDRENS_GUARDIAN
+    );
+
+    @SpyBean
+    private DocmosisDocumentGeneratorService generatorService;
+    @MockBean
+    private UploadDocumentService uploadDocumentService;
+    @MockBean
+    private DocumentDownloadService documentDownloadService;
+    @MockBean
+    private LocalAuthorityNameLookupConfiguration localAuthorityNameLookupConfiguration;
+    @MockBean
+    private HmctsCourtLookupConfiguration hmctsCourtLookupConfiguration;
+
+    private ResultsCaptor<DocmosisDocument> resultsCaptor = new ResultsCaptor<>();
+
+    @Autowired
+    private OrderCreationService underTest;
+
+    private final DocmosisOrderCaseDataGenerator dataGenerator = new DocmosisOrderCaseDataGenerator();
+
+    @ParameterizedTest
+    @MethodSource("allOrders")
+    void testAllOrders(Order order) {
+
+        String actualContent = getPdfContent(dataGenerator.generateForOrder(order));
+
+        assertThat(actualContent)
+            .isEqualToNormalizingWhitespace(readString(format("order-generation/%s.txt", order.name())));
+    }
+
+    private static Stream<Arguments> allOrders() {
+        return Stream.of(Order.values())
+            .filter(order -> !EXCLUDED_ORDERS.contains(order))
+            .map(Arguments::of);
+    }
+
+    public String getPdfContent(CaseData caseData, String... ignores) {
+        when(hmctsCourtLookupConfiguration.getCourt(LA_CODE)).thenReturn(
+            new HmctsCourtLookupConfiguration.Court(LA_COURT, null, null));
+        when(uploadDocumentService.uploadDocument(any(byte[].class),
+            anyString(),
+            anyString())).thenReturn(testDocument());
+        doAnswer(resultsCaptor).when(generatorService).generateDocmosisDocument(anyMap(), any(), any());
+
+        underTest.createOrderDocument(caseData,
+            OrderStatus.PLAIN,
+            RenderFormat.PDF);
+
+        String text = extractPdfContent(resultsCaptor.getResult().getBytes());
+        return remove(text, ignores);
+    }
+
+}

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/docmosis/OrderCreationServiceDocmosisTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/docmosis/OrderCreationServiceDocmosisTest.java
@@ -1,14 +1,12 @@
 package uk.gov.hmcts.reform.fpl.docmosis;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.test.context.ContextConfiguration;
 import uk.gov.hmcts.reform.fpl.config.HmctsCourtLookupConfiguration;
 import uk.gov.hmcts.reform.fpl.config.LocalAuthorityNameLookupConfiguration;
 import uk.gov.hmcts.reform.fpl.docmosis.generator.DocmosisOrderCaseDataGenerator;
@@ -18,12 +16,9 @@ import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.common.DocmosisDocument;
 import uk.gov.hmcts.reform.fpl.model.order.Order;
 import uk.gov.hmcts.reform.fpl.service.CaseDataExtractionService;
-import uk.gov.hmcts.reform.fpl.service.ChildrenService;
 import uk.gov.hmcts.reform.fpl.service.DocumentDownloadService;
-import uk.gov.hmcts.reform.fpl.service.HearingVenueLookUpService;
 import uk.gov.hmcts.reform.fpl.service.UploadDocumentService;
 import uk.gov.hmcts.reform.fpl.service.docmosis.DocmosisDocumentGeneratorService;
-import uk.gov.hmcts.reform.fpl.service.docmosis.DocumentConversionService;
 import uk.gov.hmcts.reform.fpl.service.orders.OrderCreationService;
 import uk.gov.hmcts.reform.fpl.service.orders.generator.C21BlankOrderDocumentParameterGenerator;
 import uk.gov.hmcts.reform.fpl.service.orders.generator.C23EPOAdditionalDocumentsCollector;
@@ -34,7 +29,6 @@ import uk.gov.hmcts.reform.fpl.service.orders.generator.C35aSupervisionOrderDocu
 import uk.gov.hmcts.reform.fpl.service.orders.generator.C35bISODocumentParameterGenerator;
 import uk.gov.hmcts.reform.fpl.service.orders.generator.C47AAppointmentOfAChildrensGuardianParameterGenerator;
 import uk.gov.hmcts.reform.fpl.service.orders.generator.DocmosisCommonElementDecorator;
-import uk.gov.hmcts.reform.fpl.service.orders.generator.DocumentMerger;
 import uk.gov.hmcts.reform.fpl.service.orders.generator.OrderDocumentGenerator;
 import uk.gov.hmcts.reform.fpl.service.orders.generator.OrderDocumentGeneratorHolder;
 import uk.gov.hmcts.reform.fpl.service.orders.generator.common.OrderDetailsWithEndTypeGenerator;
@@ -55,19 +49,14 @@ import static uk.gov.hmcts.reform.fpl.docmosis.DocmosisHelper.remove;
 import static uk.gov.hmcts.reform.fpl.utils.ResourceReader.readString;
 import static uk.gov.hmcts.reform.fpl.utils.TestDataHelper.testDocument;
 
-@SpringBootTest(classes = {
-    ObjectMapper.class,
+@ContextConfiguration(classes = {
     OrderCreationService.class,
     OrderDocumentGenerator.class,
-    ChildrenService.class,
     OrderDocumentGenerator.class,
     DocmosisDocumentGeneratorService.class,
     OrderDocumentGeneratorHolder.class,
     DocmosisCommonElementDecorator.class,
     CaseDataExtractionService.class,
-    HearingVenueLookUpService.class,
-    DocumentMerger.class,
-    DocumentConversionService.class,
     C21BlankOrderDocumentParameterGenerator.class,
     C32CareOrderDocumentParameterGenerator.class,
     C23EPODocumentParameterGenerator.class,
@@ -78,9 +67,7 @@ import static uk.gov.hmcts.reform.fpl.utils.TestDataHelper.testDocument;
     C35bISODocumentParameterGenerator.class,
     OrderDetailsWithEndTypeGenerator.class,
     DocmosisDocumentGeneratorService.class,
-    RestTemplate.class
 })
-
 public class OrderCreationServiceDocmosisTest extends AbstractDocmosisTest {
 
     private static final String LA_CODE = "LA_CODE";

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/docmosis/OrderCreationServiceDocmosisTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/docmosis/OrderCreationServiceDocmosisTest.java
@@ -131,7 +131,10 @@ public class OrderCreationServiceDocmosisTest extends AbstractDocmosisTest {
 
         byte[] bytes = docmosisDocument.getBytes();
 
-        storeToOuputFolder(docmosisDocument.getDocumentTitle(), bytes);
+        storeToOuputFolder(
+            caseData.getManageOrdersEventData().getManageOrdersType().fileName(RenderFormat.PDF),
+            bytes
+        );
 
         String text = extractPdfContent(bytes);
         return remove(text, ignores);

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/docmosis/generator/DocmosisOrderCaseDataGenerator.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/docmosis/generator/DocmosisOrderCaseDataGenerator.java
@@ -1,0 +1,143 @@
+package uk.gov.hmcts.reform.fpl.docmosis.generator;
+
+import uk.gov.hmcts.reform.fpl.enums.EPOType;
+import uk.gov.hmcts.reform.fpl.model.Address;
+import uk.gov.hmcts.reform.fpl.model.CaseData;
+import uk.gov.hmcts.reform.fpl.model.Child;
+import uk.gov.hmcts.reform.fpl.model.ChildParty;
+import uk.gov.hmcts.reform.fpl.model.common.JudgeAndLegalAdvisor;
+import uk.gov.hmcts.reform.fpl.model.event.ManageOrdersEventData;
+import uk.gov.hmcts.reform.fpl.model.order.Order;
+import uk.gov.hmcts.reform.fpl.model.order.OrderQuestionBlock;
+import uk.gov.hmcts.reform.fpl.model.order.selector.Selector;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+import static uk.gov.hmcts.reform.fpl.enums.JudgeOrMagistrateTitle.MAGISTRATES;
+import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.element;
+
+public class DocmosisOrderCaseDataGenerator {
+
+    private static final String DATA_REGION = "dataRegion";
+    private static final String LA_CODE = "LA_CODE";
+    private static final String LA_COURT = "La Court";
+
+    public CaseData generateForOrder(final Order order) {
+
+        return order.getQuestions().stream().reduce(
+            commonCaseData(order),
+            this::addDataForQuestion,
+            (v, v2) -> v2
+        ).build();
+    }
+
+    private CaseData.CaseDataBuilder commonCaseData(Order order) {
+        return CaseData.builder()
+            .manageOrdersEventData(ManageOrdersEventData.builder()
+                .manageOrdersType(order)
+                .build())
+            .familyManCaseNumber("FamilyManCaseNumber113")
+            .caseLocalAuthority(LA_CODE)
+            .id(1234567890123456L);
+    }
+
+    private CaseData.CaseDataBuilder addDataForQuestion(CaseData.CaseDataBuilder builder,
+                                                        OrderQuestionBlock questionBlock) {
+
+        switch (questionBlock) {
+            case LINKED_TO_HEARING:
+            case REVIEW_DRAFT_ORDER:
+                // Do Nothing - they won't modify the document
+                break;
+            case APPROVER:
+                return builder.judgeAndLegalAdvisor(JudgeAndLegalAdvisor.builder()
+                    .judgeTitle(MAGISTRATES)
+                    .judgeLastName("Stevenson")
+                    .legalAdvisorName("John Papa")
+                    .build());
+            case APPROVAL_DATE:
+                return builder.manageOrdersEventData(
+                    getManageOrdersEvent(builder)
+                        .manageOrdersApprovalDate(LocalDate.of(2013, 10, 5))
+                        .build());
+            case WHICH_CHILDREN:
+                return builder.children1(List.of(element(UUID.randomUUID(), Child.builder()
+                    .party(ChildParty.builder()
+                        .firstName("Kenny")
+                        .lastName("Kruger")
+                        .dateOfBirth(LocalDate.of(2010, 1, 1))
+                        .build())
+                    .build())))
+                    .childSelector(Selector.builder().selected(List.of(1)).build());
+            case DETAILS:
+                return builder.manageOrdersEventData(
+                    getManageOrdersEvent(builder)
+                        .manageOrdersTitle("Blank Order Title")
+                        .manageOrdersDirections("Order directions for Blank Order")
+                        .build()
+                );
+            case APPROVAL_DATE_TIME:
+                return builder.manageOrdersEventData(
+                    getManageOrdersEvent(builder)
+                        .manageOrdersApprovalDateTime(LocalDateTime.of(2012, 8, 7, 15, 23, 11))
+                        .build()
+                );
+            case EPO_TYPE_AND_PREVENT_REMOVAL:
+                return builder.manageOrdersEventData(
+                    getManageOrdersEvent(builder)
+                        .manageOrdersEpoRemovalAddress(Address.builder()
+                            .addressLine1("Soccer Street 212")
+                            .addressLine2("World's end")
+                            .addressLine3("Miami Beach")
+                            .country("Slovakia")
+                            .postcode("XXX 123")
+                            .postTown("Humberland Cumberland")
+                            .build())
+                        .manageOrdersEpoType(EPOType.REMOVE_TO_ACCOMMODATION)
+                        .build()
+                );
+            case EPO_INCLUDE_PHRASE:
+                return builder.manageOrdersEventData(
+                    getManageOrdersEvent(builder)
+                        .manageOrdersIncludePhrase("included extra EPO phrase")
+                        .build()
+                );
+            case EPO_CHILDREN_DESCRIPTION:
+                return builder.manageOrdersEventData(
+                    getManageOrdersEvent(builder)
+                        .manageOrdersChildrenDescription("the children are really lovely.")
+                        .build()
+                );
+            case EPO_EXPIRY_DATE:
+                return builder.manageOrdersEventData(
+                    getManageOrdersEvent(builder)
+                        .manageOrdersEndDateTime(LocalDateTime.of(2018, 9, 1, 13, 20, 4))
+                        .build()
+                );
+            case FURTHER_DIRECTIONS:
+                return builder.manageOrdersEventData(
+                    getManageOrdersEvent(builder)
+                        .manageOrdersFurtherDirections("Some further directions.")
+                        .build()
+                );
+            default:
+                throw new RuntimeException("Question block for " + questionBlock + " not implemented");
+        }
+
+        return builder;
+    }
+
+    private ManageOrdersEventData.ManageOrdersEventDataBuilder getManageOrdersEvent(CaseData.CaseDataBuilder builder) {
+        return getManageOrdersEventData(builder).toBuilder();
+    }
+
+    private ManageOrdersEventData getManageOrdersEventData(CaseData.CaseDataBuilder builder) {
+        return defaultIfNull(builder.build().getManageOrdersEventData(), ManageOrdersEventData.builder().build());
+    }
+
+
+}

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/docmosis/generator/DocmosisOrderCaseDataGenerator.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/docmosis/generator/DocmosisOrderCaseDataGenerator.java
@@ -52,6 +52,7 @@ public class DocmosisOrderCaseDataGenerator {
         switch (questionBlock) {
             case LINKED_TO_HEARING:
             case REVIEW_DRAFT_ORDER:
+            case CLOSE_CASE:
                 // Do Nothing - they won't modify the document
                 break;
             case APPROVER:

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/docmosis/generator/DocmosisOrderCaseDataGenerator.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/docmosis/generator/DocmosisOrderCaseDataGenerator.java
@@ -17,14 +17,15 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+import static uk.gov.hmcts.reform.fpl.enums.EnglandOffices.BRIGHTON;
 import static uk.gov.hmcts.reform.fpl.enums.JudgeOrMagistrateTitle.MAGISTRATES;
+import static uk.gov.hmcts.reform.fpl.enums.orders.ManageOrdersEndDateType.END_OF_PROCEEDINGS;
+import static uk.gov.hmcts.reform.fpl.enums.orders.ManageOrdersEndDateType.NUMBER_OF_MONTHS;
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.element;
 
 public class DocmosisOrderCaseDataGenerator {
 
-    private static final String DATA_REGION = "dataRegion";
     private static final String LA_CODE = "LA_CODE";
-    private static final String LA_COURT = "La Court";
 
     public CaseData generateForOrder(final Order order) {
 
@@ -122,6 +123,32 @@ public class DocmosisOrderCaseDataGenerator {
                 return builder.manageOrdersEventData(
                     getManageOrdersEvent(builder)
                         .manageOrdersFurtherDirections("Some further directions.")
+                        .build()
+                );
+            case ICO_EXCLUSION:
+                return builder.manageOrdersEventData(
+                    getManageOrdersEvent(builder)
+                        .manageOrdersExclusionDetails("Some exclusion details")
+                        .build()
+                );
+            case MANAGE_ORDER_END_DATE_WITH_END_OF_PROCEEDINGS:
+                return builder.manageOrdersEventData(
+                    getManageOrdersEvent(builder)
+                        .manageOrdersEndDateTypeWithEndOfProceedings(END_OF_PROCEEDINGS)
+                        .build()
+                );
+            case MANAGE_ORDER_END_DATE_WITH_MONTH:
+                return builder.manageOrdersEventData(
+                    getManageOrdersEvent(builder)
+                        .manageOrdersEndDateTypeWithMonth(NUMBER_OF_MONTHS)
+                        .manageOrdersSetMonthsEndDate(4)
+                        .build()
+                );
+            case CAFCASS_JURISDICTIONS:
+                return builder.manageOrdersEventData(
+                    getManageOrdersEvent(builder)
+                        .manageOrdersCafcassOfficesEngland(BRIGHTON)
+                        .manageOrdersCafcassRegion("ENGLAND")
                         .build()
                 );
             default:

--- a/service/src/integrationTest/resources/application-docmosis-template-test.yaml
+++ b/service/src/integrationTest/resources/application-docmosis-template-test.yaml
@@ -1,0 +1,8 @@
+spring:
+  profiles: docmosis-template-test
+
+integration-test:
+  docmosis:
+    tornado:
+      url: http://localhost:5433
+      key: ACCESS_KEY

--- a/service/src/integrationTest/resources/application-docmosis-template-test.yaml
+++ b/service/src/integrationTest/resources/application-docmosis-template-test.yaml
@@ -6,3 +6,5 @@ integration-test:
     tornado:
       url: http://localhost:5433
       key: ACCESS_KEY
+      output:
+        folder: '../build/docmosis-generated'

--- a/service/src/integrationTest/resources/order-generation/C21_BLANK_ORDER.txt
+++ b/service/src/integrationTest/resources/order-generation/C21_BLANK_ORDER.txt
@@ -1,0 +1,16 @@
+FAMILYMANCASENUMBER113
+1234-5678-9012-3456
+
+Blank Order Title
+
+Section 31 Children Act 1989
+
+Ordered on 5 October 2013 by Justice of the Peace and Justices’ Legal Adviser John Papa
+
+La Court
+
+Child in the case
+Kenny Kruger Born 1 January 2010
+
+Order directions for Blank Order
+

--- a/service/src/integrationTest/resources/order-generation/C23_EMERGENCY_PROTECTION_ORDER.txt
+++ b/service/src/integrationTest/resources/order-generation/C23_EMERGENCY_PROTECTION_ORDER.txt
@@ -1,0 +1,67 @@
+FAMILYMANCASENUMBER113
+1234-5678-9012-3456
+
+Emergency protection order
+Section 44 Children Act 1989
+
+Ordered on 7 August 2012, 3:23pm by Justice of the Peace and Justices’ Legal Adviser
+
+John Papa
+
+La Court
+
+Children in the case
+Kenny Kruger Born 1 January 2010
+
+Description
+the children are really lovely.
+
+Warning
+It’s a criminal offence to intentionally obstruct a person who’s authorised under
+section 44(4)(b) Children Act 1989 either to remove a child or to prevent the removal
+of a child (section 44(15) Children Act 1989).
+An Emergency Protection Order is granted to the applicant, .
+The order gives the applicant parental responsibility for the child.
+The Court authorises the applicant to remove the child to accommodation provided by or
+on behalf of the applicant.
+
+Some further directions.
+
+This order starts on 7 August 2012 at 3:23pm.
+
+This order ends on 1 September 2018 at 1:20pm.
+
+Notes about the emergency protection order
+
+About this order
+
+This is an Emergency Protection Order.
+
+This order states what has been authorised in respect of the child and when the order will
+end.
+
+The court can extend this order for up to 7 days but it can only do this once.
+
+Warning
+If you are shown this order, you must comply with it. If you do not, you may commit an
+offence. Read the order now.
+What you may do
+You may apply to the court at any time to:
+ change the directions
+ end the order
+If you would like to ask the court to change the directions, or end the order, you must fill in
+a form. You can obtain the form from a court office.
+If the court has directed that the child should have a medical, psychiatric or another kind of
+examination, you may ask the court to allow a doctor of your choice to be at the
+examination.
+
+What you should do
+Go to a solicitor as soon as you can.
+Some solicitors specialise in court proceedings which involve children. You can obtain the
+address of a solicitor or advice agency from the Yellow Pages or the Solicitors’ Regional
+Directory. You will find these books at:
+ a Citizens Advice centre
+ a Law Centre
+ a library
+A solicitor or an advice agency will be able to tell you whether you may be eligible for Legal
+Aid.

--- a/service/src/integrationTest/resources/order-generation/C23_EMERGENCY_PROTECTION_ORDER.txt
+++ b/service/src/integrationTest/resources/order-generation/C23_EMERGENCY_PROTECTION_ORDER.txt
@@ -20,7 +20,7 @@ Warning
 It’s a criminal offence to intentionally obstruct a person who’s authorised under
 section 44(4)(b) Children Act 1989 either to remove a child or to prevent the removal
 of a child (section 44(15) Children Act 1989).
-An Emergency Protection Order is granted to the applicant, .
+An Emergency Protection Order is granted to the applicant, LocalAuthorityName.
 The order gives the applicant parental responsibility for the child.
 The Court authorises the applicant to remove the child to accommodation provided by or
 on behalf of the applicant.

--- a/service/src/integrationTest/resources/order-generation/C32_CARE_ORDER.txt
+++ b/service/src/integrationTest/resources/order-generation/C32_CARE_ORDER.txt
@@ -1,0 +1,32 @@
+FAMILYMANCASENUMBER113
+1234-5678-9012-3456
+Care order
+
+Section 31 Children Act 1989
+
+Ordered on 5 October 2013 by Justice of the Peace and Justices’ Legal Adviser John Papa
+
+La Court
+
+Child in the case
+Kenny Kruger Born 1 January 2010
+
+It is ordered that the child is placed in the care of LocalAuthorityName.
+
+Some further directions.
+
+Care order restrictions
+
+While a care order is in place, no one can:
+ change the child’s surname
+ take the child out of the UK
+unless they have written consent from all people with parental responsibility, or
+permission from the court.
+
+Taking the child from the UK without this consent or permission might be an offence
+under the Child Abduction Act 1984.
+
+LocalAuthorityName has been given parental responsibility under this care order.
+
+LocalAuthorityName may take the child out of the UK for up to 1 month without this
+consent or permission.

--- a/service/src/integrationTest/resources/order-generation/C33_INTERIM_CARE_ORDER.txt
+++ b/service/src/integrationTest/resources/order-generation/C33_INTERIM_CARE_ORDER.txt
@@ -1,0 +1,33 @@
+FAMILYMANCASENUMBER113
+1234-5678-9012-3456
+
+Interim care order
+
+Section 38 Children Act 1989
+
+Ordered on 5 October 2013 by Justice of the Peace and Justices’ Legal Adviser John Papa
+
+La Court
+Child in the case
+
+Kenny Kruger Born 1 January 2010
+
+Some exclusion details
+
+The Court orders that the child is placed in the care of LocalAuthorityName until the end
+of the proceedings or until a further order is made.
+
+Some further directions.
+
+Care order restrictions
+
+While a care order is in place, no one can:
+ change the child’s surname
+ take the child out of the UK
+unless they have written consent from all people with parental responsibility, or
+permission from the court.
+
+Taking the child from the UK without this consent or permission might be an offence
+under the Child Abduction Act 1984.
+LocalAuthorityName has been given parental responsibility under this care order. LocalAuthorityName may take the child out of the
+UK for up to 1 month without this consent or permission.

--- a/service/src/integrationTest/resources/order-generation/C35A_SUPERVISION_ORDER.txt
+++ b/service/src/integrationTest/resources/order-generation/C35A_SUPERVISION_ORDER.txt
@@ -1,0 +1,19 @@
+FAMILYMANCASENUMBER113
+1234-5678-9012-3456
+
+Supervision order
+
+Section 31 and Paragraphs 1 and 2 Schedule 3 Children Act 1989
+
+Ordered on 5 October 2013 by Justice of the Peace and Justices’ Legal Adviser John Papa
+
+La Court
+
+Child in the case
+
+Kenny Kruger Born 1 January 2010
+
+The Court orders LocalAuthorityName supervises the child for 4 months from the date of
+this order until 5th February 2014.
+
+Some further directions.

--- a/service/src/integrationTest/resources/order-generation/C35B_INTERIM_SUPERVISION_ORDER.txt
+++ b/service/src/integrationTest/resources/order-generation/C35B_INTERIM_SUPERVISION_ORDER.txt
@@ -1,0 +1,19 @@
+FAMILYMANCASENUMBER113
+1234-5678-9012-3456
+
+Interim supervision order
+
+Section 38 and Paragraphs 1 and 2 Schedule 3 Children Act 1989
+
+Ordered on 5 October 2013 by Justice of the Peace and Justices’ Legal Adviser John Papa
+
+La Court
+
+Child in the case
+
+Kenny Kruger Born 1 January 2010
+
+The Court orders LocalAuthorityName supervises the child until the end of the proceedings
+or until a further order is made.
+
+Some further directions.

--- a/service/src/integrationTest/resources/order-generation/C47A_APPOINTMENT_OF_A_CHILDRENS_GUARDIAN.txt
+++ b/service/src/integrationTest/resources/order-generation/C47A_APPOINTMENT_OF_A_CHILDRENS_GUARDIAN.txt
@@ -1,0 +1,15 @@
+FAMILYMANCASENUMBER113
+1234-5678-9012-3456
+
+Appointment of a Children's Guardian
+
+Section 41(1) Children Act 1989
+
+Ordered on 5 October 2013 by Justice of the Peace and Justices’ Legal Adviser John Papa
+
+La Court
+
+The court appoints Cafcass Brighton as a Children's Guardian for the child in the
+proceedings.
+
+Some further directions.

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/docmosis/DocmosisHelper.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/docmosis/DocmosisHelper.java
@@ -1,0 +1,59 @@
+package uk.gov.hmcts.reform.fpl.docmosis;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.text.PDFTextStripperByArea;
+
+import java.awt.geom.Rectangle2D;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+public class DocmosisHelper {
+
+    private DocmosisHelper() {
+    }
+
+    private static final float POINTS_PER_INCH = 72;
+    private static final float POINTS_PER_MM = 1 / (10 * 2.54f) * POINTS_PER_INCH;
+    private static final int FOOTER_HEIGHT_IN_MM = 15;
+    private static final int FOOTER_HEIGHT_IN_POINTS = Math.round(POINTS_PER_MM * FOOTER_HEIGHT_IN_MM);
+    private static final String DATA_REGION = "dataRegion";
+
+    public static String extractPdfContent(byte[] binaries) {
+
+        try (final PDDocument pdf = PDDocument.load(binaries)) {
+
+            final StringBuilder textBuilder = new StringBuilder();
+
+            for (int i = 0; i < pdf.getNumberOfPages(); i++) {
+                PDPage page = pdf.getPage(i);
+
+                PDRectangle dimensions = page.getCropBox();
+
+                Rectangle2D dataRegion = new Rectangle2D.Double(0, 0,
+                    dimensions.getWidth(), dimensions.getHeight() - FOOTER_HEIGHT_IN_POINTS);
+
+                PDFTextStripperByArea textStripper = new PDFTextStripperByArea();
+
+                textStripper.addRegion(DATA_REGION, dataRegion);
+                textStripper.extractRegions(page);
+
+                textBuilder.append(textStripper.getTextForRegion(DATA_REGION));
+            }
+
+            return textBuilder.toString();
+
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public static String remove(String text, String... ignores) {
+        String updatedText = text;
+        for (String ignore : ignores) {
+            updatedText = updatedText.replaceAll(ignore, "");
+        }
+        return updatedText;
+    }
+}


### PR DESCRIPTION
FPLA-1986: Docmosis generation testing

This is automating the integration between java and docmosis. There's a similar test in the API testing, but for a more thorough business logic testing (rather than a smoke test), there's a feeling that API testing is not the easiest place (trying to avoid the reverse pyramid testing trouble)

The way it works is to hook for generated orders (the one generated by "Manage orders" event) via the most generic component. 

The test automatically loops over all the Order enums and generate the appropriate mock case data based on the QuestionBlocks configured for the order.

The test test against the stripped code (as per the api test) and stores the pdf generated in the artefacts https://build.platform.hmcts.net/job/HMCTS_FPL/job/fpl-ccd-configuration/job/PR-2730/15/artifact/build/docmosis-generated/

When a new order gets added to the enum list, the developer need to provide a correspondent TXT file with the expected content, plus to implement the mocked data correspondent to the added question (if added)





