### PR TITLE
fix: Fix Null pointer exception when submitting a case  without mandatory fields

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/docmosis/CaseSubmissionGenerationService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/docmosis/CaseSubmissionGenerationService.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.fpl.service.docmosis;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -286,7 +287,8 @@ public class CaseSubmissionGenerationService
     }
 
     public String getSigneeName(final List<Element<Applicant>> applicants) {
-        String legalTeamManager = applicants.get(0).getValue().getParty().getLegalTeamManager();
+        String legalTeamManager = ObjectUtils.isEmpty(applicants) ? EMPTY
+            : applicants.get(0).getValue().getParty().getLegalTeamManager();
 
         if (isNotBlank(legalTeamManager)) {
             return legalTeamManager;

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/docmosis/CaseSubmissionGenerationServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/docmosis/CaseSubmissionGenerationServiceTest.java
@@ -29,6 +29,7 @@ import uk.gov.hmcts.reform.fpl.model.Others;
 import uk.gov.hmcts.reform.fpl.model.Proceeding;
 import uk.gov.hmcts.reform.fpl.model.Respondent;
 import uk.gov.hmcts.reform.fpl.model.RespondentParty;
+import uk.gov.hmcts.reform.fpl.model.common.Element;
 import uk.gov.hmcts.reform.fpl.model.common.EmailAddress;
 import uk.gov.hmcts.reform.fpl.model.common.Telephone;
 import uk.gov.hmcts.reform.fpl.model.docmosis.DocmosisAnnexDocuments;
@@ -46,6 +47,7 @@ import uk.gov.hmcts.reform.idam.client.IdamClient;
 import uk.gov.hmcts.reform.idam.client.models.UserInfo;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import static java.time.LocalDate.now;
 import static java.util.List.of;
@@ -139,6 +141,17 @@ class CaseSubmissionGenerationServiceTest {
 
             DocmosisCaseSubmission caseSubmission = templateDataGenerationService.getTemplateData(updatedCaseData);
             assertThat(caseSubmission.getUserFullName()).isEqualTo("legal team manager");
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        void shouldReturnIdamUserNameAsSigneeNameWhenApplicantDetailsAreNullOrEmpty(
+            List<Element<Applicant>> applicants) {
+
+            CaseData updatedCaseData = givenCaseData.toBuilder().applicants(applicants).build();
+
+            DocmosisCaseSubmission caseSubmission = templateDataGenerationService.getTemplateData(updatedCaseData);
+            assertThat(caseSubmission.getUserFullName()).isEqualTo("Professor");
         }
 
         @ParameterizedTest

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/docmosis/CaseSubmissionGenerationServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/docmosis/CaseSubmissionGenerationServiceTest.java
@@ -145,7 +145,7 @@ class CaseSubmissionGenerationServiceTest {
 
         @ParameterizedTest
         @NullAndEmptySource
-        void shouldReturnIdamUserNameAsSigneeNameWhenApplicantDetailsAreNullOrEmpty(
+        void shouldReturnCurrentUserWhenApplicantsListIsNullOrEmpty(
             List<Element<Applicant>> applicants) {
 
             CaseData updatedCaseData = givenCaseData.toBuilder().applicants(applicants).build();


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FPLA-3110

### Change description ###
When the user is submitting a case without completing the applicant details section and other mandatory fields, a Null Pointer Exception is being thrown as the applicants list is empty.
Added null check on applicants list which will return the logged in user name when applicants list is empty.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
