### PR TITLE
bug: nested complex field mandatory even when hidden (EUI-4213)

### DIFF
--- a/ccd-definition/AuthorisationCaseEvent/CareSupervision/AuthorisationCaseEvent.json
+++ b/ccd-definition/AuthorisationCaseEvent/CareSupervision/AuthorisationCaseEvent.json
@@ -1245,5 +1245,12 @@
     "CaseEventID": "removeManagingOrganisation",
     "UserRole": "[LASOLICITOR]",
     "CRUD": "CR"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseEventID": "mandatoryHiddenFieldEvent",
+    "UserRole": "caseworker-publiclaw-courtadmin",
+    "CRUD": "CR"
   }
 ]

--- a/ccd-definition/AuthorisationCaseField/CareSupervision/court-admin.json
+++ b/ccd-definition/AuthorisationCaseField/CareSupervision/court-admin.json
@@ -2273,5 +2273,12 @@
     "CaseFieldID": "manageOrdersCafcassOfficesWales",
     "UserRole": "caseworker-publiclaw-courtadmin",
     "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseFieldID": "mandatoryHiddenField",
+    "UserRole": "caseworker-publiclaw-courtadmin",
+    "CRUD": "CRU"
   }
 ]

--- a/ccd-definition/CaseEvent/CareSupervision/MultiState.json
+++ b/ccd-definition/CaseEvent/CareSupervision/MultiState.json
@@ -13,6 +13,15 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "ID": "mandatoryHiddenFieldEvent",
+    "Name": "(TEST) Mandatory hidden field",
+    "PreConditionState(s)": "*",
+    "PostConditionState": "*",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
     "ID": "internal-update-task-list",
     "Name": "Update task list",
     "PreConditionState(s)": "*",

--- a/ccd-definition/CaseEventToComplexTypes/hiddenMandatoryField.json
+++ b/ccd-definition/CaseEventToComplexTypes/hiddenMandatoryField.json
@@ -1,0 +1,29 @@
+[
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "HiddenMandatoryField",
+    "CaseEventID": "mandatoryHiddenFieldEvent",
+    "CaseFieldID": "mandatoryHiddenField",
+    "ListElementCode": "radioButton",
+    "FieldDisplayOrder": 1,
+    "DisplayContext": "MANDATORY"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "HiddenMandatoryField",
+    "CaseEventID": "mandatoryHiddenFieldEvent",
+    "CaseFieldID": "mandatoryHiddenField",
+    "ListElementCode": "nestedComplex.text",
+    "FieldDisplayOrder": 2,
+    "DisplayContext": "MANDATORY"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "HiddenMandatoryField",
+    "CaseEventID": "mandatoryHiddenFieldEvent",
+    "CaseFieldID": "mandatoryHiddenField",
+    "ListElementCode": "nestedComplex.textArea",
+    "FieldDisplayOrder": 3,
+    "DisplayContext": "MANDATORY"
+  }
+]

--- a/ccd-definition/CaseEventToFields/CareSupervision/mandatoryHiddenField.json
+++ b/ccd-definition/CaseEventToFields/CareSupervision/mandatoryHiddenField.json
@@ -1,0 +1,13 @@
+[
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseEventID": "mandatoryHiddenFieldEvent",
+    "CaseFieldID": "mandatoryHiddenField",
+    "PageID": 1,
+    "PageDisplayOrder": 1,
+    "PageFieldDisplayOrder": 1,
+    "PageColumnNumber": 1,
+    "DisplayContext": "COMPLEX"
+  }
+]

--- a/ccd-definition/CaseField/CareSupervision/caseField.json
+++ b/ccd-definition/CaseField/CareSupervision/caseField.json
@@ -1708,5 +1708,14 @@
     "FieldType": "Text",
     "SecurityClassification": "Public",
     "Searchable": "N"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "ID": "mandatoryHiddenField",
+    "Label": "Test complex type with mandatory hidden field",
+    "FieldType": "TestComplexType",
+    "SecurityClassification": "Public",
+    "Searchable": "N"
   }
 ]

--- a/ccd-definition/ComplexTypes/CareSupervision/AnotherTestComplexType.json
+++ b/ccd-definition/ComplexTypes/CareSupervision/AnotherTestComplexType.json
@@ -1,0 +1,18 @@
+[
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "AnotherTestComplexType",
+    "ListElementCode": "text",
+    "FieldType": "Text",
+    "ElementLabel": "Some text here",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "AnotherTestComplexType",
+    "ListElementCode": "textArea",
+    "FieldType": "TextArea",
+    "ElementLabel": "More text!",
+    "SecurityClassification": "Public"
+  }
+]

--- a/ccd-definition/ComplexTypes/CareSupervision/TestComplexType.json
+++ b/ccd-definition/ComplexTypes/CareSupervision/TestComplexType.json
@@ -1,0 +1,19 @@
+[
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "TestComplexType",
+    "ListElementCode": "radioButton",
+    "FieldType": "YesOrNo",
+    "ElementLabel": "Please select yes or no",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "TestComplexType",
+    "ListElementCode": "nestedComplex",
+    "FieldType": "AnotherTestComplexType",
+    "ElementLabel": "This is a nested complex type",
+    "SecurityClassification": "Public",
+    "FieldShowCondition": "radioButton=\"Yes\""
+  }
+]


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/EUI-4213

### Steps ###

1. log in hmcts-admin@example.com | Password12
2. on any case, go to (TEST) Mandatory hidden field event
3. Use yes/no options and see that continue button is greyed out when selecting no, due to a bug with nested complex type controlled by COMPLEX DisplayContext and MANDATORY set in CaseEventToComplexType

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
