### PR TITLE
refactor(FPLA-2416): Making close case logic more genenic so that I c…

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/GeneratedOrderController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/GeneratedOrderController.java
@@ -332,12 +332,13 @@ public class GeneratedOrderController extends CallbackController {
     }
 
     private List<Element<Child>> getUpdatedChildren(CaseData caseData) {
+        List<Element<Child>> childrenToIssueFinalOrder =
+            childrenService.getSelectedChildrenForIssuingFinalOrder(caseData);
         return childrenService.updateFinalOrderIssued(
             caseData.getOrderTypeAndDocument().getTypeLabel(),
             caseData.getAllChildren(),
             caseData.getOrderAppliesToAllChildren(),
-            caseData.getChildSelector(),
-            caseData.getRemainingChildIndex()
+            childrenToIssueFinalOrder
         );
     }
 }


### PR DESCRIPTION
…an more easily implement it with Smart selector that chooses between single- or multi-selection children component.

This component is coming on PR https://github.com/hmcts/fpl-ccd-configuration/pull/2831

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
