### PR TITLE
Chore: Nightly pipeline cross-browser improvements

### DIFF
--- a/e2e/helpers/accessibility/runner.js
+++ b/e2e/helpers/accessibility/runner.js
@@ -60,7 +60,7 @@ async function runAccessibility(url, page) {
 }
 
 function updateResultObject(url, pageTitle, screenshotReportRef, accessibilityErrorsOnThePage) {
-  const isPageAccessible = accessibilityErrorsOnThePage.length === 0 ? result.PASSED : result.FAILED;
+  const isPageAccessible = accessibilityErrorsOnThePage && accessibilityErrorsOnThePage.length === 0 ? result.PASSED : result.FAILED;
 
   const urlArr = url.split('/');
 

--- a/e2e/helpers/hooks_helper.js
+++ b/e2e/helpers/hooks_helper.js
@@ -22,9 +22,11 @@ module.exports = class HooksHelpers extends Helper {
     });
   }
 
-  _beforeStep() {
+  _beforeStep(step) {
     const helper = this.helpers['Puppeteer'] || this.helpers['WebDriver'];
-    return helper.waitForInvisible('xuilib-loading-spinner', 30);
+    if (step.name !== 'amOnPage') {
+      return helper.waitForInvisible('xuilib-loading-spinner', 30);
+    }
   }
 
 };

--- a/e2e/helpers/hooks_helper.js
+++ b/e2e/helpers/hooks_helper.js
@@ -1,4 +1,5 @@
 const recorder = require('codeceptjs').recorder;
+const output = require('codeceptjs').output;
 const lodash = require('lodash');
 const retryableErrors = [
   'Execution context was destroyed',
@@ -7,6 +8,10 @@ const retryableErrors = [
   'net::ERR_ABORTED'];
 
 module.exports = class HooksHelpers extends Helper {
+  getHelper() {
+    return this.helpers['Puppeteer'] || this.helpers['WebDriver'];
+  }
+
   _test(test) {
     const retries = parseInt(process.env.TEST_RETRIES || '-1');
     if (retries !== -1 || test.retries() === -1) {
@@ -23,10 +28,17 @@ module.exports = class HooksHelpers extends Helper {
   }
 
   _beforeStep(step) {
-    const helper = this.helpers['Puppeteer'] || this.helpers['WebDriver'];
+    const helper = this.getHelper();
     if (step.name !== 'amOnPage') {
       return helper.waitForInvisible('xuilib-loading-spinner', 30);
     }
   }
 
+  _afterStep(step) {
+    const helper = this.getHelper();
+    if (step.name === 'attachFile') {
+      output.debug('Waiting for file to finish "Uploading..."');
+      return helper.waitForInvisible('//*[contains(text(), "Uploading...")]', 20);
+    }
+  }
 };

--- a/e2e/pages/caseView.page.js
+++ b/e2e/pages/caseView.page.js
@@ -49,7 +49,7 @@ module.exports = {
           I.refreshPage();
         }
       }
-    }, 'ccd-case-event-trigger');
+    }, 'ccd-case-event-trigger', false);
   },
 
   async checkActionsAreAvailable(actions) {

--- a/e2e/pages/events/addApplicationDocumentsEvent.page.js
+++ b/e2e/pages/events/addApplicationDocumentsEvent.page.js
@@ -7,6 +7,7 @@ module.exports = {
       document: `#applicationDocuments_${index}_document`,
       includedInSWET: `#applicationDocuments_${index}_includedInSWET`,
       documentName: `#applicationDocuments_${index}_documentName`,
+      documentUploading: `//*[@id="applicationDocuments_${index}_${index}"]//*[contains(text(), "Uploading")]`,
     };
   },
 
@@ -14,9 +15,9 @@ module.exports = {
 
     await I.addAnotherElementToCollection('Documents');
     const index = await I.getActiveElementIndex();
+    await I.runAccessibilityTest();
 
     this.selectDocumentType(option, index);
-    await I.runAccessibilityTest();
     this.uploadFile(file, index);
 
     if (name) {
@@ -34,6 +35,7 @@ module.exports = {
 
   uploadFile(file, index) {
     I.attachFile(this.fields(index).document, file);
+    I.waitForInvisible(this.fields(index).documentUploading, 20);
   },
 
   enterWhatIsIncludedInSWET(description, index) {

--- a/e2e/pages/events/addApplicationDocumentsEvent.page.js
+++ b/e2e/pages/events/addApplicationDocumentsEvent.page.js
@@ -7,7 +7,6 @@ module.exports = {
       document: `#applicationDocuments_${index}_document`,
       includedInSWET: `#applicationDocuments_${index}_includedInSWET`,
       documentName: `#applicationDocuments_${index}_documentName`,
-      documentUploading: `//*[@id="applicationDocuments_${index}_${index}"]//*[contains(text(), "Uploading")]`,
     };
   },
 
@@ -35,7 +34,6 @@ module.exports = {
 
   uploadFile(file, index) {
     I.attachFile(this.fields(index).document, file);
-    I.waitForInvisible(this.fields(index).documentUploading, 20);
   },
 
   enterWhatIsIncludedInSWET(description, index) {

--- a/e2e/tests/localAuthoritySubmitsApplication_test.js
+++ b/e2e/tests/localAuthoritySubmitsApplication_test.js
@@ -665,7 +665,6 @@ Scenario('local authority submits application @create-case-with-mandatory-sectio
 });
 
 Scenario('HMCTS admin check the payment', async ({I, caseViewPage, paymentHistoryPage}) => {
-  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
   await I.navigateToCaseDetailsAs(config.hmctsAdminUser, caseId);
   caseViewPage.selectTab(caseViewPage.tabs.paymentHistory);
   await paymentHistoryPage.checkPayment(feeToPay, applicant.pbaNumber);


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FPLA-3172

### Change description ###

1. improvement for goToNewActions() e2e step to force action to be executed in retries - this improved stability quite a bit
2. don't check for spinner before loading a URL in e2e tests as it's not necessary
3. stop "Uncaught TypeError: Cannot read property 'length' of undefined" errors being thrown from accessibility test runner.js
4. remove unnecessary navigateToCaseDetailsAs() duplication
5. make e2e uploadFile() step wait for 'Uploading...' element to disappear before continuing, to ensure upload is complete. This is mainly to help IE11

### Nightly pipeline result ###

![image](https://user-images.githubusercontent.com/11600884/123227212-47ec0880-d4cc-11eb-8814-e0e7ad3b1150.png)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
