### PR TITLE
fix: Cannot add hearing in a past (FPLA-3214)

### DIFF
--- a/ccd-definition/AuthorisationCaseField/CareSupervision/court-admin.json
+++ b/ccd-definition/AuthorisationCaseField/CareSupervision/court-admin.json
@@ -375,7 +375,7 @@
     "CaseTypeID": "CARE_SUPERVISION_EPO",
     "CaseFieldID": "hearingOption",
     "UserRole": "caseworker-publiclaw-courtadmin",
-    "CRUD": "CRU"
+    "CRUD": "CRUD"
   },
   {
     "LiveFrom": "01/01/2017",

--- a/ccd-definition/AuthorisationCaseField/CareSupervision/gatekeeper.json
+++ b/ccd-definition/AuthorisationCaseField/CareSupervision/gatekeeper.json
@@ -1215,7 +1215,7 @@
     "CaseTypeID": "CARE_SUPERVISION_EPO",
     "CaseFieldID": "hearingOption",
     "UserRole": "caseworker-publiclaw-gatekeeper",
-    "CRUD": "CRU"
+    "CRUD": "CRUD"
   },
   {
     "LiveFrom": "01/01/2017",

--- a/ccd-definition/AuthorisationCaseField/CareSupervision/judiciary.json
+++ b/ccd-definition/AuthorisationCaseField/CareSupervision/judiciary.json
@@ -1250,7 +1250,7 @@
     "CaseTypeID": "CARE_SUPERVISION_EPO",
     "CaseFieldID": "hearingOption",
     "UserRole": "caseworker-publiclaw-judiciary",
-    "CRUD": "CRU"
+    "CRUD": "CRUD"
   },
   {
     "LiveFrom": "01/01/2017",

--- a/ccd-definition/CaseEventToFields/CareSupervision/manageHearings.json
+++ b/ccd-definition/CaseEventToFields/CareSupervision/manageHearings.json
@@ -16,18 +16,6 @@
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
     "CaseEventID": "manageHearings",
-    "CaseFieldID": "firstHearingFlag",
-    "PageFieldDisplayOrder": 1,
-    "DisplayContext": "READONLY",
-    "PageID": "SelectHearingOption",
-    "ShowSummaryChangeOption": "Y",
-    "PageDisplayOrder": 1,
-    "FieldShowCondition": "hearingOption=\"DO_NOT_SHOW\""
-  },
-  {
-    "LiveFrom": "01/01/2017",
-    "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "CaseEventID": "manageHearings",
     "CaseFieldID": "hasFutureHearingDateFlag",
     "PageFieldDisplayOrder": 1,
     "DisplayContext": "READONLY",
@@ -370,6 +358,18 @@
     "ShowSummaryChangeOption": "N",
     "FieldShowCondition": "hearingStartDate=\"DO_NOT_SHOW\"",
     "PageDisplayOrder": 5
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseEventID": "manageHearings",
+    "CaseFieldID": "firstHearingFlag",
+    "PageFieldDisplayOrder": 1,
+    "DisplayContext": "READONLY",
+    "PageID": "EnterHearingDetails",
+    "ShowSummaryChangeOption": "Y",
+    "PageDisplayOrder": 5,
+    "FieldShowCondition": "hearingOption=\"DO_NOT_SHOW\""
   },
   {
     "LiveFrom": "01/01/2017",

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/ManageHearingsController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/ManageHearingsController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackResponse;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.fpl.enums.YesNo;
 import uk.gov.hmcts.reform.fpl.events.AfterSubmissionCaseDataUpdated;
 import uk.gov.hmcts.reform.fpl.events.PopulateStandardDirectionsOrderDatesEvent;
 import uk.gov.hmcts.reform.fpl.events.SendNoticeOfHearing;
@@ -231,7 +232,7 @@ public class ManageHearingsController extends CallbackController {
         CaseDetails caseDetails = callbackRequest.getCaseDetails();
         CaseData caseData = getCaseData(caseDetails);
 
-        JudgeAndLegalAdvisor tempJudge  = caseData.getJudgeAndLegalAdvisor();
+        JudgeAndLegalAdvisor tempJudge = caseData.getJudgeAndLegalAdvisor();
 
         if (caseData.hasSelectedTemporaryJudge(tempJudge)) {
             Optional<String> error = validateEmailService.validate(tempJudge.getJudgeEmailAddress());
@@ -356,7 +357,9 @@ public class ManageHearingsController extends CallbackController {
     }
 
     private boolean isAddingNewHearing(CaseData caseData) {
-        return isEmpty(caseData.getHearingOption()) || NEW_HEARING.equals(caseData.getHearingOption());
+        return isEmpty(caseData.getHearingOption())
+            || NEW_HEARING.equals(caseData.getHearingOption())
+            || YesNo.fromString(caseData.getFirstHearingFlag()) == YES;
     }
 
     private boolean isNewOrReListedHearing(CaseData caseData) {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/ManageHearingsService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/ManageHearingsService.java
@@ -346,7 +346,8 @@ public class ManageHearingsService {
             START_DATE_FLAG,
             END_DATE_FLAG,
             "hasSession",
-            "hearingPresence"
+            "hearingPresence",
+            "hearingOption"
         );
     }
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/FPLA-3214

Steps to reproduce:

1. Add hearing in future as first hearing in a case
2. Vacate this hearing (without relisting)
3. Create new hearing, should be able to provide date in past, but system complains date must be in future

Issue description:
Service allowed date in past only when new hearing is added (not edited or relisted). To determine if this is new hearing filed 'hearingOption' is used. This field contains radio button selection (ADD|EDIT|VACATE|ADJOURN|RELIST). This filed was supposed to be cleaned each time new event is started (in about to start callback) but with recent xui changes filed is preserved (bug) which cause that system sees current action as VACATE and not ADD, and does not allow date to be in past.

As a solution flag should be reset after event submission and not at the start of new event, but this approach wont solve cases that already have it saved. To solve it other field - is first hearing is used to determine if action is about adding new hearing.