### PR TITLE
fix: update amendable sort date to not rely on new fields

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/order/generated/GeneratedOrder.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/order/generated/GeneratedOrder.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Builder;
 import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ObjectUtils;
 import uk.gov.hmcts.reform.fpl.enums.YesNo;
 import uk.gov.hmcts.reform.fpl.json.converter.BasicChildConverter;
@@ -18,6 +19,7 @@ import uk.gov.hmcts.reform.fpl.model.interfaces.RemovableOrder;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -27,8 +29,12 @@ import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
 import static uk.gov.hmcts.reform.fpl.enums.GeneratedOrderSubtype.FINAL;
 import static uk.gov.hmcts.reform.fpl.enums.GeneratedOrderType.EMERGENCY_PROTECTION_ORDER;
 import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.DATE;
+import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.TIME_DATE;
 import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.formatLocalDateTimeBaseUsingFormat;
+import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.parseLocalDateFromStringUsingFormat;
+import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.parseLocalDateTimeFromStringUsingFormat;
 
+@Slf4j
 @Data
 @Builder(toBuilder = true)
 public class GeneratedOrder implements RemovableOrder, AmendableOrder {
@@ -92,7 +98,32 @@ public class GeneratedOrder implements RemovableOrder, AmendableOrder {
 
     @Override
     public LocalDate amendableSortDate() {
-        return null != approvalDate ? approvalDate : approvalDateTime.toLocalDate();
+        if (null != approvalDate) {
+            return approvalDate;
+        }
+
+        if (null != approvalDateTime) {
+            return approvalDateTime.toLocalDate();
+        }
+
+        try {
+            if (null != dateOfIssue) {
+                return parseLocalDateFromStringUsingFormat(dateOfIssue, DATE);
+            }
+        } catch (DateTimeParseException ignored) {
+            log.warn("Could not parse {} with format {}", dateOfIssue, DATE);
+        }
+
+        try {
+            if (null != date) {
+                return parseLocalDateTimeFromStringUsingFormat(date, TIME_DATE).toLocalDate();
+            }
+        } catch (DateTimeParseException ignored) {
+            log.warn("Could not parse {} with format {}", date, TIME_DATE);
+        }
+
+        log.warn("Could not find any date to sort amendable list by, falling back to null");
+        return null;
     }
 
     @JsonIgnore

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/orders/amendment/list/AmendableOrderListBuilder.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/orders/amendment/list/AmendableOrderListBuilder.java
@@ -15,6 +15,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static java.util.Comparator.comparing;
+import static java.util.Comparator.naturalOrder;
+import static java.util.Comparator.nullsLast;
 import static java.util.Comparator.reverseOrder;
 
 @Component
@@ -25,10 +27,10 @@ public class AmendableOrderListBuilder {
 
     public DynamicList buildList(CaseData caseData) {
         Comparator<Element<? extends AmendableOrder>> comparator = comparing(
-            order -> order.getValue().amendableSortDate(), reverseOrder()
+            order -> order.getValue().amendableSortDate(), nullsLast(reverseOrder())
         );
 
-        comparator = comparator.thenComparing(order -> order.getValue().asLabel());
+        comparator = comparator.thenComparing(order -> order.getValue().asLabel(), nullsLast(naturalOrder()));
 
         List<Element<? extends AmendableOrder>> amendableOrders = providers.stream()
             .map(provider -> provider.provideListItems(caseData))

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/model/StandardDirectionOrderTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/model/StandardDirectionOrderTest.java
@@ -98,4 +98,23 @@ class StandardDirectionOrderTest {
             assertThat(standardDirectionOrder.asLabel()).isEqualTo("Gatekeeping order - 1 January 2020");
         }
     }
+
+    @Test
+    void amendableSortDateDateOfUpload() {
+        LocalDate date = LocalDate.of(1, 1, 1);
+        StandardDirectionOrder sdo = StandardDirectionOrder.builder().dateOfUpload(date).build();
+        assertThat(sdo.amendableSortDate()).isEqualTo(date);
+    }
+
+    @Test
+    void amendableSortDateDateOfIssue() {
+        StandardDirectionOrder sdo = StandardDirectionOrder.builder().dateOfIssue("1 January 0001").build();
+        assertThat(sdo.amendableSortDate()).isEqualTo(LocalDate.of(1, 1, 1));
+    }
+
+    @Test
+    void amendableSortDateNull() {
+        StandardDirectionOrder sdo = StandardDirectionOrder.builder().build();
+        assertThat(sdo.amendableSortDate()).isNull();
+    }
 }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/model/order/generated/GeneratedOrderTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/model/order/generated/GeneratedOrderTest.java
@@ -11,7 +11,9 @@ import uk.gov.hmcts.reform.fpl.model.Child;
 import uk.gov.hmcts.reform.fpl.model.GeneratedOrderTypeDescriptor;
 import uk.gov.hmcts.reform.fpl.utils.ElementUtils;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -35,6 +37,52 @@ class GeneratedOrderTest {
     @Test
     void testOrderCanAlwaysBeRemoved() {
         assertThat(GeneratedOrder.builder().build().isRemovable()).isEqualTo(true);
+    }
+
+    @Test
+    void amendableSortDateApprovalDate() {
+        LocalDate approvalDate = LocalDate.of(1, 1, 1);
+        GeneratedOrder order = GeneratedOrder.builder().approvalDate(approvalDate).build();
+        assertThat(order.amendableSortDate()).isEqualTo(approvalDate);
+    }
+
+    @Test
+    void amendableSortDateApprovalDateTime() {
+        LocalDate approvalDate = LocalDate.of(1, 1, 1);
+        GeneratedOrder order = GeneratedOrder.builder()
+            .approvalDateTime(LocalDateTime.of(approvalDate, LocalTime.NOON))
+            .build();
+        assertThat(order.amendableSortDate()).isEqualTo(approvalDate);
+    }
+
+    @Test
+    void amendableSortDateDateOfIssue() {
+        GeneratedOrder order = GeneratedOrder.builder().dateOfIssue("1 January 0001").build();
+        assertThat(order.amendableSortDate()).isEqualTo(LocalDate.of(1, 1, 1));
+    }
+
+    @Test
+    void amendableSortDateDate() {
+        GeneratedOrder order = GeneratedOrder.builder().date("1:11am, 1 January 0001").build();
+        assertThat(order.amendableSortDate()).isEqualTo(LocalDate.of(1, 1, 1));
+    }
+
+    @Test
+    void amendableSortDateNull() {
+        GeneratedOrder order = GeneratedOrder.builder().build();
+        assertThat(order.amendableSortDate()).isNull();
+    }
+
+    @Test
+    void amendableSortDateInvalidDateOfIssueFormat() {
+        GeneratedOrder order = GeneratedOrder.builder().dateOfIssue("1:11am, 1 January 0001").build();
+        assertThat(order.amendableSortDate()).isNull();
+    }
+
+    @Test
+    void amendableSortDateInvalidDateFormat() {
+        GeneratedOrder order = GeneratedOrder.builder().date("1 January 0001").build();
+        assertThat(order.amendableSortDate()).isNull();
     }
 
     @Test
@@ -110,19 +158,6 @@ class GeneratedOrderTest {
         }
     }
 
-    private static Stream<Arguments> isFinalOrderSource() {
-        return Stream.of(
-            Arguments.of(builder().type(BLANK_ORDER).build(), false),
-            Arguments.of(builder().type(CARE_ORDER).subtype(INTERIM).build(), false),
-            Arguments.of(builder().type(CARE_ORDER).subtype(FINAL).build(), true),
-            Arguments.of(builder().type(SUPERVISION_ORDER).subtype(INTERIM).build(), false),
-            Arguments.of(builder().type(SUPERVISION_ORDER).subtype(FINAL).build(), true),
-            Arguments.of(builder().type(EMERGENCY_PROTECTION_ORDER).build(), true),
-            Arguments.of(builder().type(DISCHARGE_OF_CARE_ORDER).build(), false),
-            Arguments.of(builder().type(UPLOAD).build(), false)
-        );
-    }
-
     @Test
     void shouldReturnListOfChildrenIdsWhenExisting() {
         UUID childOneId = UUID.randomUUID();
@@ -142,5 +177,18 @@ class GeneratedOrderTest {
         GeneratedOrder order = GeneratedOrder.builder().build();
 
         assertThat(order.getChildrenIDs()).isEmpty();
+    }
+
+    private static Stream<Arguments> isFinalOrderSource() {
+        return Stream.of(
+            Arguments.of(builder().type(BLANK_ORDER).build(), false),
+            Arguments.of(builder().type(CARE_ORDER).subtype(INTERIM).build(), false),
+            Arguments.of(builder().type(CARE_ORDER).subtype(FINAL).build(), true),
+            Arguments.of(builder().type(SUPERVISION_ORDER).subtype(INTERIM).build(), false),
+            Arguments.of(builder().type(SUPERVISION_ORDER).subtype(FINAL).build(), true),
+            Arguments.of(builder().type(EMERGENCY_PROTECTION_ORDER).build(), true),
+            Arguments.of(builder().type(DISCHARGE_OF_CARE_ORDER).build(), false),
+            Arguments.of(builder().type(UPLOAD).build(), false)
+        );
     }
 }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/orders/amendment/list/AmendableOrderListBuilderTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/orders/amendment/list/AmendableOrderListBuilderTest.java
@@ -52,8 +52,7 @@ class AmendableOrderListBuilderTest {
         CaseData caseData = mock(CaseData.class);
 
         when(provider.provideListItems(caseData)).thenReturn(List.of(
-            element(order1Id, order1), order2Element, element(order3Id, order3),
-            element(order4Id, order4)
+            element(order1Id, order1), order2Element, element(order3Id, order3), element(order4Id, order4)
         ));
 
         // order1 and order4 label methods are not called as the comparator doesn't need to evaluate those methods


### PR DESCRIPTION
### Change description ###

Update amendableSortDate method to not rely soly on new fields, added parsing exception resilience as well

Stack trace from azure
```
"uk.gov.hmcts.reform.fpl.model.order.generated.GeneratedOrder.amendableSortDate","level":0,"line":95,"fileName":"GeneratedOrder.java",
"uk.gov.hmcts.reform.fpl.service.orders.amendment.list.AmendableOrderListBuilder.lambda$buildList$0","level":1,"line":28,"fileName":"AmendableOrderListBuilder.java",
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
