### PR TITLE
Chore: revert the e2e postcode link check to use a locator

### DIFF
--- a/e2e/fragments/addressPostcodeLookup.js
+++ b/e2e/fragments/addressPostcodeLookup.js
@@ -16,7 +16,7 @@ module.exports = {
     country: 'input[id$="Country"]',
   },
   findAddressButton: 'Find address',
-  cantEnterPostcodeLink: 'I can\'t enter a UK postcode',
+  cantEnterPostcodeLink: locate('a').withText('I can\'t enter a UK postcode'),
 
   lookupPostcode(address) {
     I.fillField(this.fields.postcodeLookup, address.postcode);
@@ -33,7 +33,7 @@ module.exports = {
   },
 
   enterAddressManually(address) {
-    I.waitForText(this.cantEnterPostcodeLink);
+    I.waitForElement(this.cantEnterPostcodeLink);
     I.click(this.cantEnterPostcodeLink);
     if(address.buildingAndStreet.lineOne) {
       I.fillField(this.fields.buildingAndStreet.lineOne, address.buildingAndStreet.lineOne);


### PR DESCRIPTION
### JIRA link (if applicable) ###

n/a

### Change description ###

Change `cantEnterPostcodeLink` back to a locator and use waitForElement() to wait for the link, because the text check wasn't working as expected in AAT.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
