### PR TITLE
fix: search by element UUID rather than index

### DIFF
--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ChildControllerAboutToSubmitTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ChildControllerAboutToSubmitTest.java
@@ -202,13 +202,15 @@ class ChildControllerAboutToSubmitTest extends AbstractCallbackTest {
     void shouldAddMainRepresentativeInfoWhenAllUseMainRepresentativeIfBeforeNotSelected() {
         CaseData caseDataBefore = CaseData.builder()
             .localAuthorities(LOCAL_AUTHORITIES)
-            .children1(wrapElements(
-                Child.builder()
+            .children1(List.of(
+                element(Child.builder()
                     .party(ChildParty.builder().firstName(CHILD_NAME_1).lastName(CHILD_SURNAME_1).build())
-                    .build(),
-                Child.builder()
+                    .build()
+                ),
+                element(Child.builder()
                     .party(ChildParty.builder().firstName(CHILD_NAME_2).lastName(CHILD_SURNAME_2).build())
                     .build()
+                )
             )).childrenEventData(ChildrenEventData.builder()
                 .childrenHaveRepresentation("No")
                 .build())
@@ -261,15 +263,17 @@ class ChildControllerAboutToSubmitTest extends AbstractCallbackTest {
 
         CaseData caseDataBefore = CaseData.builder()
             .localAuthorities(LOCAL_AUTHORITIES)
-            .children1(wrapElements(
-                Child.builder()
+            .children1(List.of(
+                element(Child.builder()
                     .party(ChildParty.builder().firstName(CHILD_NAME_1).lastName(CHILD_SURNAME_1).build())
                     .solicitor(MAIN_REPRESENTATIVE)
-                    .build(),
-                Child.builder()
+                    .build()
+                ),
+                element(Child.builder()
                     .party(ChildParty.builder().firstName(CHILD_NAME_2).lastName(CHILD_SURNAME_2).build())
                     .solicitor(MAIN_REPRESENTATIVE)
                     .build()
+                )
             )).childrenEventData(ChildrenEventData.builder()
                 .childrenHaveRepresentation("Yes")
                 .childrenMainRepresentative(MAIN_REPRESENTATIVE)

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/NoticeOfChangeControllerSubmittedTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/NoticeOfChangeControllerSubmittedTest.java
@@ -90,7 +90,6 @@ class NoticeOfChangeControllerSubmittedTest extends AbstractCallbackTest {
     @MockBean
     private CaseAccessDataStoreApi accessApi;
 
-
     NoticeOfChangeControllerSubmittedTest() {
         super("noc-decision");
     }
@@ -181,7 +180,7 @@ class NoticeOfChangeControllerSubmittedTest extends AbstractCallbackTest {
 
         CaseData caseData = caseDataBefore.toBuilder()
             .respondents1(List.of(OTHER_RESPONDENT, element(
-                Respondent.builder()
+                OLD_RESPONDENT.getId(), Respondent.builder()
                     .legalRepresentation("Yes")
                     .party(RESPONDENT_PARTY)
                     .solicitor(NEW_REGISTERED_SOLICITOR)


### PR DESCRIPTION
### Change description ###

In the `RepresentableLegalCounselUpdater` IndexOutOfBounds exceptions can occur when a respondent/child is removed.

This change ensures that the search uses the element id instead of the index instead which is a much safer approach.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
