### PR TITLE
fix: Fix judicial messages dynamic list label (FPLA-3091)

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/judicialmessage/JudicialMessage.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/judicialmessage/JudicialMessage.java
@@ -6,6 +6,7 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
+import org.apache.commons.lang3.StringUtils;
 import uk.gov.hmcts.reform.fpl.enums.JudicialMessageStatus;
 import uk.gov.hmcts.reform.fpl.enums.YesNo;
 import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
@@ -37,6 +38,7 @@ public class JudicialMessage extends JudicialMessageMetaData {
     private final String replyTo;
 
     public String toLabel() {
+        final int maxDynamicListLabelLength = 250;
         List<String> labels = new ArrayList<>();
 
         if (YES.equals(isRelatedToC2)) {
@@ -50,10 +52,11 @@ public class JudicialMessage extends JudicialMessageMetaData {
         labels.add(dateSent);
 
         if (isNotBlank(getUrgency())) {
-            labels.add("Urgent");
+            labels.add(getUrgency());
         }
 
-        return String.join(", ", labels);
+        String label = String.join(", ", labels);
+        return StringUtils.abbreviate(label, maxDynamicListLabelLength);
     }
 
     @JsonIgnore

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/judicialmessage/JudicialMessage.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/judicialmessage/JudicialMessage.java
@@ -50,7 +50,7 @@ public class JudicialMessage extends JudicialMessageMetaData {
         labels.add(dateSent);
 
         if (isNotBlank(getUrgency())) {
-            labels.add(getUrgency());
+            labels.add("Urgent");
         }
 
         return String.join(", ", labels);

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/judicialmessage/JudicialMessage.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/judicialmessage/JudicialMessage.java
@@ -25,6 +25,8 @@ import static uk.gov.hmcts.reform.fpl.enums.YesNo.YES;
 @Jacksonized
 @ToString(callSuper = true)
 public class JudicialMessage extends JudicialMessageMetaData {
+    private static final int MAX_DYNAMIC_LIST_LABEL_LENGTH = 250;
+
     private final String dateSent;
     private final LocalDateTime updatedTime;
     private final JudicialMessageStatus status;
@@ -38,7 +40,6 @@ public class JudicialMessage extends JudicialMessageMetaData {
     private final String replyTo;
 
     public String toLabel() {
-        final int maxDynamicListLabelLength = 250;
         List<String> labels = new ArrayList<>();
 
         if (YES.equals(isRelatedToC2)) {
@@ -56,7 +57,7 @@ public class JudicialMessage extends JudicialMessageMetaData {
         }
 
         String label = String.join(", ", labels);
-        return StringUtils.abbreviate(label, maxDynamicListLabelLength);
+        return StringUtils.abbreviate(label, MAX_DYNAMIC_LIST_LABEL_LENGTH);
     }
 
     @JsonIgnore

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/model/CaseDataTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/model/CaseDataTest.java
@@ -1485,9 +1485,9 @@ class CaseDataTest {
 
             CaseData caseData = CaseData.builder().judicialMessages(judicialMessages).build();
             DynamicList expectedDynamicList = buildDynamicList(
-                Pair.of(firstId, "C2, Subject 1, 11 November 2020, Low"),
-                Pair.of(secondId, "Subject 2, 12 November 2020, Medium"),
-                Pair.of(thirdId, "C2, Subject 3, 13 November 2020, High")
+                Pair.of(firstId, "C2, Subject 1, 11 November 2020, Urgent"),
+                Pair.of(secondId, "Subject 2, 12 November 2020, Urgent"),
+                Pair.of(thirdId, "C2, Subject 3, 13 November 2020, Urgent")
             );
 
             assertThat(caseData.buildJudicialMessageDynamicList())
@@ -1504,9 +1504,9 @@ class CaseDataTest {
 
             CaseData caseData = CaseData.builder().judicialMessages(judicialMessages).build();
             DynamicList expectedDynamicList = buildDynamicList(2,
-                Pair.of(firstId, "C2, Subject 1, 11 November 2020, Low"),
-                Pair.of(secondId, "Subject 2, 12 November 2020, Medium"),
-                Pair.of(thirdId, "C2, Subject 3, 13 November 2020, High")
+                Pair.of(firstId, "C2, Subject 1, 11 November 2020, Urgent"),
+                Pair.of(secondId, "Subject 2, 12 November 2020, Urgent"),
+                Pair.of(thirdId, "C2, Subject 3, 13 November 2020, Urgent")
             );
 
             assertThat(caseData.buildJudicialMessageDynamicList(thirdId))

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/model/CaseDataTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/model/CaseDataTest.java
@@ -1485,9 +1485,9 @@ class CaseDataTest {
 
             CaseData caseData = CaseData.builder().judicialMessages(judicialMessages).build();
             DynamicList expectedDynamicList = buildDynamicList(
-                Pair.of(firstId, "C2, Subject 1, 11 November 2020, Urgent"),
-                Pair.of(secondId, "Subject 2, 12 November 2020, Urgent"),
-                Pair.of(thirdId, "C2, Subject 3, 13 November 2020, Urgent")
+                Pair.of(firstId, "C2, Subject 1, 11 November 2020, Low"),
+                Pair.of(secondId, "Subject 2, 12 November 2020, Medium"),
+                Pair.of(thirdId, "C2, Subject 3, 13 November 2020, High")
             );
 
             assertThat(caseData.buildJudicialMessageDynamicList())
@@ -1504,9 +1504,9 @@ class CaseDataTest {
 
             CaseData caseData = CaseData.builder().judicialMessages(judicialMessages).build();
             DynamicList expectedDynamicList = buildDynamicList(2,
-                Pair.of(firstId, "C2, Subject 1, 11 November 2020, Urgent"),
-                Pair.of(secondId, "Subject 2, 12 November 2020, Urgent"),
-                Pair.of(thirdId, "C2, Subject 3, 13 November 2020, Urgent")
+                Pair.of(firstId, "C2, Subject 1, 11 November 2020, Low"),
+                Pair.of(secondId, "Subject 2, 12 November 2020, Medium"),
+                Pair.of(thirdId, "C2, Subject 3, 13 November 2020, High")
             );
 
             assertThat(caseData.buildJudicialMessageDynamicList(thirdId))

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/model/JudicialMessageTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/model/JudicialMessageTest.java
@@ -8,7 +8,7 @@ import static uk.gov.hmcts.reform.fpl.enums.YesNo.YES;
 
 class JudicialMessageTest {
     private static String DATE_SENT = "11 November at 08:30am";
-    private static String URGENCY = "Urgent";
+    private static String URGENCY = "High urgency";
     private static String SUBJECT = "Subject";
 
     @Test
@@ -26,7 +26,7 @@ class JudicialMessageTest {
     @Test
     void shouldBuildJudicialMessageLabelWithoutC2() {
         JudicialMessage judicialMessage = JudicialMessage.builder()
-            .urgency("Urgent - need directions for the application")
+            .urgency(URGENCY)
             .dateSent(DATE_SENT)
             .subject(SUBJECT)
             .build();
@@ -52,6 +52,27 @@ class JudicialMessageTest {
             .build();
 
         assertThat(judicialMessage.toLabel()).isEqualTo(String.format("%s", DATE_SENT));
+    }
+
+    @Test
+    void shouldBuildJudicialMessageLabelWithMaximumLengthAllowedWhenUrgencyIsTooLong() {
+        String longUrgency = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed sollicitudin eu felis "
+            + "tincidunt volutpat. Donec tempus quis metus congue placerat. Sed ligula nisl, tempor at eleifend ac, "
+            + "consequat condimentum sem. In sed porttitor turpis, at laoreet quam. Fusce bibendum vehicula ipsum, et "
+            + "tempus ante fermentum non.";
+
+        JudicialMessage judicialMessage = JudicialMessage.builder()
+            .urgency(longUrgency.substring(0, 249))
+            .dateSent(DATE_SENT)
+            .build();
+
+        String truncatedUrgencyText = "Lorem ipsum dolor sit amet, consectetur adipiscing "
+            + "elit. Sed sollicitudin eu felis tincidunt volutpat. Donec tempus quis metus congue placerat. Sed ligula "
+            + "nisl, tempor at eleifend ac, consequat condimentum sem. In sed portt...";
+
+        String expectedMessageLabel = String.format("%s, %s", DATE_SENT, truncatedUrgencyText);
+
+        assertThat(judicialMessage.toLabel()).isEqualTo(expectedMessageLabel);
     }
 
     @Test

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/model/JudicialMessageTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/model/JudicialMessageTest.java
@@ -8,7 +8,7 @@ import static uk.gov.hmcts.reform.fpl.enums.YesNo.YES;
 
 class JudicialMessageTest {
     private static String DATE_SENT = "11 November at 08:30am";
-    private static String URGENCY = "High urgency";
+    private static String URGENCY = "Urgent";
     private static String SUBJECT = "Subject";
 
     @Test
@@ -26,7 +26,7 @@ class JudicialMessageTest {
     @Test
     void shouldBuildJudicialMessageLabelWithoutC2() {
         JudicialMessage judicialMessage = JudicialMessage.builder()
-            .urgency(URGENCY)
+            .urgency("Urgent - need directions for the application")
             .dateSent(DATE_SENT)
             .subject(SUBJECT)
             .build();

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/MessageJudgeServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/MessageJudgeServiceTest.java
@@ -507,7 +507,7 @@ class MessageJudgeServiceTest {
         );
 
         DynamicList judicialMessageDynamicList = buildDynamicList(0,
-            Pair.of(SELECTED_DYNAMIC_LIST_ITEM_ID, "Test subject, 12 January 2021, high"),
+            Pair.of(SELECTED_DYNAMIC_LIST_ITEM_ID, "Test subject, 12 January 2021, Urgent"),
             Pair.of(judicialMessages.get(1).getId(), "null")
         );
 

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/MessageJudgeServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/MessageJudgeServiceTest.java
@@ -99,17 +99,23 @@ class MessageJudgeServiceTest {
     @Test
     void shouldInitialiseCaseFieldsWhenAdditionalApplicationDocumentsAndJudicialMessagesExist() {
         UUID uuid = randomUUID();
+        String longUrgency = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed sollicitudin eu felis "
+            + "tincidunt volutpat. Donec tempus quis metus congue placerat. Sed ligula nisl, tempor at eleifend ac, "
+            + "consequat condimentum sem. In sed porttitor turpis, at laoreet quam. Fusce bibendum vehicula ipsum, et "
+            + "tempus ante fermentum non.";
 
         List<Element<JudicialMessage>> judicialMessages = List.of(
             element(JudicialMessage.builder()
                 .latestMessage("some note")
                 .messageHistory("some history")
+                .urgency(longUrgency)
                 .dateSent("01 Dec 2020")
                 .build()),
             element(JudicialMessage.builder()
                 .latestMessage("some note")
                 .messageHistory("some history")
                 .dateSent("02 Dec 2020")
+                .urgency("High")
                 .build())
         );
 
@@ -134,9 +140,13 @@ class MessageJudgeServiceTest {
             Pair.of(uuid, "C2, 01 Dec 2020")
         );
 
+        String expectedUrgencyText = "Lorem ipsum dolor sit amet, consectetur adipiscing "
+            + "elit. Sed sollicitudin eu felis tincidunt volutpat. Donec tempus quis metus congue placerat. Sed ligula "
+            + "nisl, tempor at eleifend ac, consequat condimentum sem. In sed porttitor turpis...";
+
         DynamicList expectedJudicialDynamicList = buildDynamicList(
-            Pair.of(judicialMessages.get(0).getId(), "01 Dec 2020"),
-            Pair.of(judicialMessages.get(1).getId(), "02 Dec 2020")
+            Pair.of(judicialMessages.get(0).getId(), "01 Dec 2020, " + expectedUrgencyText),
+            Pair.of(judicialMessages.get(1).getId(), "02 Dec 2020, High")
         );
 
         Map<String, Object> expectedData = Map.of(
@@ -507,7 +517,7 @@ class MessageJudgeServiceTest {
         );
 
         DynamicList judicialMessageDynamicList = buildDynamicList(0,
-            Pair.of(SELECTED_DYNAMIC_LIST_ITEM_ID, "Test subject, 12 January 2021, Urgent"),
+            Pair.of(SELECTED_DYNAMIC_LIST_ITEM_ID, "Test subject, 12 January 2021, high"),
             Pair.of(judicialMessages.get(1).getId(), "null")
         );
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FPLA-3091

### Change description ###
Judicial messages dynamic list label appends `urgent` field data which can be too long for the dynamic list label.
Update the label to just append `Urgent` for messages with urgent text.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
