### PR TITLE
Chore: Improve nightly pipeline stability

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -108,6 +108,10 @@ withNightlyPipeline(type, product, component) {
     env.TESTS_FOR_ACCESSIBILITY = false
   }
 
+  before('crossBrowserTest') {
+    env.TEST_RETRIES = 2
+  }
+
   after('crossBrowserTest') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'output/**/*'
   }

--- a/e2e/actors/base.js
+++ b/e2e/actors/base.js
@@ -182,9 +182,8 @@ module.exports = {
     if (!currentUrl.replace(/#.+/g, '').endsWith(caseId)) {
       await this.retryUntilExists(async () => {
         await this.goToPage(`${baseUrl}/cases/case-details/${caseId}`);
-      }, signedInSelector);
+      }, '#next-step');
     }
-    this.waitForElement('#next-step');
   },
 
   async navigateToCaseDetailsAs(user, caseId) {

--- a/e2e/pages/caseView.page.js
+++ b/e2e/pages/caseView.page.js
@@ -44,7 +44,7 @@ module.exports = {
         I.click(this.goButton);
       } else {
         const newUrl = await I.grabCurrentUrl();
-        if(newUrl === currentUrl){
+        if(newUrl === currentUrl || !newUrl.includes('http')){
           output.print('Page refresh');
           I.refreshPage();
         }

--- a/e2e/pages/caseView.page.js
+++ b/e2e/pages/caseView.page.js
@@ -38,7 +38,7 @@ module.exports = {
   async goToNewActions(actionSelected) {
     const currentUrl = await I.grabCurrentUrl();
     await I.retryUntilExists(async () => {
-      if(await I.waitForSelector(this.actionsDropdown, 60) != null) {
+      if(await I.waitForSelector(this.actionsDropdown, 30) != null) {
         await I.scrollToElement(this.actionsDropdown);
         I.selectOption(this.actionsDropdown, actionSelected);
         I.click(this.goButton);

--- a/e2e/tests/localAuthoritySubmitsApplication_test.js
+++ b/e2e/tests/localAuthoritySubmitsApplication_test.js
@@ -14,9 +14,8 @@ Feature('Local authority creates application');
 
 BeforeSuite(async ({I}) => caseId = await I.submitNewCase(config.swanseaLocalAuthorityUserOne));
 
-Before(async ({I}) => await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId));
-
-Scenario('local authority sees task list', async ({caseViewPage}) => {
+Scenario('local authority sees task list', async ({I, caseViewPage}) => {
+  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
   caseViewPage.selectTab(caseViewPage.tabs.startApplication);
 
   await caseViewPage.checkTaskIsFinished(config.applicationActions.changeCaseName);
@@ -48,6 +47,7 @@ Scenario('local authority sees task list', async ({caseViewPage}) => {
 });
 
 Scenario('local authority changes case name @create-case-with-mandatory-sections-only @cross-browser', async ({I, caseViewPage, changeCaseNameEventPage}) => {
+  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
   await caseViewPage.goToNewActions(config.applicationActions.changeCaseName);
   await changeCaseNameEventPage.changeCaseName('New case name');
   await I.seeCheckAnswersAndCompleteEvent('Save and continue');
@@ -63,6 +63,7 @@ Scenario('local authority changes case name @create-case-with-mandatory-sections
 });
 
 Scenario('local authority enters orders and directions @create-case-with-mandatory-sections-only @cross-browser', async ({I, caseViewPage, enterOrdersAndDirectionsNeededEventPage}) => {
+  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
   await caseViewPage.goToNewActions(config.applicationActions.enterOrdersAndDirectionsNeeded);
   await enterOrdersAndDirectionsNeededEventPage.checkCareOrder();
   enterOrdersAndDirectionsNeededEventPage.checkInterimCareOrder();
@@ -118,6 +119,7 @@ Scenario('local authority enters orders and directions @create-case-with-mandato
 });
 
 Scenario('local authority enters hearing @create-case-with-mandatory-sections-only @cross-browser', async ({I, caseViewPage, enterHearingNeededEventPage}) => {
+  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
   await caseViewPage.goToNewActions(config.applicationActions.enterHearingNeeded);
   await enterHearingNeededEventPage.enterTimeFrame();
   enterHearingNeededEventPage.enterHearingType();
@@ -149,6 +151,7 @@ Scenario('local authority enters hearing @create-case-with-mandatory-sections-on
 });
 
 Scenario('local authority enters children @create-case-with-mandatory-sections-only @cross-browser', async ({I, caseViewPage, enterChildrenEventPage}) => {
+  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
   await caseViewPage.goToNewActions(config.applicationActions.enterChildren);
   await enterChildrenEventPage.enterChildDetails('Bran', 'Stark', '01', '08', '2015');
   await enterChildrenEventPage.defineChildSituation('01', '11', '2017');
@@ -243,6 +246,7 @@ Scenario('local authority enters children @create-case-with-mandatory-sections-o
 });
 
 Scenario('local authority enters respondents @create-case-with-mandatory-sections-only', async ({I, caseViewPage, enterRespondentsEventPage}) => {
+  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
   await caseViewPage.goToNewActions(config.applicationActions.enterRespondents);
   await enterRespondentsEventPage.enterRespondent(respondents[0]);
   await enterRespondentsEventPage.enterContactDetailsHidden('No', 'mock reason');
@@ -343,6 +347,7 @@ Scenario('local authority enters respondents @create-case-with-mandatory-section
 });
 
 Scenario('local authority enters applicant @create-case-with-mandatory-sections-only', async ({I, caseViewPage, enterApplicantEventPage}) => {
+  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
   await caseViewPage.goToNewActions(config.applicationActions.enterApplicant);
   await enterApplicantEventPage.enterApplicantDetails(applicant);
   await enterApplicantEventPage.enterSolicitorDetails(solicitor);
@@ -383,6 +388,7 @@ Scenario('local authority enters applicant @create-case-with-mandatory-sections-
 });
 
 Scenario('local authority enters others to be given notice', async ({I, caseViewPage, enterOthersEventPage}) => {
+  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
   await caseViewPage.goToNewActions(config.applicationActions.enterOthers);
   await enterOthersEventPage.enterOtherDetails(others[0]);
   await enterOthersEventPage.enterRelationshipToChild('Tim Smith');
@@ -439,6 +445,7 @@ Scenario('local authority enters others to be given notice', async ({I, caseView
 });
 
 Scenario('local authority enters grounds for application @create-case-with-mandatory-sections-only', async ({I, caseViewPage, enterGroundsForApplicationEventPage}) => {
+  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
   await caseViewPage.goToNewActions(config.applicationActions.enterGrounds);
   await enterGroundsForApplicationEventPage.enterThresholdCriteriaDetails();
   await enterGroundsForApplicationEventPage.enterGroundsForEmergencyProtectionOrder();
@@ -458,6 +465,7 @@ Scenario('local authority enters grounds for application @create-case-with-manda
 });
 
 Scenario('local authority enters risk and harm to children', async ({I, caseViewPage, enterRiskAndHarmToChildrenEventPage}) => {
+  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
   await caseViewPage.goToNewActions(config.applicationActions.enterRiskAndHarmToChildren);
   await enterRiskAndHarmToChildrenEventPage.completePhysicalHarm();
   enterRiskAndHarmToChildrenEventPage.completeEmotionalHarm();
@@ -481,6 +489,7 @@ Scenario('local authority enters risk and harm to children', async ({I, caseView
 });
 
 Scenario('local authority enters factors affecting parenting', async ({I, caseViewPage, enterFactorsAffectingParentingEventPage}) => {
+  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
   await caseViewPage.goToNewActions(config.applicationActions.enterFactorsAffectingParenting);
   await enterFactorsAffectingParentingEventPage.completeAlcoholOrDrugAbuse();
   enterFactorsAffectingParentingEventPage.completeDomesticViolence();
@@ -503,6 +512,7 @@ Scenario('local authority enters factors affecting parenting', async ({I, caseVi
 });
 
 Scenario('local authority enters international element', async ({I, caseViewPage, enterInternationalElementEventPage}) => {
+  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
   await caseViewPage.goToNewActions(config.applicationActions.enterInternationalElement);
   await enterInternationalElementEventPage.fillForm();
   await I.seeCheckAnswersAndCompleteEvent('Save and continue');
@@ -526,6 +536,7 @@ Scenario('local authority enters international element', async ({I, caseViewPage
 });
 
 Scenario('local authority enters other proceedings', async ({I, caseViewPage, enterOtherProceedingsEventPage}) => {
+  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
   await caseViewPage.goToNewActions(config.applicationActions.enterOtherProceedings);
   enterOtherProceedingsEventPage.selectYesForProceeding();
   await enterOtherProceedingsEventPage.enterProceedingInformation(otherProceedings[0]);
@@ -562,6 +573,7 @@ Scenario('local authority enters other proceedings', async ({I, caseViewPage, en
 });
 
 Scenario('local authority enters allocation proposal @create-case-with-mandatory-sections-only', async ({I, caseViewPage, enterAllocationProposalEventPage}) => {
+  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
   await caseViewPage.goToNewActions(config.applicationActions.enterAllocationProposal);
   await enterAllocationProposalEventPage.selectAllocationProposal('Magistrate');
   await enterAllocationProposalEventPage.enterProposalReason('test');
@@ -576,6 +588,7 @@ Scenario('local authority enters allocation proposal @create-case-with-mandatory
 });
 
 Scenario('local authority enters attending hearing', async ({I, caseViewPage, enterAttendingHearingEventPage}) => {
+  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
   await caseViewPage.goToNewActions(config.applicationActions.enterAttendingHearing);
   await enterAttendingHearingEventPage.enterInterpreter();
   enterAttendingHearingEventPage.enterWelshProceedings();
@@ -604,6 +617,7 @@ Scenario('local authority enters attending hearing', async ({I, caseViewPage, en
 });
 
 Scenario('local authority adds multiple application documents @cross-browser', async ({I, caseViewPage, addApplicationDocumentsEventPage}) => {
+  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
   const browser = await I.getBrowser();
   // Both edge and safari fail to upload files in Saucelabs. Excluded for now.
   if (browser !== 'MicrosoftEdge' && browser !== 'safari') {
@@ -636,6 +650,7 @@ Scenario('local authority adds multiple application documents @cross-browser', a
 let feeToPay = '2055'; //Need to remember this between tests.. default in case the test below fails
 
 Scenario('local authority submits application @create-case-with-mandatory-sections-only', async ({I, caseViewPage, submitApplicationEventPage}) => {
+  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
   await caseViewPage.selectTab(caseViewPage.tabs.startApplication);
   await caseViewPage.startTask(config.applicationActions.submitCase);
 
@@ -650,6 +665,7 @@ Scenario('local authority submits application @create-case-with-mandatory-sectio
 });
 
 Scenario('HMCTS admin check the payment', async ({I, caseViewPage, paymentHistoryPage}) => {
+  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
   await I.navigateToCaseDetailsAs(config.hmctsAdminUser, caseId);
   caseViewPage.selectTab(caseViewPage.tabs.paymentHistory);
   await paymentHistoryPage.checkPayment(feeToPay, applicant.pbaNumber);

--- a/saucelabs.conf.js
+++ b/saucelabs.conf.js
@@ -78,7 +78,7 @@ const setupConfig = {
     },
     autoDelay: {
       enabled: true,
-      delayAfter: 2000,
+      delayAfter: 1000,
     },
     screenshotOnFail: {
       enabled: true,

--- a/saucelabs.conf.js
+++ b/saucelabs.conf.js
@@ -12,6 +12,7 @@ const defaultSauceOptions = {
   tunnelIdentifier: process.env.TUNNEL_IDENTIFIER || 'reformtunnel',
   acceptSslCerts: true,
   tags: ['FPL'],
+  maxDuration: 3000,
 };
 
 function merge(intoObject, fromObject) {


### PR DESCRIPTION
### JIRA link (if applicable) ###

n/a

### Change description ###

Multiple tweaks and hardening for the nightly pipeline:
- configure max 2 retries for the nightly cross-browser tests
- increased Saucelabs max test duration to 50mins, to allow for additional retries (and reduced the `delayAfter` to speed up cross-browser tests in general)
- make `navigateToCaseDetails()` wait for a less generic element, to make sure page has loaded more fully. Improves retry logic.
- reduced a long wait in `goToNewActions()`, as this blows out test run times when those steps can end up retrying up to 5 attempts. This is currently getting caught on a [ExUI page load issue](https://tools.hmcts.net/jira/browse/EUI-4210), and refreshing would actually resolve this issue, so no point waiting too long. If the element hasn't appeared in 30 secs it probably won't. 
- added an extra case to `goToNewActions()`'s refresh logic to handle a situation where IE11 can not return a URL if the page hasn't loaded correctly (again suffering from the [ExUI page load issue](https://tools.hmcts.net/jira/browse/EUI-4210))
- moved steps out of `Before()` function for `localAuthoritySubmitsApplication_test.js` to allow Codecept to retry them if they fail - unfortunately Codecept does not appear to support retrying of either `Before()` or `BeforeSuite()` code. (it's more rare to have failures at the `BeforeSuite()` stage)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

![image](https://user-images.githubusercontent.com/11600884/122584274-139ec500-d052-11eb-9770-a5dbef2b35a0.png)

