### PR TITLE
fix: Fix prod version of ccd def

### DIFF
--- a/ccd-definition/CaseEvent/CareSupervision/MultiState-nonprod.json
+++ b/ccd-definition/CaseEvent/CareSupervision/MultiState-nonprod.json
@@ -32,22 +32,5 @@
     "ShowSummary": "Y",
     "ShowEventNotes": "N",
     "EndButtonLabel": "Save and continue"
-  },
-  {
-    "LiveFrom": "01/01/2017",
-    "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "ID": "manageLocalAuthorities",
-    "Name": "Manage local authorities",
-    "Description": "Manage local authorities",
-    "DisplayOrder": 10,
-    "PreConditionState(s)": "Submitted;Gatekeeping;PREPARE_FOR_HEARING;FINAL_HEARING;CLOSED",
-    "PostConditionState": "*",
-    "SecurityClassification": "Public",
-    "CallBackURLAboutToStartEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/manage-local-authorities/about-to-start",
-    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/manage-local-authorities/about-to-submit",
-    "CallBackURLSubmittedEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/manage-local-authorities/submitted",
-    "EndButtonLabel": "Save and continue",
-    "ShowSummary": "Y",
-    "ShowEventNotes": "N"
   }
 ]

--- a/ccd-definition/CaseEvent/CareSupervision/MultiState.json
+++ b/ccd-definition/CaseEvent/CareSupervision/MultiState.json
@@ -851,5 +851,22 @@
     "EndButtonLabel": "Save and continue",
     "ShowEventNotes": "Y",
     "ShowSummary": "Y"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "ID": "manageLocalAuthorities",
+    "Name": "Manage local authorities",
+    "Description": "Manage local authorities",
+    "DisplayOrder": 10,
+    "PreConditionState(s)": "Submitted;Gatekeeping;PREPARE_FOR_HEARING;FINAL_HEARING;CLOSED",
+    "PostConditionState": "*",
+    "SecurityClassification": "Public",
+    "CallBackURLAboutToStartEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/manage-local-authorities/about-to-start",
+    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/manage-local-authorities/about-to-submit",
+    "CallBackURLSubmittedEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/manage-local-authorities/submitted",
+    "EndButtonLabel": "Save and continue",
+    "ShowSummary": "Y",
+    "ShowEventNotes": "N"
   }
 ]


### PR DESCRIPTION
event is toggled off in event authorisation section
https://github.com/hmcts/fpl-ccd-configuration/blob/68dad4b69e500927543a5fd3affaa6b8c2f5bdcf/ccd-definition/AuthorisationCaseEvent/CareSupervision/AuthorisationCaseEvent-nonprod.json#L132

if event is not present and pageShowCondition exists for that event in event to fields section, then import throws NPE