### PR TITLE
More portable shebang

### DIFF
--- a/bin/generate-local-user-mappings.sh
+++ b/bin/generate-local-user-mappings.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -eu
 


### PR DESCRIPTION
As ubuntu uses dash by default, the `function` keyword doesn't work and the terminal will complain about a "(" when running the generate-local-user-mappings.sh script. This shebang will work fine on linux and osx


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
