### PR TITLE
fix: allow epo e2e tests to run regardless of time of day

### DIFF
--- a/e2e/tests/adminManagesOrders_test.js
+++ b/e2e/tests/adminManagesOrders_test.js
@@ -7,7 +7,8 @@ const caseDataWithApplication = require('../fixtures/caseData/gatekeepingWithPas
 const closedCaseData = require('../fixtures/caseData/closedCase.json');
 
 const orderTitle = 'some title';
-const today = moment().hours(10).minutes(5).seconds(23).milliseconds(0).toDate();
+const now = moment().toDate();
+const today = moment(now).subtract(1, 'hours').minutes(5).seconds(23).milliseconds(0).toDate();
 const aYearAgo = moment(today).subtract(1, 'years').toDate();
 const futureDate = moment(today).add(1, 'days').toDate();
 const removalAddress = { buildingAndStreet: { lineOne: 'Flat 2 Caversham', town: 'Reading' }, postcode: 'RG4 7AA' };

--- a/e2e/tests/adminManagesOrders_test.js
+++ b/e2e/tests/adminManagesOrders_test.js
@@ -8,7 +8,7 @@ const closedCaseData = require('../fixtures/caseData/closedCase.json');
 
 const orderTitle = 'some title';
 const now = moment().toDate();
-const today = moment(now).subtract(1, 'hours').minutes(5).seconds(23).milliseconds(0).toDate();
+const today = moment(now).subtract(2, 'hours').minutes(5).seconds(23).milliseconds(0).toDate();
 const aYearAgo = moment(today).subtract(1, 'years').toDate();
 const futureDate = moment(today).add(1, 'days').toDate();
 const removalAddress = { buildingAndStreet: { lineOne: 'Flat 2 Caversham', town: 'Reading' }, postcode: 'RG4 7AA' };

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/orders/validator/ApprovalDateTimeValidator.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/orders/validator/ApprovalDateTimeValidator.java
@@ -16,7 +16,7 @@ import static uk.gov.hmcts.reform.fpl.model.order.OrderQuestionBlock.APPROVAL_DA
 @RequiredArgsConstructor(onConstructor_ = {@Autowired})
 public class ApprovalDateTimeValidator implements QuestionBlockOrderValidator {
 
-    private static final String MESSAGE = "Approval date cannot not be in the future";
+    private static final String MESSAGE = "Approval date cannot be in the future";
 
     private final Time time;
 

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/orders/validator/ApprovalDateTimeValidatorTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/orders/validator/ApprovalDateTimeValidatorTest.java
@@ -13,7 +13,7 @@ import static uk.gov.hmcts.reform.fpl.model.order.OrderQuestionBlock.APPROVAL_DA
 
 class ApprovalDateTimeValidatorTest {
 
-    private static final String MESSAGE = "Approval date cannot not be in the future";
+    private static final String MESSAGE = "Approval date cannot be in the future";
 
     private final Time time = new FixedTimeConfiguration().stoppedTime();
 


### PR DESCRIPTION
### Change description ###

Set the today variable in the manage orders e2e tests to always be in the past.

Update clarity of error message (based off validation) from
```
Approval date cannot not be in the future
```
to
```
Approval date cannot be in the future
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[x] No
```
