### PR TITLE
Fix: Nightly security scan stage

### DIFF
--- a/security.sh
+++ b/security.sh
@@ -3,11 +3,13 @@
 export LC_ALL=C.UTF-8
 export LANG=C.UTF-8
 export PYTHONDONTWRITEBYTECODE=1
-
 zap-api-scan.py -t ${URL_FOR_SECURITY_SCAN}/v2/api-docs -f openapi -S -d -u ${SECURITY_RULES} -P 1001 -l FAIL --hook=zap_hooks.py
-cat zap.out
 curl --fail http://0.0.0.0:1001/OTHER/core/other/jsonreport/?formMethod=GET --output report.json
+
+export LC_ALL=C.UTF-8
+export LANG=C.UTF-8
+export PYTHONDONTWRITEBYTECODE=1
 zap-cli --zap-url http://0.0.0.0 -p 1001 report -o api-report.html -f html
+zap-cli --zap-url http://0.0.0.0 -p 1001 alerts -l Informational --exit-code False
 cp report.json functional-output/
 cp api-report.html functional-output/
-zap-cli --zap-url http://0.0.0.0 -p 1001 alerts -l Informational --exit-code False

--- a/security.sh
+++ b/security.sh
@@ -7,9 +7,12 @@ zap-api-scan.py -t ${URL_FOR_SECURITY_SCAN}/v2/api-docs -f openapi -S -d -u ${SE
 cat zap.out
 curl --fail http://0.0.0.0:1001/OTHER/core/other/jsonreport/?formMethod=GET --output report.json
 
-export LC_ALL=C.UTF-8
-export LANG=C.UTF-8
-export PYTHONDONTWRITEBYTECODE=1
+#export LC_ALL=C.UTF-8
+#export LANG=C.UTF-8
+#export PYTHONDONTWRITEBYTECODE=1
+echo "LC_ALL = ${LC_ALL}"
+echo "LANG = ${LANG}"
+echo "PYTHONDONTWRITEBYTECODE = ${PYTHONDONTWRITEBYTECODE}"
 zap-cli --zap-url http://0.0.0.0 -p 1001 report -o api-report.html -f html
 zap-cli --zap-url http://0.0.0.0 -p 1001 alerts -l Informational --exit-code False
 cp report.json functional-output/

--- a/security.sh
+++ b/security.sh
@@ -4,6 +4,7 @@ export LC_ALL=C.UTF-8
 export LANG=C.UTF-8
 export PYTHONDONTWRITEBYTECODE=1
 zap-api-scan.py -t ${URL_FOR_SECURITY_SCAN}/v2/api-docs -f openapi -S -d -u ${SECURITY_RULES} -P 1001 -l FAIL --hook=zap_hooks.py
+cat zap.out
 curl --fail http://0.0.0.0:1001/OTHER/core/other/jsonreport/?formMethod=GET --output report.json
 
 export LC_ALL=C.UTF-8

--- a/security.sh
+++ b/security.sh
@@ -7,12 +7,9 @@ zap-api-scan.py -t ${URL_FOR_SECURITY_SCAN}/v2/api-docs -f openapi -S -d -u ${SE
 cat zap.out
 curl --fail http://0.0.0.0:1001/OTHER/core/other/jsonreport/?formMethod=GET --output report.json
 
-#export LC_ALL=C.UTF-8
-#export LANG=C.UTF-8
-#export PYTHONDONTWRITEBYTECODE=1
-echo "LC_ALL = ${LC_ALL}"
-echo "LANG = ${LANG}"
-echo "PYTHONDONTWRITEBYTECODE = ${PYTHONDONTWRITEBYTECODE}"
+echo "LC_ALL: ${LC_ALL}"
+echo "LANG: ${LANG}"
+echo "PYTHONDONTWRITEBYTECODE: ${PYTHONDONTWRITEBYTECODE}"
 zap-cli --zap-url http://0.0.0.0 -p 1001 report -o api-report.html -f html
 zap-cli --zap-url http://0.0.0.0 -p 1001 alerts -l Informational --exit-code False
 cp report.json functional-output/


### PR DESCRIPTION
### JIRA link (if applicable) ###

n/a

### Change description ###

The Security Scan step in the nightly pipeline fails since the new ZAP version was updated to Docker, apparently due to the ordering of some of the calls. To solve this it was suggested to move the `zap-cli` calls above the copy calls as there's an issue where the env vars can be lost after something like a copy or mkdir call.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
