### PR TITLE
impr: See more messages in judicial message threads (FPLA-3001)

### DIFF
--- a/ccd-definition/CaseTypeTab/CareSupervision/11_JudicialMessages.json
+++ b/ccd-definition/CaseTypeTab/CareSupervision/11_JudicialMessages.json
@@ -28,7 +28,8 @@
     "TabDisplayOrder": 11,
     "CaseFieldID": "judicialMessages",
     "TabFieldDisplayOrder": 3,
-    "FieldShowCondition": "judicialMessages!=\"\""
+    "FieldShowCondition": "judicialMessages!=\"\"",
+    "DisplayContextParameter": "#TABLE(sender, recipient, requestedBy, dateSent, status)"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -49,6 +50,7 @@
     "TabLabel": "Closed messages",
     "TabDisplayOrder": 13,
     "CaseFieldID": "closedJudicialMessages",
-    "TabFieldDisplayOrder": 5
+    "TabFieldDisplayOrder": 5,
+    "DisplayContextParameter": "#TABLE(sender, recipient, requestedBy, dateSent, status)"
   }
 ]

--- a/ccd-definition/ComplexTypes/CareSupervision/JudicialMessage/JudicialMessage.json
+++ b/ccd-definition/ComplexTypes/CareSupervision/JudicialMessage/JudicialMessage.json
@@ -91,7 +91,8 @@
     "FieldType": "Collection",
     "FieldTypeParameter": "Document",
     "ElementLabel": "Related documents",
-    "SecurityClassification": "Public"
+    "SecurityClassification": "Public",
+    "FieldShowCondition": "relatedDocuments=\"*\""
   },
   {
     "LiveFrom": "01/01/2017",
@@ -133,8 +134,7 @@
     "ListElementCode": "messageHistory",
     "FieldType": "TextArea",
     "ElementLabel": "Message history",
-    "SecurityClassification": "Public",
-    "FieldShowCondition": "status=\"CLOSED\""
+    "SecurityClassification": "Public"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -142,6 +142,7 @@
     "ListElementCode": "closeMessageLabel",
     "FieldType": "Label",
     "ElementLabel": "This message will now be marked as closed",
-    "SecurityClassification": "Public"
+    "SecurityClassification": "Public",
+    "FieldShowCondition": "closeMessageLabel=\"DO_NOT_SHOW\""
   }
 ]

--- a/e2e/pages/events/messageJudgeOrLegalAdviserEvent.page.js
+++ b/e2e/pages/events/messageJudgeOrLegalAdviserEvent.page.js
@@ -21,7 +21,6 @@ module.exports = {
         no: '#judicialMessageReply_isReplying_No',
       },
     },
-    closeMessageLabel: '#judicialMessageReply_closeMessageLabel',
     subject: '#judicialMessageMetaData_requestedBy',
     urgency: '#judicialMessageMetaData_urgency',
     latestMessage: '#judicialMessageNote',


### PR DESCRIPTION
### JIRA link (if applicable) ###
[FPLA-3001](https://tools.hmcts.net/jira/browse/FPLA-3001)


### Change description ###
Changes the judicial messages under the tab to be displayed within a table with expanding rows.
Each row can be expanded to show the full message history.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
