### PR TITLE
migration: remove draft CMO (FPLA-3262)

### DIFF
--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseControllerTest.java
@@ -9,8 +9,6 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.controllers.AbstractCallbackTest;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.HearingBooking;
-import uk.gov.hmcts.reform.fpl.model.SupportingEvidenceBundle;
-import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
 import uk.gov.hmcts.reform.fpl.model.order.HearingOrder;
 
@@ -21,7 +19,6 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.element;
-import static uk.gov.hmcts.reform.fpl.utils.TestDataHelper.testDocumentReference;
 
 @WebMvcTest(MigrateCaseController.class)
 @OverrideAutoConfiguration(enabled = true)
@@ -32,8 +29,8 @@ class MigrateCaseControllerTest extends AbstractCallbackTest {
 
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     @Nested
-    class Fpla3126 {
-        final String migrationId = "FPLA-3126";
+    class Fpla3262 {
+        final String migrationId = "FPLA-3262";
 
         @Test
         void shouldRemoveDraftCMOIfPresent() {
@@ -45,7 +42,7 @@ class MigrateCaseControllerTest extends AbstractCallbackTest {
                 .state("Submitted")
                 .data(Map.of(
                     "name", "Test",
-                    "familyManCaseNumber", "NE21C50026",
+                    "familyManCaseNumber", "PE21C50004",
                     "draftUploadedCMOs", List.of(element(id, HearingOrder.builder().title("remove me").build())),
                     "cancelledHearingDetails", cancelledHearings,
                     "migrationId", migrationId))
@@ -69,7 +66,7 @@ class MigrateCaseControllerTest extends AbstractCallbackTest {
                 .state("Submitted")
                 .data(Map.of(
                     "name", "Test",
-                    "familyManCaseNumber", "NE21C50026",
+                    "familyManCaseNumber", "PE21C50004",
                     "draftUploadedCMOs", List.of(element(id, HearingOrder.builder().title("remove me").build())),
                     "cancelledHearingDetails", cancelledHearings,
                     "migrationId", migrationId))
@@ -84,63 +81,12 @@ class MigrateCaseControllerTest extends AbstractCallbackTest {
                 .id(10L)
                 .state("Submitted")
                 .data(Map.of(
-                    "familyManCaseNumber", "NE21C50026",
+                    "familyManCaseNumber", "PE21C50004",
                     "name", "Test",
                     "migrationId", migrationId))
                 .build();
 
             assertThatThrownBy(() -> postAboutToSubmitEvent(caseDetails));
-        }
-    }
-
-    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-    @Nested
-    class Fpla3239 {
-        final String migrationId = "FPLA-3239";
-
-        @Test
-        void shouldReplaceC110aWithCorrespondenceDoc() {
-
-            DocumentReference redacted = testDocumentReference();
-            Element<SupportingEvidenceBundle> redactedC110a = element(
-                UUID.fromString("b1b7ef2d-b760-4961-aa5c-0ef9f5e40e95"),
-                SupportingEvidenceBundle.builder()
-                    .name("Redacted C110a")
-                    .document(redacted).build());
-
-            CaseDetails caseDetails = CaseDetails.builder()
-                .id(10L)
-                .state("Submitted")
-                .data(Map.of(
-                    "name", "Test",
-                    "familyManCaseNumber", "DE21C50042",
-                    "submittedForm", testDocumentReference(),
-                    "correspondenceDocuments", List.of(
-                        element(SupportingEvidenceBundle.builder()
-                            .name("Some correspondence")
-                            .document(testDocumentReference()).build()),
-                        redactedC110a),
-                    "migrationId", migrationId))
-                .build();
-
-            CaseData extractedCaseData = extractCaseData(postAboutToSubmitEvent(caseDetails));
-
-            assertThat(extractedCaseData.getSubmittedForm()).isEqualTo(redacted);
-            assertThat(extractedCaseData.getCorrespondenceDocuments()).doesNotContain(redactedC110a);
-        }
-
-        @Test
-        void shouldRemoveMigrationIdWhenNoC110a() {
-            CaseDetails caseDetails = CaseDetails.builder()
-                .id(10L)
-                .state("Submitted")
-                .data(Map.of(
-                    "familyManCaseNumber", "DE21C50042",
-                    "name", "Test",
-                    "migrationId", migrationId))
-                .build();
-
-            assertThatThrownBy(() -> postAboutToSubmitEvent(caseDetails).getData());
         }
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -14,7 +14,6 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.controllers.CallbackController;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.HearingBooking;
-import uk.gov.hmcts.reform.fpl.model.SupportingEvidenceBundle;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
 import uk.gov.hmcts.reform.fpl.model.order.HearingOrder;
 
@@ -40,11 +39,8 @@ public class MigrateCaseController extends CallbackController {
         log.info("Migration " + migrationId);
 
         switch (migrationId) {
-            case "FPLA-3126":
-                run3126(caseDetails);
-                break;
-            case "FPLA-3239":
-                run3239(caseDetails);
+            case "FPLA-3262":
+                run3262(caseDetails);
                 break;
             default:
                 log.error("Unhandled migration {}", migrationId);
@@ -54,9 +50,9 @@ public class MigrateCaseController extends CallbackController {
         return respond(caseDetails);
     }
 
-    private void run3126(CaseDetails caseDetails) {
+    private void run3262(CaseDetails caseDetails) {
         CaseData caseData = getCaseData(caseDetails);
-        validateFamilyManNumber("FPLA-3126", "NE21C50026", caseData);
+        validateFamilyManNumber("FPLA-3262", "PE21C50004", caseData);
 
         List<Element<HearingOrder>> draftUploadedCMOs = caseData.getDraftUploadedCMOs();
         if (isNotEmpty(draftUploadedCMOs) && draftUploadedCMOs.size() == 1) {
@@ -74,28 +70,6 @@ public class MigrateCaseController extends CallbackController {
         } else {
             throw new IllegalStateException(
                 format("Case %s has unexpected cancelled hearing details", caseDetails.getId()));
-        }
-    }
-
-    private void run3239(CaseDetails caseDetails) {
-        CaseData caseData = getCaseData(caseDetails);
-        validateFamilyManNumber("FPLA-3239", "DE21C50042", caseData);
-
-        Element<SupportingEvidenceBundle> correspondenceElement = caseData.getCorrespondenceDocuments()
-            .stream()
-            .filter(element -> "b1b7ef2d-b760-4961-aa5c-0ef9f5e40e95".equals(element.getId().toString()))
-            .findAny()
-            .orElseThrow(() -> new IllegalStateException(
-                format("Case %s does not contain redacted copy in correspondence collection", caseDetails.getId())));
-
-        if (isNotEmpty(caseData.getSubmittedForm())
-            && "Redacted C110a".equals(correspondenceElement.getValue().getName())) {
-            caseDetails.getData().put("submittedForm", correspondenceElement.getValue().getDocument());
-
-            caseData.getCorrespondenceDocuments().remove(correspondenceElement);
-            caseDetails.getData().put("correspondenceDocuments", caseData.getCorrespondenceDocuments());
-        } else {
-            throw new IllegalStateException(format("Case %s does not have C110a/redacted copy", caseDetails.getId()));
         }
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FPLA-3262
https://github.com/hmcts/fpl-ccd-data-migration-tool/pull/89

@lewisbirks can run this

### Change description ###

remove draft CMO and unlink cancelled hearing

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
