### PR TITLE
Chore: Move e2e Before() and BeforeSuite() steps into Scenarios

### DIFF
--- a/e2e/tests/accessSegregation_test.js
+++ b/e2e/tests/accessSegregation_test.js
@@ -4,39 +4,48 @@ let caseId;
 
 Feature('Access segregation');
 
-BeforeSuite(async ({I}) => caseId = await I.submitNewCaseWithData());
+async function setupScenario(I) {
+  if (!caseId) { caseId = await I.submitNewCaseWithData(); }
+}
 
 Scenario('Different user in the same local authority can see case created', async ({I}) => {
+  await setupScenario(I);
   await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserTwo, caseId);
   I.see(caseId);
 });
 
 Scenario('Different user in a different local authority cannot see case created', async ({I, caseListPage}) => {
+  await setupScenario(I);
   await I.signIn(config.hillingdonLocalAuthorityUserTwo);
   caseListPage.verifyCaseIsNotAccessible(caseId);
 });
 
 Scenario('HMCTS admin user can see the case', async ({I}) => {
+  await setupScenario(I);
   await I.navigateToCaseDetailsAs(config.hmctsAdminUser, caseId);
   I.see(caseId);
 });
 
 Scenario('CAFCASS user can see the case', async ({I}) => {
+  await setupScenario(I);
   await I.navigateToCaseDetailsAs(config.cafcassUser, caseId);
   I.see(caseId);
 });
 
 Scenario('Gatekeeper user can see the case', async ({I}) => {
+  await setupScenario(I);
   await I.navigateToCaseDetailsAs(config.gateKeeperUser, caseId);
   I.see(caseId);
 });
 
 Scenario('Judiciary user can see the case', async ({I}) => {
+  await setupScenario(I);
   await I.navigateToCaseDetailsAs(config.judicaryUser, caseId);
   I.see(caseId);
 });
 
 Scenario('Magistrate user can see the case', async ({I}) => {
+  await setupScenario(I);
   await I.navigateToCaseDetailsAs(config.magistrateUser, caseId);
   I.see(caseId);
   await I.seeAvailableEvents([config.administrationActions.manageDocuments]);

--- a/e2e/tests/adminManagesOrders_test.js
+++ b/e2e/tests/adminManagesOrders_test.js
@@ -16,13 +16,14 @@ let caseId;
 
 Feature('HMCTS Admin manages orders');
 
-BeforeSuite(async ({ I }) => caseId = await I.submitNewCaseWithData(caseData));
-
-Before(async ({ I }) => await I.navigateToCaseDetailsAs(config.hmctsAdminUser, caseId));
+async function setupScenario(I, caseViewPage) {
+  if (!caseId) { caseId = await I.submitNewCaseWithData(caseData); }
+  await I.navigateToCaseDetailsAs(config.hmctsAdminUser, caseId);
+  await caseViewPage.goToNewActions(config.administrationActions.manageOrders);
+}
 
 Scenario('Create C32 care order (with pre filled hearing details)', async ({ I, caseViewPage, manageOrdersEventPage }) => {
-  await caseViewPage.goToNewActions(config.administrationActions.manageOrders);
-
+  await setupScenario(I, caseViewPage);
   await manageOrdersEventPage.selectOperation(manageOrdersEventPage.operations.options.create);
   await I.goToNextPage();
   await manageOrdersEventPage.selectOrder(manageOrdersEventPage.orders.options.c32);
@@ -53,7 +54,7 @@ Scenario('Create C32 care order (with pre filled hearing details)', async ({ I, 
 });
 
 Scenario('Create 32b discharge of care order', async ({I, caseViewPage, manageOrdersEventPage}) => {
-  await caseViewPage.goToNewActions(config.administrationActions.manageOrders);
+  await setupScenario(I, caseViewPage);
   await manageOrdersEventPage.selectOperation(manageOrdersEventPage.operations.options.create);
   await I.goToNextPage();
   await manageOrdersEventPage.selectOrder(manageOrdersEventPage.orders.options.c32b);
@@ -84,8 +85,7 @@ Scenario('Create 32b discharge of care order', async ({I, caseViewPage, manageOr
 });
 
 Scenario('Create EPO order', async ({ I, caseViewPage, manageOrdersEventPage }) => {
-  await caseViewPage.goToNewActions(config.administrationActions.manageOrders);
-
+  await setupScenario(I, caseViewPage);
   await manageOrdersEventPage.selectOperation(manageOrdersEventPage.operations.options.create);
   await I.goToNextPage();
   await manageOrdersEventPage.selectOrder(manageOrdersEventPage.orders.options.c23);
@@ -116,8 +116,7 @@ Scenario('Create EPO order', async ({ I, caseViewPage, manageOrdersEventPage }) 
 });
 
 Scenario('Create EPO Prevent removal order', async ({ I, caseViewPage, manageOrdersEventPage }) => {
-  await caseViewPage.goToNewActions(config.administrationActions.manageOrders);
-
+  await setupScenario(I, caseViewPage);
   await manageOrdersEventPage.selectOperation(manageOrdersEventPage.operations.options.create);
   await I.goToNextPage();
   await manageOrdersEventPage.selectOrder(manageOrdersEventPage.orders.options.c23);
@@ -153,7 +152,7 @@ Scenario('Create EPO Prevent removal order', async ({ I, caseViewPage, manageOrd
 });
 
 Scenario('Create C21 blank order', async ({ I, caseViewPage, manageOrdersEventPage }) => {
-  await caseViewPage.goToNewActions(config.administrationActions.manageOrders);
+  await setupScenario(I, caseViewPage);
   await manageOrdersEventPage.selectOperation(manageOrdersEventPage.operations.options.create);
   await I.goToNextPage();
   await manageOrdersEventPage.selectOrder(manageOrdersEventPage.orders.options.c21);
@@ -216,7 +215,7 @@ Scenario('Create C21 blank order in closed case', async ({ I, caseViewPage, mana
 });
 
 Scenario('Create C35a Supervision order', async ({ I, caseViewPage, manageOrdersEventPage }) => {
-  await caseViewPage.goToNewActions(config.administrationActions.manageOrders);
+  await setupScenario(I, caseViewPage);
   await manageOrdersEventPage.selectOperation(manageOrdersEventPage.operations.options.create);
   await I.goToNextPage();
   await manageOrdersEventPage.selectOrder(manageOrdersEventPage.orders.options.c35A);
@@ -246,7 +245,7 @@ Scenario('Create C35a Supervision order', async ({ I, caseViewPage, manageOrders
 });
 
 Scenario('Create Interim care order  (C33)', async ({ I, caseViewPage, manageOrdersEventPage }) => {
-  await caseViewPage.goToNewActions(config.administrationActions.manageOrders);
+  await setupScenario(I, caseViewPage);
   await manageOrdersEventPage.selectOperation(manageOrdersEventPage.operations.options.create);
   await I.goToNextPage();
   await manageOrdersEventPage.selectOrder(manageOrdersEventPage.orders.options.c33);
@@ -276,7 +275,7 @@ Scenario('Create Interim care order  (C33)', async ({ I, caseViewPage, manageOrd
 });
 
 Scenario('Interim supervision order (C35B)', async ({ I, caseViewPage, manageOrdersEventPage }) => {
-  await caseViewPage.goToNewActions(config.administrationActions.manageOrders);
+  await setupScenario(I, caseViewPage);
   await manageOrdersEventPage.selectOperation(manageOrdersEventPage.operations.options.create);
   await I.goToNextPage();
   await manageOrdersEventPage.selectOrder(manageOrdersEventPage.orders.options.c35B);
@@ -339,7 +338,7 @@ Scenario('Create C47A appointment of a Children\'s Guardian', async ({ I, caseVi
 });
 
 Scenario('Upload Manual order (other order)', async ({I, caseViewPage, manageOrdersEventPage}) => {
-  await caseViewPage.goToNewActions(config.administrationActions.manageOrders);
+  await setupScenario(I, caseViewPage);
   await manageOrdersEventPage.selectOperation(manageOrdersEventPage.operations.options.upload);
   await I.goToNextPage();
   await manageOrdersEventPage.selectUploadOrder(manageOrdersEventPage.orders.options.other);

--- a/e2e/tests/adminMangesHearings_test.js
+++ b/e2e/tests/adminMangesHearings_test.js
@@ -14,14 +14,16 @@ let hearingEndDate;
 
 Feature('Hearing administration');
 
-BeforeSuite(async ({I}) => {
-  caseId = await I.submitNewCaseWithData(mandatoryWithMultipleChildren);
-  submittedAt = new Date();
-});
-
-Before(async ({I}) => await I.navigateToCaseDetailsAs(config.hmctsAdminUser, caseId));
+async function setupScenario(I) {
+  if (!caseId) {
+    caseId = await I.submitNewCaseWithData(mandatoryWithMultipleChildren);
+    submittedAt = new Date();
+  }
+  await I.navigateToCaseDetailsAs(config.hmctsAdminUser, caseId);
+}
 
 Scenario('HMCTS admin creates first hearings', async ({I, caseViewPage, manageHearingsEventPage}) => {
+  await setupScenario(I);
   hearingStartDate = moment().add(5,'m').toDate();
   hearingEndDate = moment(hearingStartDate).add(5,'m').toDate();
 
@@ -53,6 +55,7 @@ Scenario('HMCTS admin creates first hearings', async ({I, caseViewPage, manageHe
 });
 
 Scenario('HMCTS admin creates subsequent hearings', async ({I, caseViewPage, manageHearingsEventPage}) => {
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.administrationActions.manageHearings);
   manageHearingsEventPage.selectAddNewHearing();
   await I.goToNextPage();
@@ -75,6 +78,7 @@ Scenario('HMCTS admin creates subsequent hearings', async ({I, caseViewPage, man
 });
 
 Scenario('HMCTS admin edit hearings', async ({I, caseViewPage, manageHearingsEventPage}) => {
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.administrationActions.manageHearings);
   manageHearingsEventPage.selectEditHearing('Case management hearing, 1 January 2060');
   await I.goToNextPage();
@@ -107,6 +111,7 @@ Scenario('HMCTS admin edit hearings', async ({I, caseViewPage, manageHearingsEve
 });
 
 Scenario('HMCTS admin uploads further hearing evidence documents', async ({I, caseViewPage, manageDocumentsEventPage}) => {
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.administrationActions.manageDocuments);
   manageDocumentsEventPage.selectFurtherEvidence();
   await I.goToNextPage();
@@ -144,6 +149,7 @@ Scenario('HMCTS admin uploads further hearing evidence documents', async ({I, ca
 });
 
 Scenario('HMCTS admin adjourns and re-lists a hearing', async ({I, caseViewPage, manageHearingsEventPage}) => {
+  await setupScenario(I);
   const reListedHearingJudgeName = 'Brown';
 
   await caseViewPage.goToNewActions(config.administrationActions.manageHearings);
@@ -185,6 +191,7 @@ Scenario('HMCTS admin adjourns and re-lists a hearing', async ({I, caseViewPage,
 });
 
 Scenario('HMCTS admin vacates and re-lists a hearing', async ({I, caseViewPage, manageHearingsEventPage}) => {
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.administrationActions.manageHearings);
   manageHearingsEventPage.selectVacateHearing('Case management hearing, 1 January 2060');
   await I.goToNextPage();
@@ -219,6 +226,7 @@ Scenario('HMCTS admin vacates and re-lists a hearing', async ({I, caseViewPage, 
 });
 
 Scenario('HMCTS admin cancels and re-lists hearing', async ({I, caseViewPage, manageHearingsEventPage}) => {
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.administrationActions.manageHearings);
   manageHearingsEventPage.selectVacateHearing('Case management hearing, 1 January 2060');
   await I.goToNextPage();
@@ -262,6 +270,7 @@ Scenario('HMCTS admin cancels and re-lists hearing', async ({I, caseViewPage, ma
 });
 
 Scenario('HMCTS admin adds past hearing', async ({I, caseViewPage, manageHearingsEventPage}) => {
+  await setupScenario(I);
   hearingStartDate = moment().subtract(10,'m').toDate();
   hearingEndDate = moment(hearingStartDate).add(5,'m').toDate();
 

--- a/e2e/tests/bulkScanUserUploadsScannedDocuments_test.js
+++ b/e2e/tests/bulkScanUserUploadsScannedDocuments_test.js
@@ -5,12 +5,13 @@ let caseId;
 
 Feature('Uploading bulk scan document');
 
-BeforeSuite(async ({I}) => {
-  caseId = await I.submitNewCaseWithData();
+async function setupScenario(I) {
+  if (!caseId) { caseId = await I.submitNewCaseWithData(); }
   await I.navigateToCaseDetailsAs(config.hmctsAdminUser, caseId);
-});
+}
 
 Scenario('HMCTS admin uploads documents to be scanned', async ({I, caseViewPage, handleSupplementaryEvidenceEventPage, attachScannedDocsEventPage}) => {
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.administrationActions.bulkScan);
   await attachScannedDocsEventPage.enterScannedDocument(scannedDocument, config.testFile);
   await I.goToNextPage();
@@ -19,6 +20,7 @@ Scenario('HMCTS admin uploads documents to be scanned', async ({I, caseViewPage,
 });
 
 Scenario('HMCTS admin can see documents scanned in with Bulk Scan', async ({I, caseViewPage}) => {
+  await setupScenario(I);
   caseViewPage.selectTab(caseViewPage.tabs.furtherEvidence);
   I.expandDocumentSection('Any other documents', 'Example file name');
   I.seeInExpandedDocument('Example file name', null, '12:00pm, 1 January 2050');

--- a/e2e/tests/gatekeeperAdministersCaseAfterGatekeeping_test.js
+++ b/e2e/tests/gatekeeperAdministersCaseAfterGatekeeping_test.js
@@ -7,14 +7,13 @@ let caseId;
 
 Feature('Gatekeeper Case administration after gatekeeping');
 
-BeforeSuite(async ({I}) => {
-  caseId = await I.submitNewCaseWithData(gatekeepingCaseData);
+async function setupScenario(I) {
+  if (!caseId) { caseId = await I.submitNewCaseWithData(gatekeepingCaseData); }
   await I.navigateToCaseDetailsAs(config.gateKeeperUser, caseId);
-});
-
-Before(async ({I}) => await I.navigateToCaseDetails(caseId));
+}
 
 Scenario('Gatekeeper notifies another gatekeeper with a link to the case', async ({I, caseViewPage, notifyGatekeeperEventPage}) => {
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.administrationActions.notifyGatekeeper);
   await notifyGatekeeperEventPage.enterEmail('gatekeeper@mailnesia.com');
   await I.completeEvent('Save and continue');
@@ -22,6 +21,7 @@ Scenario('Gatekeeper notifies another gatekeeper with a link to the case', async
 });
 
 Scenario('Gatekeeper adds allocated judge', async ({I, caseViewPage, allocatedJudgeEventPage}) => {
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.applicationActions.allocatedJudge);
   await allocatedJudgeEventPage.enterAllocatedJudge('Moley', 'moley@example.com');
   await I.completeEvent('Save and continue');
@@ -33,6 +33,7 @@ Scenario('Gatekeeper adds allocated judge', async ({I, caseViewPage, allocatedJu
 });
 
 Scenario('Gatekeeper make allocation decision based on proposal', async ({I, caseViewPage, enterAllocationDecisionEventPage}) => {
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.applicationActions.enterAllocationDecision);
   enterAllocationDecisionEventPage.selectCorrectLevelOfJudge('Yes');
   await I.completeEvent('Save and continue');
@@ -43,6 +44,7 @@ Scenario('Gatekeeper make allocation decision based on proposal', async ({I, cas
 });
 
 Scenario('Gatekeeper enters allocation decision', async ({I, caseViewPage, enterAllocationDecisionEventPage}) => {
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.applicationActions.enterAllocationDecision);
   enterAllocationDecisionEventPage.selectCorrectLevelOfJudge('No');
   await enterAllocationDecisionEventPage.selectAllocationDecision('Magistrate');
@@ -56,6 +58,7 @@ Scenario('Gatekeeper enters allocation decision', async ({I, caseViewPage, enter
 });
 
 Scenario('Gatekeeper drafts standard directions', async ({I, caseViewPage, draftStandardDirectionsEventPage}) => {
+  await setupScenario(I);
   const today = new Date();
   await caseViewPage.goToNewActions(config.administrationActions.draftStandardDirections);
   await draftStandardDirectionsEventPage.createSDOThroughService();
@@ -73,6 +76,7 @@ Scenario('Gatekeeper drafts standard directions', async ({I, caseViewPage, draft
 });
 
 Scenario('Gatekeeper submits final version of standard directions', async ({I, caseViewPage, draftStandardDirectionsEventPage}) => {
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.administrationActions.draftStandardDirections);
   await draftStandardDirectionsEventPage.enterDateOfIssue({day: 11, month: 1, year: 2020});
   draftStandardDirectionsEventPage.useAllocatedJudge('Bob Ross');

--- a/e2e/tests/gatekeepingOrderJourney_test.js
+++ b/e2e/tests/gatekeepingOrderJourney_test.js
@@ -7,14 +7,13 @@ let caseId;
 
 Feature('Gatekeeping judge SDO journey');
 
-BeforeSuite(async ({I}) => {
-  caseId = await I.submitNewCaseWithData(gatekeepingCaseData);
+async function setupScenario(I) {
+  if (!caseId) { caseId = await I.submitNewCaseWithData(gatekeepingCaseData); }
   await I.navigateToCaseDetailsAs(config.judicaryUser, caseId);
-});
-
-Before(async ({I}) => await I.navigateToCaseDetails(caseId));
+}
 
 Scenario('Gatekeeping judge drafts gatekeeping order', async ({I, caseViewPage, addGatekeepingOrderEventPage}) => {
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.administrationActions.addGatekeepingOrder);
   addGatekeepingOrderEventPage.createGatekeepingOrderThroughService();
   await I.runAccessibilityTest();
@@ -121,6 +120,7 @@ Scenario('Gatekeeping judge drafts gatekeeping order', async ({I, caseViewPage, 
 });
 
 Scenario('Gatekeeping judge adds allocated judge', async ({I, caseViewPage, allocatedJudgeEventPage}) => {
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.applicationActions.allocatedJudge);
   await allocatedJudgeEventPage.enterAllocatedJudge('Moley', 'moley@example.com');
   await I.completeEvent('Save and continue');
@@ -132,6 +132,7 @@ Scenario('Gatekeeping judge adds allocated judge', async ({I, caseViewPage, allo
 });
 
 Scenario('Gatekeeping judge seals gatekeeping order', async ({I, caseViewPage, addGatekeepingOrderEventPage}) => {
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.administrationActions.addGatekeepingOrder);
   await I.goToNextPage();
 

--- a/e2e/tests/hmctsAdministersCaseAfterSubmission_test.js
+++ b/e2e/tests/hmctsAdministersCaseAfterSubmission_test.js
@@ -21,13 +21,13 @@ let caseId;
 
 Feature('Case administration after submission');
 
-BeforeSuite(async ({I}) => {
-  caseId = await I.submitNewCaseWithData(mandatoryWithMultipleChildren);
-});
-
-Before(async ({I}) => await I.navigateToCaseDetailsAs(config.hmctsAdminUser, caseId));
+async function setupScenario(I) {
+  if (!caseId) { caseId = await I.submitNewCaseWithData(mandatoryWithMultipleChildren); }
+  await I.navigateToCaseDetailsAs(config.hmctsAdminUser, caseId);
+}
 
 Scenario('HMCTS admin enters FamilyMan reference number', async ({I, caseViewPage, enterFamilyManCaseNumberEventPage}) => {
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.administrationActions.addFamilyManCaseNumber);
   await enterFamilyManCaseNumberEventPage.enterCaseID('mockCaseID');
   await I.completeEvent('Save and continue');
@@ -36,6 +36,7 @@ Scenario('HMCTS admin enters FamilyMan reference number', async ({I, caseViewPag
 });
 
 Scenario('HMCTS admin amends children, respondents, others, international element, other proceedings and attending hearing', async ({I, caseViewPage, enterOtherProceedingsEventPage, enterChildrenEventPage}) => {
+  await setupScenario(I);
   const I_doEventAndCheckIfAppropriateSummaryAndDescriptionIsVisible = async (event, summary, description, I_doActionsOnEditPage = () => {}) => {
     await caseViewPage.goToNewActions(event);
     await I_doActionsOnEditPage();
@@ -64,6 +65,7 @@ Scenario('HMCTS admin amends children, respondents, others, international elemen
 });
 
 Scenario('HMCTS admin uploads additional applications to the case', async ({I, caseViewPage, uploadAdditionalApplicationsEventPage, paymentHistoryPage}) => {
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.administrationActions.uploadAdditionalApplications);
   uploadAdditionalApplicationsEventPage.selectAdditionalApplicationType('OTHER_ORDER');
   uploadAdditionalApplicationsEventPage.selectAdditionalApplicationType('C2_ORDER');
@@ -139,6 +141,7 @@ Scenario('HMCTS admin uploads additional applications to the case', async ({I, c
 });
 
 Scenario('HMCTS admin edits supporting evidence document on C2 application', async({I, caseViewPage, manageDocumentsEventPage}) => {
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.administrationActions.manageDocuments);
   await manageDocumentsEventPage.selectAdditionalApplicationsSupportingDocuments();
   await manageDocumentsEventPage.selectApplicationBundleFromDropdown(3);
@@ -155,6 +158,7 @@ Scenario('HMCTS admin edits supporting evidence document on C2 application', asy
 });
 
 Scenario('HMCTS admin edits supporting evidence document on Other application', async({I, caseViewPage, manageDocumentsEventPage}) => {
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.administrationActions.manageDocuments);
   await manageDocumentsEventPage.selectAdditionalApplicationsSupportingDocuments();
   await manageDocumentsEventPage.selectApplicationBundleFromDropdown(2);
@@ -174,6 +178,7 @@ Scenario('HMCTS admin share case with representatives', async ({I, caseViewPage,
   const representative1 = representatives.servedByDigitalService;
   const representative2 = representatives.servedByPost;
 
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.administrationActions.amendRepresentatives);
 
   await enterRepresentativesEventPage.enterRepresentative(representative1);
@@ -203,6 +208,7 @@ Scenario('HMCTS admin share case with representatives', async ({I, caseViewPage,
 });
 
 Scenario('HMCTS admin revoke case access from representative', async ({I, caseViewPage, caseListPage}) => {
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.administrationActions.amendRepresentatives);
 
   await I.removeElementFromCollection('Representatives');
@@ -216,39 +222,48 @@ Scenario('HMCTS admin revoke case access from representative', async ({I, caseVi
 });
 
 Scenario('HMCTS admin creates blank order', async ({I, caseViewPage, createOrderEventPage}) => {
+  await setupScenario(I);
   await verifyOrderCreation(I, caseViewPage, createOrderEventPage, blankOrder);
 }).retry(1); //Async case update in prev test
 
 Scenario('HMCTS admin creates interim supervision order', async ({I, caseViewPage, createOrderEventPage}) => {
+  await setupScenario(I);
   await verifyOrderCreation(I, caseViewPage, createOrderEventPage, interimSuperVisionOrder);
 }).retry(1); //Async case update in prev test
 
 Scenario('HMCTS admin creates final supervision order', async ({I, caseViewPage, createOrderEventPage}) => {
+  await setupScenario(I);
   await verifyOrderCreation(I, caseViewPage, createOrderEventPage, finalSuperVisionOrder);
 }).retry(1); //Async case update in prev test
 
 Scenario('HMCTS admin creates emergency protection order', async ({I, caseViewPage, createOrderEventPage}) => {
+  await setupScenario(I);
   await verifyOrderCreation(I, caseViewPage, createOrderEventPage, emergencyProtectionOrder);
 }).retry(1); //Async case update in prev test
 
 Scenario('HMCTS admin creates interim care order', async ({I, caseViewPage, createOrderEventPage}) => {
+  await setupScenario(I);
   await verifyOrderCreation(I, caseViewPage, createOrderEventPage, interimCareOrder);
 }).retry(1); //Async case update in prev test
 
 Scenario('HMCTS admin uploads order', async ({I, caseViewPage, createOrderEventPage}) => {
+  await setupScenario(I);
   await verifyOrderCreation(I, caseViewPage, createOrderEventPage, uploadedOrder);
 }).retry(1); //Async case update in prev test
 
 Scenario('HMCTS admin creates final care order', async ({I, caseViewPage, createOrderEventPage}) => {
+  await setupScenario(I);
   await verifyOrderCreation(I, caseViewPage, createOrderEventPage, finalCareOrder);
 }).retry(1); //Async case update in prev test
 
 Scenario('HMCTS admin creates discharge of care order', async ({I, caseViewPage, createOrderEventPage}) => {
+  await setupScenario(I);
   await verifyOrderCreation(I, caseViewPage, createOrderEventPage, dischargeOfCareOrder);
 }).retry(1); //Async case update in prev test
 
 // Disabled as part of FPLA-1754 - TBD if super user will have access to notice of proceedings event
 xScenario('HMCTS admin creates notice of proceedings documents', async (I, caseViewPage, createNoticeOfProceedingsEventPage) => {
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.administrationActions.createNoticeOfProceedings);
   await createNoticeOfProceedingsEventPage.checkC6();
   createNoticeOfProceedingsEventPage.checkC6A();
@@ -266,6 +281,7 @@ xScenario('HMCTS admin creates notice of proceedings documents', async (I, caseV
 
 // Disabled as part of FPLA-1754 - TBD if super user will have access to notice of proceedings event
 xScenario('HMCTS admin creates notice of proceedings documents with allocated judge', async (I, caseViewPage, createNoticeOfProceedingsEventPage) => {
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.administrationActions.createNoticeOfProceedings);
   await createNoticeOfProceedingsEventPage.checkC6();
   await createNoticeOfProceedingsEventPage.useAllocatedJudge();
@@ -286,6 +302,7 @@ xScenario('HMCTS admin creates notice of proceedings documents with allocated ju
 });
 
 Scenario('HMCTS admin handles supplementary evidence', async ({I, caseListPage, caseViewPage, handleSupplementaryEvidenceEventPage}) => {
+  await setupScenario(I);
   I.navigateToCaseList();
   await caseListPage.searchForCasesWithHandledEvidences(caseId);
   I.dontSeeCaseInSearchResult(caseId);
@@ -302,6 +319,7 @@ Scenario('HMCTS admin handles supplementary evidence', async ({I, caseListPage, 
 }).retry(1); //Async case update in prev test
 
 Scenario('HMCTS admin sends email to gatekeeper with a link to the case', async ({I, caseViewPage, sendCaseToGatekeeperEventPage}) => {
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.administrationActions.sendToGatekeeper);
   await sendCaseToGatekeeperEventPage.enterEmail();
   await I.addAnotherElementToCollection();
@@ -312,6 +330,7 @@ Scenario('HMCTS admin sends email to gatekeeper with a link to the case', async 
 
 Scenario('HMCTS admin adds a note to the case', async ({I, caseViewPage, addNoteEventPage}) => {
   const note = 'Example note';
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.administrationActions.addNote);
   await addNoteEventPage.addNote(note);
   await I.completeEvent('Save and continue');
@@ -321,6 +340,7 @@ Scenario('HMCTS admin adds a note to the case', async ({I, caseViewPage, addNote
 }).retry(1); // async processing in previous test
 
 Scenario('HMCTS admin adds expert report log', async ({I, caseViewPage, addExpertReportEventPage}) => {
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.administrationActions.addExpertReportLog);
   await addExpertReportEventPage.addExpertReportLog(expertReportLog[0]);
   await I.completeEvent('Save and continue');
@@ -333,6 +353,7 @@ Scenario('HMCTS admin adds expert report log', async ({I, caseViewPage, addExper
 }).retry(1);
 
 Scenario('HMCTS admin makes 26-week case extension', async ({I, caseViewPage, addExtend26WeekTimelineEventPage}) => {
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.applicationActions.extend26WeekTimeline);
   await addExtend26WeekTimelineEventPage.selectEightWeekExtensionTime();
   addExtend26WeekTimelineEventPage.selectTimetableForChildExtensionReason();
@@ -351,6 +372,7 @@ Scenario('HMCTS admin makes 26-week case extension', async ({I, caseViewPage, ad
 }).retry(1);
 
 Scenario('HMCTS admin closes the case', async ({I, caseViewPage, closeTheCaseEventPage}) => {
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.administrationActions.closeTheCase);
   await closeTheCaseEventPage.closeCase({day: 12, month: 3, year: 2020}, closeTheCaseEventPage.fields.reasons.deprivation);
   await I.completeEvent('Submit');

--- a/e2e/tests/hmctsSuperUserAdministersCase_test.js
+++ b/e2e/tests/hmctsSuperUserAdministersCase_test.js
@@ -7,12 +7,13 @@ let caseId;
 
 Feature('Case administration by super user');
 
-BeforeSuite(async ({I}) => {
-  caseId = await I.submitNewCaseWithData(caseManagementCaseData);
+async function setupScenario(I) {
+  if (!caseId) { caseId = await I.submitNewCaseWithData(caseManagementCaseData); }
   await I.navigateToCaseDetailsAs(config.hmctsSuperUser, caseId);
-});
+}
 
 Scenario('HMCTS super user updates FamilyMan reference number', async ({I, caseViewPage, enterFamilyManCaseNumberEventPage}) => {
+  await setupScenario(I);
   I.seeFamilyManNumber('mockcaseID');
 
   await caseViewPage.goToNewActions(config.administrationActions.addFamilyManCaseNumber);
@@ -24,7 +25,7 @@ Scenario('HMCTS super user updates FamilyMan reference number', async ({I, caseV
 });
 
 Scenario('HMCTS super user changes state from case management to final hearing', async ({I, caseViewPage, changeCaseStateEventPage}) => {
-  await I.navigateToCaseDetailsAs(config.hmctsSuperUser, caseId);
+  await setupScenario(I);
 
   await caseViewPage.goToNewActions(config.superUserActions.changeCaseState);
   await changeCaseStateEventPage.seeAsCurrentState('Case management');

--- a/e2e/tests/hmctsSuperUserRemovesOrders_test.js
+++ b/e2e/tests/hmctsSuperUserRemovesOrders_test.js
@@ -7,14 +7,13 @@ Feature('HMCTS super user removes orders');
 
 let caseId;
 
-BeforeSuite(async ({I}) => {
-  caseId = await I.submitNewCaseWithData(finalHearingCaseData);
+async function setupScenario(I) {
+  if (!caseId) { caseId = await I.submitNewCaseWithData(finalHearingCaseData); }
   await I.navigateToCaseDetailsAs(config.hmctsSuperUser, caseId);
-});
-
-Before(async ({I}) => await I.navigateToCaseDetails(caseId));
+}
 
 Scenario('HMCTS super user removes a generated order from a case', async ({I, caseViewPage, removeOrderEventPage}) => {
+  await setupScenario(I);
   const orderToRemove = finalHearingCaseData.caseData.orderCollection[0];
   const labelToSelect = `${orderToRemove.value.title} - ${orderToRemove.value.dateOfIssue}`;
 
@@ -30,6 +29,7 @@ Scenario('HMCTS super user removes a generated order from a case', async ({I, ca
 });
 
 Scenario('HMCTS super user removes a sealed cmo from a case', async ({I, caseViewPage, removeOrderEventPage}) => {
+  await setupScenario(I);
   const orderToRemove = finalHearingCaseData.caseData.sealedCMOs[0].value;
   const labelToSelect = 'Sealed case management order issued on ' + moment(orderToRemove.dateIssued).format('D MMMM YYYY');
 
@@ -46,6 +46,7 @@ Scenario('HMCTS super user removes a sealed cmo from a case', async ({I, caseVie
 });
 
 Scenario('HMCTS super user removes a sdo from a case', async ({I, caseViewPage, removeOrderEventPage}) => {
+  await setupScenario(I);
   const orderToRemove = finalHearingCaseData.caseData.standardDirectionOrder;
   const labelToSelect = `Gatekeeping order - ${moment(orderToRemove.dateOfIssue, 'DDMMMMY').format('D MMMM YYYY')}`;
 
@@ -59,6 +60,7 @@ Scenario('HMCTS super user removes a sdo from a case', async ({I, caseViewPage, 
 });
 
 Scenario('HMCTS super user removes a draft cmo from a case', async ({I, caseViewPage, removeOrderEventPage}) => {
+  await setupScenario(I);
   const orderToRemove = finalHearingCaseData.caseData.hearingOrdersBundlesDrafts[0].value.orders[0].value;
   const labelToSelect = 'Draft case management order sent on ' + moment(orderToRemove.dateSent).format('D MMMM YYYY');
 
@@ -71,6 +73,7 @@ Scenario('HMCTS super user removes a draft cmo from a case', async ({I, caseView
 });
 
 Scenario('HMCTS super user removes an agreed cmo from a case', async ({I, caseViewPage, removeOrderEventPage}) => {
+  await setupScenario(I);
   const orderToRemove = finalHearingCaseData.caseData.hearingOrdersBundlesDrafts[0].value.orders[0].value;
   const labelToSelect = 'Agreed case management order sent on ' + moment(orderToRemove.dateSent).format('D MMMM YYYY');
 
@@ -84,6 +87,7 @@ Scenario('HMCTS super user removes an agreed cmo from a case', async ({I, caseVi
 
 
 Scenario('HMCTS super user removes a draft order from a case', async ({I, caseViewPage, removeOrderEventPage}) => {
+  await setupScenario(I);
   const orderToRemove = finalHearingCaseData.caseData.hearingOrdersBundlesDrafts[0].value.orders[0].value;
   const labelToSelect = 'Draft order sent on ' + moment(orderToRemove.dateSent).format('D MMMM YYYY');
 

--- a/e2e/tests/localAuthorityCorrectsReturnedApplication_test.js
+++ b/e2e/tests/localAuthorityCorrectsReturnedApplication_test.js
@@ -7,11 +7,12 @@ let caseId;
 
 Feature('Local authority corrects returned application');
 
-BeforeSuite(async ({I}) => {
-  caseId = await I.submitNewCaseWithData(mandatorySubmissionWithApplicationDocuments);
-});
+async function setupScenario(I) {
+  if (!caseId) { caseId = await I.submitNewCaseWithData(mandatorySubmissionWithApplicationDocuments); }
+}
 
 Scenario('Admin returns application to the LA', async ({I, caseViewPage, returnApplicationEventPage}) => {
+  await setupScenario(I);
   await I.navigateToCaseDetailsAs(config.hmctsAdminUser, caseId);
 
   await caseViewPage.goToNewActions(config.administrationActions.returnApplication);
@@ -26,6 +27,7 @@ Scenario('LA makes corrections to the application', async ({I, caseViewPage, ent
   const now = new Date();
   const formattedDate = dateFormat(now, 'd mmmm yyyy');
 
+  await setupScenario(I);
   await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
 
   caseViewPage.selectTab(caseViewPage.tabs.viewApplication);

--- a/e2e/tests/localAuthorityDeletesApplication_test.js
+++ b/e2e/tests/localAuthorityDeletesApplication_test.js
@@ -5,12 +5,13 @@ let caseName;
 
 Feature('Local authority deletes application');
 
-BeforeSuite(async ({I}) => {
-  caseName = `Case ${new Date().toISOString()}`;
-  caseId = await I.submitNewCase(config.swanseaLocalAuthorityUserOne, caseName);
-});
+async function setupScenario(I) {
+  if (!caseName) { caseName = `Case ${new Date().toISOString()}`; }
+  if (!caseId) { caseId = await I.submitNewCase(config.swanseaLocalAuthorityUserOne, caseName); }
+}
 
 Scenario('local authority deletes application', async ({I, caseViewPage, deleteApplicationEventPage, caseListPage}) => {
+  await setupScenario(I);
   await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
   await caseViewPage.goToNewActions(config.applicationActions.deleteApplication);
   await deleteApplicationEventPage.tickDeletionConsent();

--- a/e2e/tests/localAuthorityMaintainsCaseAfterSubmission_test.js
+++ b/e2e/tests/localAuthorityMaintainsCaseAfterSubmission_test.js
@@ -8,14 +8,13 @@ let caseId;
 
 Feature('Case maintenance after submission');
 
-BeforeSuite(async ({I}) => {
-  caseId = await I.submitNewCaseWithData(mandatoryWithMultipleChildren);
-  await I.signIn(config.swanseaLocalAuthorityUserOne);
-});
-
-Before(async ({I}) => await I.navigateToCaseDetails(caseId));
+async function setupScenario(I) {
+  if (!caseId) { caseId = await I.submitNewCaseWithData(mandatoryWithMultipleChildren); }
+  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
+}
 
 Scenario('local authority add an external barrister as a legal representative for the case', async ({I, caseViewPage, manageLegalRepresentativesEventPage}) => {
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.applicationActions.manageLegalRepresentatives);
   await I.goToNextPage();
   await manageLegalRepresentativesEventPage.addLegalRepresentative(legalRepresentatives.barrister);
@@ -32,6 +31,7 @@ Scenario('local authority add an external barrister as a legal representative fo
 });
 
 Scenario('local authority update solicitor', async ({I, caseViewPage, enterApplicantEventPage}) => {
+  await setupScenario(I);
   const solicitorEmail = 'solicitor@test.com';
   await caseViewPage.goToNewActions(config.applicationActions.enterApplicant);
   await enterApplicantEventPage.enterSolicitorDetails({email: solicitorEmail});
@@ -42,6 +42,7 @@ Scenario('local authority update solicitor', async ({I, caseViewPage, enterAppli
 });
 
 Scenario('local authority provides a statements of service', async ({I, caseViewPage, addStatementOfServiceEventPage}) => {
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.administrationActions.addStatementOfService);
   await addStatementOfServiceEventPage.enterRecipientDetails(recipients[0]);
   await I.addAnotherElementToCollection();
@@ -80,6 +81,7 @@ Scenario('local authority provides a statements of service', async ({I, caseView
 });
 
 Scenario('local authority upload placement application', async ({I, caseViewPage, placementEventPage}) => {
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.administrationActions.placement);
   await placementEventPage.selectChild('Timothy Jones');
   await placementEventPage.addApplication(config.testFile);

--- a/e2e/tests/localAuthoritySubmitsApplication_test.js
+++ b/e2e/tests/localAuthoritySubmitsApplication_test.js
@@ -12,10 +12,13 @@ let caseId;
 
 Feature('Local authority creates application');
 
-BeforeSuite(async ({I}) => caseId = await I.submitNewCase(config.swanseaLocalAuthorityUserOne));
+async function setupScenario(I) {
+  if (!caseId) { caseId = await I.submitNewCase(config.swanseaLocalAuthorityUserOne); }
+  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
+}
 
 Scenario('local authority sees task list', async ({I, caseViewPage}) => {
-  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
+  await setupScenario(I);
   caseViewPage.selectTab(caseViewPage.tabs.startApplication);
 
   await caseViewPage.checkTaskIsFinished(config.applicationActions.changeCaseName);
@@ -47,7 +50,7 @@ Scenario('local authority sees task list', async ({I, caseViewPage}) => {
 });
 
 Scenario('local authority changes case name @create-case-with-mandatory-sections-only @cross-browser', async ({I, caseViewPage, changeCaseNameEventPage}) => {
-  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.applicationActions.changeCaseName);
   await changeCaseNameEventPage.changeCaseName('New case name');
   await I.seeCheckAnswersAndCompleteEvent('Save and continue');
@@ -63,7 +66,7 @@ Scenario('local authority changes case name @create-case-with-mandatory-sections
 });
 
 Scenario('local authority enters orders and directions @create-case-with-mandatory-sections-only @cross-browser', async ({I, caseViewPage, enterOrdersAndDirectionsNeededEventPage}) => {
-  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.applicationActions.enterOrdersAndDirectionsNeeded);
   await enterOrdersAndDirectionsNeededEventPage.checkCareOrder();
   enterOrdersAndDirectionsNeededEventPage.checkInterimCareOrder();
@@ -119,7 +122,7 @@ Scenario('local authority enters orders and directions @create-case-with-mandato
 });
 
 Scenario('local authority enters hearing @create-case-with-mandatory-sections-only @cross-browser', async ({I, caseViewPage, enterHearingNeededEventPage}) => {
-  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.applicationActions.enterHearingNeeded);
   await enterHearingNeededEventPage.enterTimeFrame();
   enterHearingNeededEventPage.enterHearingType();
@@ -152,7 +155,7 @@ Scenario('local authority enters hearing @create-case-with-mandatory-sections-on
 
 
 Scenario('local authority enters children @create-case-with-mandatory-sections-only @cross-browser', async ({I, caseViewPage, enterChildrenEventPage}) => {
-  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.applicationActions.enterChildren);
   await enterChildrenEventPage.enterChildDetails('Bran', 'Stark', '01', '08', '2015');
   await enterChildrenEventPage.defineChildSituation('01', '11', '2017');
@@ -247,7 +250,7 @@ Scenario('local authority enters children @create-case-with-mandatory-sections-o
 });
 
 Scenario('local authority enters respondents @create-case-with-mandatory-sections-only', async ({I, caseViewPage, enterRespondentsEventPage}) => {
-  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.applicationActions.enterRespondents);
   await enterRespondentsEventPage.enterRespondent(respondents[0]);
   await enterRespondentsEventPage.enterContactDetailsHidden('No', 'mock reason');
@@ -348,7 +351,7 @@ Scenario('local authority enters respondents @create-case-with-mandatory-section
 });
 
 Scenario('local authority enters applicant @create-case-with-mandatory-sections-only', async ({I, caseViewPage, enterApplicantEventPage}) => {
-  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.applicationActions.enterApplicant);
   await enterApplicantEventPage.enterApplicantDetails(applicant);
   await enterApplicantEventPage.enterSolicitorDetails(solicitor);
@@ -389,7 +392,7 @@ Scenario('local authority enters applicant @create-case-with-mandatory-sections-
 });
 
 Scenario('local authority enters others to be given notice', async ({I, caseViewPage, enterOthersEventPage}) => {
-  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.applicationActions.enterOthers);
   await enterOthersEventPage.enterOtherDetails(others[0]);
   await enterOthersEventPage.enterRelationshipToChild('Tim Smith');
@@ -446,7 +449,7 @@ Scenario('local authority enters others to be given notice', async ({I, caseView
 });
 
 Scenario('local authority enters grounds for application @create-case-with-mandatory-sections-only', async ({I, caseViewPage, enterGroundsForApplicationEventPage}) => {
-  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.applicationActions.enterGrounds);
   await enterGroundsForApplicationEventPage.enterThresholdCriteriaDetails();
   await enterGroundsForApplicationEventPage.enterGroundsForEmergencyProtectionOrder();
@@ -466,7 +469,7 @@ Scenario('local authority enters grounds for application @create-case-with-manda
 });
 
 Scenario('local authority enters risk and harm to children', async ({I, caseViewPage, enterRiskAndHarmToChildrenEventPage}) => {
-  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.applicationActions.enterRiskAndHarmToChildren);
   await enterRiskAndHarmToChildrenEventPage.completePhysicalHarm();
   enterRiskAndHarmToChildrenEventPage.completeEmotionalHarm();
@@ -490,7 +493,7 @@ Scenario('local authority enters risk and harm to children', async ({I, caseView
 });
 
 Scenario('local authority enters factors affecting parenting', async ({I, caseViewPage, enterFactorsAffectingParentingEventPage}) => {
-  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.applicationActions.enterFactorsAffectingParenting);
   await enterFactorsAffectingParentingEventPage.completeAlcoholOrDrugAbuse();
   enterFactorsAffectingParentingEventPage.completeDomesticViolence();
@@ -513,7 +516,7 @@ Scenario('local authority enters factors affecting parenting', async ({I, caseVi
 });
 
 Scenario('local authority enters international element', async ({I, caseViewPage, enterInternationalElementEventPage}) => {
-  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.applicationActions.enterInternationalElement);
   await enterInternationalElementEventPage.fillForm();
   await I.seeCheckAnswersAndCompleteEvent('Save and continue');
@@ -537,7 +540,7 @@ Scenario('local authority enters international element', async ({I, caseViewPage
 });
 
 Scenario('local authority enters other proceedings', async ({I, caseViewPage, enterOtherProceedingsEventPage}) => {
-  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.applicationActions.enterOtherProceedings);
   enterOtherProceedingsEventPage.selectYesForProceeding();
   await enterOtherProceedingsEventPage.enterProceedingInformation(otherProceedings[0]);
@@ -574,7 +577,7 @@ Scenario('local authority enters other proceedings', async ({I, caseViewPage, en
 });
 
 Scenario('local authority enters allocation proposal @create-case-with-mandatory-sections-only', async ({I, caseViewPage, enterAllocationProposalEventPage}) => {
-  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.applicationActions.enterAllocationProposal);
   await enterAllocationProposalEventPage.selectAllocationProposal('Magistrate');
   await enterAllocationProposalEventPage.enterProposalReason('test');
@@ -589,7 +592,7 @@ Scenario('local authority enters allocation proposal @create-case-with-mandatory
 });
 
 Scenario('local authority enters attending hearing', async ({I, caseViewPage, enterAttendingHearingEventPage}) => {
-  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.applicationActions.enterAttendingHearing);
   await enterAttendingHearingEventPage.enterInterpreter();
   enterAttendingHearingEventPage.enterWelshProceedings();
@@ -618,7 +621,7 @@ Scenario('local authority enters attending hearing', async ({I, caseViewPage, en
 });
 
 Scenario('local authority adds multiple application documents @cross-browser', async ({I, caseViewPage, addApplicationDocumentsEventPage}) => {
-  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
+  await setupScenario(I);
   const browser = await I.getBrowser();
   // Both edge and safari fail to upload files in Saucelabs. Excluded for now.
   if (browser !== 'MicrosoftEdge' && browser !== 'safari') {
@@ -651,7 +654,7 @@ Scenario('local authority adds multiple application documents @cross-browser', a
 let feeToPay = '2055'; //Need to remember this between tests.. default in case the test below fails
 
 Scenario('local authority submits application @create-case-with-mandatory-sections-only', async ({I, caseViewPage, submitApplicationEventPage}) => {
-  await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
+  await setupScenario(I);
   await caseViewPage.selectTab(caseViewPage.tabs.startApplication);
   await caseViewPage.startTask(config.applicationActions.submitCase);
 
@@ -666,6 +669,7 @@ Scenario('local authority submits application @create-case-with-mandatory-sectio
 });
 
 Scenario('HMCTS admin check the payment', async ({I, caseViewPage, paymentHistoryPage}) => {
+  await setupScenario(I);
   await I.navigateToCaseDetailsAs(config.hmctsAdminUser, caseId);
   caseViewPage.selectTab(caseViewPage.tabs.paymentHistory);
   await paymentHistoryPage.checkPayment(feeToPay, applicant.pbaNumber);

--- a/e2e/tests/manageDocuments_test.js
+++ b/e2e/tests/manageDocuments_test.js
@@ -15,13 +15,16 @@ let submittedAt;
 
 Feature('Manage documents');
 
-BeforeSuite(async ({I}) => {
-  caseId = await I.submitNewCaseWithData(mandatoryWithMultipleChildren);
-  await api.grantCaseAccess(caseId, config.hillingdonLocalAuthorityUserOne, '[SOLICITOR]');
-});
+async function setupScenario(I) {
+  if (!caseId) {
+    caseId = await I.submitNewCaseWithData(mandatoryWithMultipleChildren);
+    await api.grantCaseAccess(caseId, config.hillingdonLocalAuthorityUserOne, '[SOLICITOR]');
+  }
+  await I.navigateToCaseDetailsAs(config.hmctsAdminUser, caseId);
+}
 
 Scenario('HMCTS Admin and LA upload confidential and non confidential further evidence documents', async ({I, caseViewPage, manageDocumentsEventPage, manageDocumentsLAEventPage}) => {
-  await I.navigateToCaseDetailsAs(config.hmctsAdminUser, caseId);
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.applicationActions.manageDocumentsLA);
 
   manageDocumentsEventPage.selectFurtherEvidence();
@@ -77,7 +80,7 @@ Scenario('HMCTS Admin and LA upload confidential and non confidential further ev
 });
 
 Scenario('HMCTS Admin and LA upload confidential and non confidential respondent statement', async ({I, caseViewPage, manageDocumentsEventPage, manageDocumentsLAEventPage}) => {
-  await I.navigateToCaseDetailsAs(config.hmctsAdminUser, caseId);
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.administrationActions.manageDocuments);
 
   manageDocumentsEventPage.selectFurtherEvidence();
@@ -151,7 +154,7 @@ Scenario('HMCTS Admin and LA upload confidential and non confidential respondent
 });
 
 Scenario('HMCTS Admin and LA upload confidential and non confidential correspondence documents', async ({I, caseViewPage, manageDocumentsEventPage, manageDocumentsLAEventPage}) => {
-  await I.navigateToCaseDetailsAs(config.hmctsAdminUser, caseId);
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.applicationActions.manageDocumentsLA);
 
   manageDocumentsEventPage.selectCorrespondence();
@@ -192,7 +195,7 @@ Scenario('HMCTS Admin and LA upload confidential and non confidential correspond
 });
 
 Scenario('HMCTS Admin and LA upload confidential C2 supporting documents', async ({I, caseViewPage, manageDocumentsEventPage, manageDocumentsLAEventPage, uploadAdditionalApplicationsEventPage}) => {
-  await I.navigateToCaseDetailsAs(config.hmctsAdminUser, caseId);
+  await setupScenario(I);
   await manageDocumentsForLAHelper.uploadC2(I, caseViewPage, uploadAdditionalApplicationsEventPage);
   await caseViewPage.goToNewActions(config.applicationActions.manageDocumentsLA);
 
@@ -243,7 +246,7 @@ Scenario('HMCTS Admin and LA upload confidential C2 supporting documents', async
 });
 
 Scenario('HMCTS Admin and LA upload confidential Other applications supporting documents', async ({I, caseViewPage, manageDocumentsEventPage, manageDocumentsLAEventPage, uploadAdditionalApplicationsEventPage}) => {
-  await I.navigateToCaseDetailsAs(config.hmctsAdminUser, caseId);
+  await setupScenario(I);
   await manageDocumentsForLAHelper.uploadOtherApplications(I, caseViewPage, uploadAdditionalApplicationsEventPage);
   await caseViewPage.goToNewActions(config.applicationActions.manageDocumentsLA);
 

--- a/e2e/tests/messageJudge_test.js
+++ b/e2e/tests/messageJudge_test.js
@@ -7,11 +7,12 @@ let reply = 'This is a reply';
 
 Feature('Message judge or legal adviser');
 
-BeforeSuite(async ({I}) => {
-  caseId = await I.submitNewCaseWithData(mandatoryWithAdditionalApplicationsBundle);
-});
+async function setupScenario(I) {
+  if (!caseId) { caseId = await I.submitNewCaseWithData(mandatoryWithAdditionalApplicationsBundle); }
+}
 
 Scenario('HMCTS admin messages the judge @cross-browser', async ({I, caseViewPage, messageJudgeOrLegalAdviserEventPage}) => {
+  await setupScenario(I);
   await I.navigateToCaseDetailsAs(config.hmctsAdminUser, caseId);
   await caseViewPage.goToNewActions(config.applicationActions.messageJudge);
   messageJudgeOrLegalAdviserEventPage.selectMessageRelatedToAdditionalApplication();
@@ -35,6 +36,7 @@ Scenario('HMCTS admin messages the judge @cross-browser', async ({I, caseViewPag
 });
 
 Scenario('Judge replies to HMCTS admin', async ({I, caseViewPage, messageJudgeOrLegalAdviserEventPage}) => {
+  await setupScenario(I);
   await I.navigateToCaseDetailsAs(config.judicaryUser, caseId);
   await caseViewPage.goToNewActions(config.applicationActions.messageJudge);
   messageJudgeOrLegalAdviserEventPage.selectReplyToMessage();
@@ -56,6 +58,7 @@ Scenario('Judge replies to HMCTS admin', async ({I, caseViewPage, messageJudgeOr
 });
 
 Scenario('HMCTS admin closes the message', async ({I, caseViewPage, messageJudgeOrLegalAdviserEventPage}) => {
+  await setupScenario(I);
   await I.navigateToCaseDetailsAs(config.hmctsAdminUser, caseId);
   await caseViewPage.goToNewActions(config.applicationActions.messageJudge);
   messageJudgeOrLegalAdviserEventPage.selectReplyToMessage();
@@ -77,6 +80,7 @@ Scenario('HMCTS admin closes the message', async ({I, caseViewPage, messageJudge
 });
 
 Scenario('Judge messages court admin', async ({I, caseViewPage, messageJudgeOrLegalAdviserEventPage}) => {
+  await setupScenario(I);
   await I.navigateToCaseDetailsAs(config.judicaryUser, caseId);
 
   await caseViewPage.goToNewActions(config.applicationActions.messageJudge);

--- a/e2e/tests/noticeOfChange_test.js
+++ b/e2e/tests/noticeOfChange_test.js
@@ -11,16 +11,6 @@ let caseId;
 
 Feature('Notice of change');
 
-BeforeSuite(async ({I}) => {
-  caseId = await I.submitNewCaseWithData(mandatoryWithMultipleRespondents);
-  solicitor1.details = await apiHelper.getUser(solicitor1);
-  solicitor1.details.organisation = 'Private solicitors';
-  solicitor2.details = await apiHelper.getUser(solicitor2);
-  solicitor2.details.organisation = 'London Borough Hillingdon';
-  solicitor3.details = await apiHelper.getUser(solicitor3);
-  solicitor3.details.organisation = 'Wiltshire County Council';
-});
-
 async function setupScenario(I) {
   if (!caseId) { caseId = await I.submitNewCaseWithData(mandatoryWithMultipleRespondents); }
   if (!solicitor1.details) {

--- a/e2e/tests/noticeOfChange_test.js
+++ b/e2e/tests/noticeOfChange_test.js
@@ -21,7 +21,24 @@ BeforeSuite(async ({I}) => {
   solicitor3.details.organisation = 'Wiltshire County Council';
 });
 
+async function setupScenario(I) {
+  if (!caseId) { caseId = await I.submitNewCaseWithData(mandatoryWithMultipleRespondents); }
+  if (!solicitor1.details) {
+    solicitor1.details = await apiHelper.getUser(solicitor1);
+    solicitor1.details.organisation = 'Private solicitors';
+  }
+  if (!solicitor2.details) {
+    solicitor2.details = await apiHelper.getUser(solicitor2);
+    solicitor2.details.organisation = 'London Borough Hillingdon';
+  }
+  if (!solicitor3.details) {
+    solicitor3.details = await apiHelper.getUser(solicitor3);
+    solicitor3.details.organisation = 'Wiltshire County Council';
+  }
+}
+
 Scenario('Solicitor can request representation only after case submission', async ({I, caseListPage, caseViewPage, submitApplicationEventPage, noticeOfChangePage}) => {
+  await setupScenario(I);
   await I.signIn(solicitor1);
   caseListPage.verifyCaseIsNotAccessible(caseId);
 
@@ -46,6 +63,7 @@ Scenario('Solicitor can request representation only after case submission', asyn
 });
 
 Scenario('Solicitor request representation of second unrepresented respondent', async ({I, caseListPage, caseViewPage, noticeOfChangePage}) => {
+  await setupScenario(I);
   await I.signIn(solicitor2);
   caseListPage.verifyCaseIsNotAccessible(caseId);
 
@@ -58,6 +76,7 @@ Scenario('Solicitor request representation of second unrepresented respondent', 
 });
 
 Scenario('Solicitor request representation of represented respondent', async ({I, caseListPage, caseViewPage, noticeOfChangePage}) => {
+  await setupScenario(I);
   await I.signIn(solicitor3);
   caseListPage.verifyCaseIsNotAccessible(caseId);
 
@@ -73,6 +92,7 @@ Scenario('Solicitor request representation of represented respondent', async ({I
 });
 
 Scenario('Hmcts admin replaces respondent solicitor', async ({I, caseListPage, caseViewPage, enterRespondentsEventPage}) => {
+  await setupScenario(I);
   await I.navigateToCaseDetailsAs(config.hmctsAdminUser, caseId);
   await caseViewPage.goToNewActions(config.administrationActions.amendRespondents);
 
@@ -88,6 +108,7 @@ Scenario('Hmcts admin replaces respondent solicitor', async ({I, caseListPage, c
 });
 
 Scenario('Hmcts admin removes respondent solicitor', async ({I, caseListPage, caseViewPage, enterRespondentsEventPage}) => {
+  await setupScenario(I);
   await I.navigateToCaseDetailsAs(config.hmctsAdminUser, caseId);
   await caseViewPage.goToNewActions(config.administrationActions.amendRespondents);
 

--- a/e2e/tests/uploadDraftOrders_test.js
+++ b/e2e/tests/uploadDraftOrders_test.js
@@ -44,14 +44,16 @@ let date;
 
 Feature('Upload Draft Orders Journey');
 
-BeforeSuite(async ({I}) => {
-  caseId = await I.submitNewCaseWithData(standardDirectionOrder);
-  today = new Date();
-  date = dateFormat(today, 'd mmm yyyy');
-});
+async function setupScenario(I) {
+  if (!caseId) {
+    caseId = await I.submitNewCaseWithData(standardDirectionOrder);
+    today = new Date();
+    date = dateFormat(today, 'd mmm yyyy');
+  }
+}
 
 Scenario('Local authority uploads draft orders', async ({I, caseViewPage, uploadCaseManagementOrderEventPage}) => {
-
+  await setupScenario(I);
   await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
 
   await draftOrdersHelper.localAuthoritySendsAgreedCmo(I, caseViewPage, uploadCaseManagementOrderEventPage, hearing1,null, draftOrder1);
@@ -79,6 +81,7 @@ Scenario('Local authority uploads draft orders', async ({I, caseViewPage, upload
 });
 
 Scenario('Respondent solicitor uploads draft orders', async ({I, caseViewPage, enterRepresentativesEventPage, uploadCaseManagementOrderEventPage}) => {
+  await setupScenario(I);
   await I.navigateToCaseDetailsAs(config.hmctsAdminUser, caseId);
 
   const representative = representatives.servedByDigitalService;
@@ -100,6 +103,7 @@ Scenario('Respondent solicitor uploads draft orders', async ({I, caseViewPage, e
 });
 
 Scenario('Judge makes changes to agreed CMO and seals', async ({I, caseViewPage, reviewAgreedCaseManagementOrderEventPage}) => {
+  await setupScenario(I);
   await I.navigateToCaseDetailsAs(config.judicaryUser, caseId);
 
   await caseViewPage.goToNewActions(config.applicationActions.approveOrders);
@@ -119,6 +123,7 @@ Scenario('Judge makes changes to agreed CMO and seals', async ({I, caseViewPage,
 });
 
 Scenario('Judge sends draft orders to the local authority', async ({I, caseViewPage, reviewAgreedCaseManagementOrderEventPage}) => {
+  await setupScenario(I);
   await I.navigateToCaseDetailsAs(config.judicaryUser, caseId);
 
   caseViewPage.selectTab(caseViewPage.tabs.draftOrders);
@@ -142,6 +147,7 @@ Scenario('Judge sends draft orders to the local authority', async ({I, caseViewP
 });
 
 Scenario('Local authority makes changes requested by the judge', async ({I, caseViewPage, uploadCaseManagementOrderEventPage}) => {
+  await setupScenario(I);
   await I.navigateToCaseDetailsAs(config.swanseaLocalAuthorityUserOne, caseId);
 
   caseViewPage.selectTab(caseViewPage.tabs.draftOrders);
@@ -163,6 +169,7 @@ Scenario('Local authority makes changes requested by the judge', async ({I, case
 });
 
 Scenario('Judge seals and sends draft orders for no hearing to parties', async ({I, caseViewPage, reviewAgreedCaseManagementOrderEventPage}) => {
+  await setupScenario(I);
   await I.navigateToCaseDetailsAs(config.judicaryUser, caseId);
 
   await caseViewPage.goToNewActions(config.applicationActions.approveOrders);
@@ -184,6 +191,7 @@ Scenario('Judge seals and sends draft orders for no hearing to parties', async (
 });
 
 Scenario('Judge seals and sends draft orders for hearing to parties', async ({I, caseViewPage, reviewAgreedCaseManagementOrderEventPage}) => {
+  await setupScenario(I);
   await I.navigateToCaseDetailsAs(config.judicaryUser, caseId);
 
   await caseViewPage.goToNewActions(config.applicationActions.approveOrders);

--- a/e2e/tests/urgentAndUploadSDO_test.js
+++ b/e2e/tests/urgentAndUploadSDO_test.js
@@ -6,13 +6,13 @@ let caseId;
 
 Feature('Alternate gatekeeping order route');
 
-BeforeSuite(async ({I}) => {
-  caseId = await I.submitNewCaseWithData(gatekeeping);
-
+async function setupScenario(I) {
+  if (!caseId) { caseId = await I.submitNewCaseWithData(gatekeeping); }
   await I.navigateToCaseDetailsAs(config.gateKeeperUser, caseId);
-});
+}
 
 Scenario('Gatekeeper uploads urgent hearing order', async ({I, caseViewPage, draftStandardDirectionsEventPage}) => {
+  await setupScenario(I);
   const allocationDecisionFields = draftStandardDirectionsEventPage.fields.allocationDecision;
   await caseViewPage.goToNewActions(config.administrationActions.draftStandardDirections);
   await draftStandardDirectionsEventPage.createUrgentHearingOrder();
@@ -35,6 +35,7 @@ Scenario('Gatekeeper uploads urgent hearing order', async ({I, caseViewPage, dra
 });
 
 Scenario('Gatekeeper uploads draft standard directions', async ({I, caseViewPage, draftStandardDirectionsEventPage}) => {
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.administrationActions.draftStandardDirections);
   await draftStandardDirectionsEventPage.createSDOThroughUpload();
   await draftStandardDirectionsEventPage.useAllocatedJudge('Bob Ross');
@@ -51,6 +52,7 @@ Scenario('Gatekeeper uploads draft standard directions', async ({I, caseViewPage
 });
 
 Scenario('Gatekeeper uploads final standard directions', async ({I, caseViewPage, draftStandardDirectionsEventPage}) => {
+  await setupScenario(I);
   await caseViewPage.goToNewActions(config.administrationActions.draftStandardDirections);
   await draftStandardDirectionsEventPage.useAllocatedJudge('Bob Ross');
   await I.goToNextPage();

--- a/saucelabs.conf.js
+++ b/saucelabs.conf.js
@@ -3,7 +3,7 @@
 const supportedBrowsers = require('./e2e/crossbrowser/supportedBrowsers.js');
 const testConfig = require('./e2e/config');
 
-const waitForTimeout = parseInt(process.env.WAIT_FOR_TIMEOUT) || 45000;
+const waitForTimeout = parseInt(process.env.WAIT_FOR_TIMEOUT) || 30000;
 const smartWait = parseInt(process.env.SMART_WAIT) || 30000;
 const browser = process.env.SAUCELABS_BROWSER || 'chrome';
 const defaultSauceOptions = {

--- a/saucelabs.conf.js
+++ b/saucelabs.conf.js
@@ -11,8 +11,6 @@ const defaultSauceOptions = {
   accessKey: process.env.SAUCE_ACCESS_KEY,
   tunnelIdentifier: process.env.TUNNEL_IDENTIFIER || 'reformtunnel',
   acceptSslCerts: true,
-  extendedDebugging: true,
-  capturePerformance: true,
   tags: ['FPL'],
   maxDuration: 3000,
 };

--- a/saucelabs.conf.js
+++ b/saucelabs.conf.js
@@ -11,6 +11,8 @@ const defaultSauceOptions = {
   accessKey: process.env.SAUCE_ACCESS_KEY,
   tunnelIdentifier: process.env.TUNNEL_IDENTIFIER || 'reformtunnel',
   acceptSslCerts: true,
+  extendedDebugging: true,
+  capturePerformance: true,
   tags: ['FPL'],
   maxDuration: 3000,
 };


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FPLA-3172

### Change description ###

Move e2e Before() and BeforeSuite() steps into Scenarios because Codecept doesn't retry failures in either stage, so known flakiness in AAT can't be worked around, which results in build failures unrelated to FPLA code.

Also includes a change to reduce the cross-browser test `WAIT_FOR_TIMEOUT` to help avoid hitting Saucelabs `maxDuration` threshold, since steps get retried and so can end up waiting for minutes.

![image](https://user-images.githubusercontent.com/11600884/123674577-aea95300-d839-11eb-86ea-fdf95479fe04.png)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
