### PR TITLE
chore: run nightly crossbrowser tests across multiple parallel jenkin…

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -82,7 +82,7 @@ withNightlyPipeline(type, product, component) {
   enableSecurityScan()
   enableMutationTest()
   enableFullFunctionalTest(120)
-  enableCrossBrowserTest()
+  enableCrossBrowserTest(['chrome', 'firefox', 'safari', 'microsoft'])
 
   before('mutationTest') {
     setupSecretsForIntegrationTests(pipelineConf)


### PR DESCRIPTION
### JIRA link (if applicable) ###

n/a

### Change description ###

Run nightly crossbrowser tests across multiple parallel Jenkins boxes to improve speed, and hopefully stability too, by only running a single browser group (up to 2 browsers) in parallel on any individual box.

Should result in crossbrowser test feedback in half the time: ~35mins compared to 1hr+ currently.

The browser groups are already configured in [saucelabs.conf.js's "multiple" object](https://github.com/hmcts/fpl-ccd-configuration/blob/master/saucelabs.conf.js#L165-L178), and just need to be passed to `enableCrossBrowserTest(...)` in an array:
```
enableCrossBrowserTest(['chrome', 'firefox', 'safari', 'microsoft'])
```
(Note: uses the recently merged https://github.com/hmcts/cnp-jenkins-library/pull/748)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
