### PR TITLE
fix: flip condition that is causing NPE after EXUI release (FPLA-3193)

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/ManageHearingsService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/ManageHearingsService.java
@@ -249,7 +249,7 @@ public class ManageHearingsService {
 
     public void findAndSetPreviousVenueId(CaseData caseData) {
         if (isNotEmpty(caseData.getHearingDetails()) && caseData.getPreviousHearingVenue() != null
-            && caseData.getPreviousHearingVenue().getUsePreviousVenue().equals(YES.getValue())) {
+            && YES.getValue().equals(caseData.getPreviousHearingVenue().getUsePreviousVenue())) {
 
             PreviousHearingVenue previousVenueForEditedHearing = caseData.getPreviousHearingVenue();
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FPLA-3193

### Change description ###

PreviousHearingVenue complex type was presumably null before XUI release 22.1, now it is an empty object which is causing our if statement to throw NPE

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
