### PR TITLE
chore: Clean up further evidence upload notification toggle (FPLA-3327)

### DIFF
--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/documents/ManageDocumentsControllerSubmittedTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/documents/ManageDocumentsControllerSubmittedTest.java
@@ -5,7 +5,6 @@ import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
-import uk.gov.hmcts.reform.fpl.service.FeatureToggleService;
 import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.NotificationClientException;
@@ -27,9 +26,6 @@ class ManageDocumentsControllerSubmittedTest extends ManageDocumentsControllerSu
     private static final String BUNDLE_NAME = "furtherEvidenceDocuments";
 
     @MockBean
-    private FeatureToggleService featureToggleService;
-
-    @MockBean
     private NotificationClient notificationClient;
 
     ManageDocumentsControllerSubmittedTest() {
@@ -37,23 +33,14 @@ class ManageDocumentsControllerSubmittedTest extends ManageDocumentsControllerSu
     }
 
     @Test
-    void shouldNotPublishEventWhenUploadNotificationFeatureIsDisabled() {
-        when(featureToggleService.isFurtherEvidenceUploadNotificationEnabled()).thenReturn(false);
-        postSubmittedEvent(buildCallbackRequest(BUNDLE_NAME, false));
-        verifyNoInteractions(notificationClient);
-    }
-
-    @Test
     void shouldNotPublishEventWhenConfidentialDocumentsAreUploaded() {
-        when(featureToggleService.isFurtherEvidenceUploadNotificationEnabled()).thenReturn(true);
         when(idamClient.getUserDetails(any())).thenReturn(UserDetails.builder().build());
         postSubmittedEvent(buildCallbackRequest(BUNDLE_NAME, true));
         verifyNoInteractions(notificationClient);
     }
 
     @Test
-    void shouldPublishEventWhenUploadNotificationFeatureIsEnabled() throws NotificationClientException {
-        when(featureToggleService.isFurtherEvidenceUploadNotificationEnabled()).thenReturn(true);
+    void shouldPublishNotificationEventWhenFurtherEvidenceIsUploaded() throws NotificationClientException {
         when(idamClient.getUserDetails(any())).thenReturn(UserDetails.builder().build());
         postSubmittedEvent(buildCallbackRequest(BUNDLE_NAME, false));
 

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/documents/ManageDocumentsLAControllerSubmittedTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/documents/ManageDocumentsLAControllerSubmittedTest.java
@@ -5,7 +5,6 @@ import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
-import uk.gov.hmcts.reform.fpl.service.FeatureToggleService;
 import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.NotificationClientException;
@@ -25,9 +24,6 @@ public class ManageDocumentsLAControllerSubmittedTest extends ManageDocumentsCon
     private static final String BUNDLE_NAME = "furtherEvidenceDocumentsLA";
 
     @MockBean
-    private FeatureToggleService featureToggleService;
-
-    @MockBean
     private NotificationClient notificationClient;
 
     ManageDocumentsLAControllerSubmittedTest() {
@@ -35,23 +31,14 @@ public class ManageDocumentsLAControllerSubmittedTest extends ManageDocumentsCon
     }
 
     @Test
-    void shouldNotPublishEventWhenUploadNotificationFeatureIsDisabled() {
-        when(featureToggleService.isFurtherEvidenceUploadNotificationEnabled()).thenReturn(false);
-        postSubmittedEvent(buildCallbackRequest(BUNDLE_NAME, false));
-        verifyNoInteractions(notificationClient);
-    }
-
-    @Test
     void shouldNotPublishEventWhenConfidentialDocumentsAreUploaded() {
-        when(featureToggleService.isFurtherEvidenceUploadNotificationEnabled()).thenReturn(true);
         when(idamClient.getUserDetails(any())).thenReturn(UserDetails.builder().build());
         postSubmittedEvent(buildCallbackRequest(BUNDLE_NAME, true));
         verifyNoInteractions(notificationClient);
     }
 
     @Test
-    void shouldPublishEventWhenUploadNotificationFeatureIsEnabled() throws NotificationClientException {
-        when(featureToggleService.isFurtherEvidenceUploadNotificationEnabled()).thenReturn(true);
+    void shouldPublishNotificationEventWhenFurtherEvidenceIsUploaded() throws NotificationClientException {
         when(idamClient.getUserDetails(any())).thenReturn(UserDetails.builder().build());
         postSubmittedEvent(buildCallbackRequest(BUNDLE_NAME, false));
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/documents/ManageDocumentsController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/documents/ManageDocumentsController.java
@@ -223,13 +223,12 @@ public class ManageDocumentsController extends CallbackController {
 
     @PostMapping("/submitted")
     public void handleSubmitted(@RequestBody CallbackRequest request) {
-        if (this.featureToggleService.isFurtherEvidenceUploadNotificationEnabled()) {
-            UserDetails userDetails = userService.getUserDetails();
+        UserDetails userDetails = userService.getUserDetails();
 
-            publishEvent(new FurtherEvidenceUploadedEvent(getCaseData(request),
-                getCaseDataBefore(request), false,
-                userDetails));
-        }
+        publishEvent(new FurtherEvidenceUploadedEvent(getCaseData(request),
+            getCaseDataBefore(request), false,
+            userDetails));
+
     }
 
     private boolean isSolicitor(Long id) {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/documents/ManageDocumentsLAController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/documents/ManageDocumentsLAController.java
@@ -225,11 +225,9 @@ public class ManageDocumentsLAController extends CallbackController {
 
     @PostMapping("/submitted")
     public void handleSubmitted(@RequestBody CallbackRequest request) {
-        if (this.featureToggleService.isFurtherEvidenceUploadNotificationEnabled()) {
-            UserDetails userDetails = idamClient.getUserDetails(requestData.authorisation());
+        UserDetails userDetails = idamClient.getUserDetails(requestData.authorisation());
 
-            publishEvent(new FurtherEvidenceUploadedEvent(getCaseData(request), getCaseDataBefore(request),
-                true, userDetails));
-        }
+        publishEvent(new FurtherEvidenceUploadedEvent(getCaseData(request), getCaseDataBefore(request),
+            true, userDetails));
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/FeatureToggleService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/FeatureToggleService.java
@@ -59,11 +59,6 @@ public class FeatureToggleService {
         return ldClient.boolVariation("fee-and-pay-case-type", createLDUser(), false);
     }
 
-    public boolean isFurtherEvidenceUploadNotificationEnabled() {
-        return ldClient.boolVariation("further-evidence-upload-notification",
-            createLDUser(), false);
-    }
-
     public boolean isFurtherEvidenceDocumentTabEnabled() {
         return ldClient.boolVariation("further-evidence-document-tab",
             createLDUser(), false);

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/FeatureToggleServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/FeatureToggleServiceTest.java
@@ -128,18 +128,6 @@ class FeatureToggleServiceTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    void shouldMakeCorrectCallForIsFurtherEvidenceUploadNotificationEnabled(Boolean toggleState) {
-        givenToggle(toggleState);
-
-        assertThat(service.isFurtherEvidenceUploadNotificationEnabled()).isEqualTo(toggleState);
-        verify(ldClient).boolVariation(
-            eq("further-evidence-upload-notification"),
-            argThat(ldUser(ENVIRONMENT).build()),
-            eq(false));
-    }
-
-    @ParameterizedTest
-    @ValueSource(booleans = {true, false})
     void shouldMakeCorrectCallForIsLanguageRequirementsEnabled(Boolean toggleState) {
         givenToggle(toggleState);
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FPLA-3327

### Change description ###
Remove feature toggle used for publishing further evidence uploaded notification


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
