### PR TITLE
toggle: amended orders (FPLA-3251)

### DIFF
--- a/ccd-definition/FixedLists/CareSupervision/ManageOrdersOperation-nonprod.json
+++ b/ccd-definition/FixedLists/CareSupervision/ManageOrdersOperation-nonprod.json
@@ -1,9 +1,0 @@
-[
-  {
-    "LiveFrom": "01/01/2017",
-    "ID": "ManageOrdersOperation",
-    "ListElementCode": "AMEND",
-    "ListElement": "Amend order under the slip rule",
-    "DisplayOrder": 3
-  }
-]

--- a/ccd-definition/FixedLists/CareSupervision/ManageOrdersOperation.json
+++ b/ccd-definition/FixedLists/CareSupervision/ManageOrdersOperation.json
@@ -12,5 +12,12 @@
     "ListElementCode": "UPLOAD",
     "ListElement": "Upload an order",
     "DisplayOrder": 2
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "ManageOrdersOperation",
+    "ListElementCode": "AMEND",
+    "ListElement": "Amend order under the slip rule",
+    "DisplayOrder": 3
   }
 ]

--- a/ccd-definition/FixedLists/CareSupervision/ManageOrdersOperationClosedState-nonprod.json
+++ b/ccd-definition/FixedLists/CareSupervision/ManageOrdersOperationClosedState-nonprod.json
@@ -1,9 +1,0 @@
-[
-  {
-    "LiveFrom": "01/01/2017",
-    "ID": "ManageOrdersOperationClosedState",
-    "ListElementCode": "AMEND",
-    "ListElement": "Amend order under the slip rule",
-    "DisplayOrder": 2
-  }
-]

--- a/ccd-definition/FixedLists/CareSupervision/ManageOrdersOperationClosedState.json
+++ b/ccd-definition/FixedLists/CareSupervision/ManageOrdersOperationClosedState.json
@@ -5,5 +5,12 @@
     "ListElementCode": "CREATE",
     "ListElement": "Create an order",
     "DisplayOrder": 1
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "ManageOrdersOperationClosedState",
+    "ListElementCode": "AMEND",
+    "ListElement": "Amend order under the slip rule",
+    "DisplayOrder": 2
   }
 ]

--- a/e2e/tests/adminManagesOrdersAmendment_test.js
+++ b/e2e/tests/adminManagesOrdersAmendment_test.js
@@ -1,5 +1,6 @@
 const config = require('../config.js');
 const dateFormat = require('dateformat');
+const api = require('../helpers/api_helper');
 const caseData = require('../fixtures/caseData/caseWithAllTypesOfOrders.json');
 const closedCaseData = {
   state: 'CLOSED',
@@ -49,6 +50,7 @@ Scenario('Amend generated order', async ({ I, caseViewPage, manageOrdersEventPag
   await setupScenario(I);
   await amendOrder(I, caseViewPage, manageOrdersEventPage, orders.generated);
   assertAmendment(I, caseViewPage, orders.generated);
+  await api.pollLastEvent(caseId, config.internalActions.updateCase);
 });
 
 Scenario('Amend standard directions order', async ({ I, caseViewPage, manageOrdersEventPage }) => {
@@ -61,12 +63,14 @@ Scenario('Amend urgent hearing order', async ({ I, caseViewPage, manageOrdersEve
   await setupScenario(I);
   await amendOrder(I, caseViewPage, manageOrdersEventPage, orders.urgentHearingOrder);
   assertAmendment(I, caseViewPage, orders.urgentHearingOrder);
+  await api.pollLastEvent(caseId, config.internalActions.updateCase);
 });
 
 Scenario('Amend case management order', async ({ I, caseViewPage, manageOrdersEventPage }) => {
   await setupScenario(I);
   await amendOrder(I, caseViewPage, manageOrdersEventPage, orders.caseManagementOrder);
   assertAmendment(I, caseViewPage, orders.caseManagementOrder);
+  await api.pollLastEvent(caseId, config.internalActions.updateCase);
 });
 
 Scenario('Amend generated order (closed)', async ({ I, caseViewPage, manageOrdersEventPage }) => {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/order/HearingOrder.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/order/HearingOrder.java
@@ -111,9 +111,13 @@ public class HearingOrder implements RemovableOrder, AmendableOrder {
         return AmendedOrderType.CASE_MANAGEMENT_ORDER.getLabel();
     }
 
+    public List<Element<Other>> getOthers() {
+        return defaultIfNull(others, new ArrayList<>());
+    }
+
     @JsonIgnore
     @Override
     public List<Element<Other>> getSelectedOthers() {
-        return defaultIfNull(getOthers(), new ArrayList<>());
+        return this.getOthers();
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/order/generated/GeneratedOrder.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/order/generated/GeneratedOrder.java
@@ -31,7 +31,6 @@ import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
 import static uk.gov.hmcts.reform.fpl.enums.GeneratedOrderSubtype.FINAL;
 import static uk.gov.hmcts.reform.fpl.enums.GeneratedOrderType.EMERGENCY_PROTECTION_ORDER;
 import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.DATE;
-import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.DATE;
 import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.TIME_DATE;
 import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.formatLocalDateTimeBaseUsingFormat;
 import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.parseLocalDateFromStringUsingFormat;
@@ -154,9 +153,13 @@ public class GeneratedOrder implements RemovableOrder, AmendableOrder {
         return type;
     }
 
+    public List<Element<Other>> getOthers() {
+        return defaultIfNull(others, new ArrayList<>());
+    }
+
     @JsonIgnore
     @Override
     public List<Element<Other>> getSelectedOthers() {
-        return defaultIfNull(this.getOthers(), new ArrayList<>());
+        return this.getOthers();
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

[FPLA-3251](https://tools.hmcts.net/jira/browse/FPLA-3251)

### Change description ###

Toggled on the amended order flow.

Fixed some regressions issues where old orders would not have the others field populated where as current ones have it assigned an empty list by default.

Improved test stability by making them wait for the send by post event to finish.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
