### PR TITLE
fix: only seal applications when CTSC user (DFPL-241)

### DIFF
--- a/ccd-definition/AuthorisationCaseField/CareSupervision/cafcass.json
+++ b/ccd-definition/AuthorisationCaseField/CareSupervision/cafcass.json
@@ -642,5 +642,12 @@
     "CaseFieldID": "showFurtherEvidenceTab",
     "UserRole": "caseworker-publiclaw-cafcass",
     "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseFieldID": "people_label",
+    "UserRole": "caseworker-publiclaw-cafcass",
+    "CRUD": "CRU"
   }
 ]

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/UploadAdditionalApplicationsAboutToSubmitControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/UploadAdditionalApplicationsAboutToSubmitControllerTest.java
@@ -31,7 +31,6 @@ import uk.gov.hmcts.reform.fpl.model.common.OtherApplicationsBundle;
 import uk.gov.hmcts.reform.fpl.model.common.dynamic.DynamicList;
 import uk.gov.hmcts.reform.fpl.model.common.dynamic.DynamicListElement;
 import uk.gov.hmcts.reform.fpl.model.order.selector.Selector;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 import uk.gov.hmcts.reform.fpl.service.DocumentSealingService;
 import uk.gov.hmcts.reform.fpl.service.time.Time;
 import uk.gov.hmcts.reform.idam.client.models.UserDetails;
@@ -39,15 +38,11 @@ import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 import java.util.List;
 import java.util.Map;
 
-import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static uk.gov.hmcts.reform.fpl.enums.C2ApplicationType.WITHOUT_NOTICE;
 import static uk.gov.hmcts.reform.fpl.enums.C2ApplicationType.WITH_NOTICE;
 import static uk.gov.hmcts.reform.fpl.enums.RepresentativeServingPreferences.EMAIL;
-import static uk.gov.hmcts.reform.fpl.enums.UserRole.HMCTS_ADMIN;
-import static uk.gov.hmcts.reform.fpl.enums.UserRole.JUDICIARY;
 import static uk.gov.hmcts.reform.fpl.model.common.DocumentReference.buildFromDocument;
 import static uk.gov.hmcts.reform.fpl.utils.CoreCaseDataStoreLoader.callbackRequest;
 import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.DATE_TIME;
@@ -64,17 +59,15 @@ import static uk.gov.hmcts.reform.fpl.utils.TestDataHelper.testDocumentReference
 class UploadAdditionalApplicationsAboutToSubmitControllerTest extends AbstractCallbackTest {
 
     private static final String USER_NAME = "HMCTS";
-    private static final Long CASE_ID = 12345L;
     private static final String LOCAL_AUTHORITY_NAME = "Swansea local authority";
     private static final String APPLICANT_SOMEONE_ELSE = "SOMEONE_ELSE";
     private static final String APPLICANT = "applicant";
     private static final String OTHER_APPLICANT_NAME = "some other name";
 
-    private static final DocumentReference uploadedDocument = testDocumentReference();
-    private static final DocumentReference sealedDocument = testDocumentReference();
+    private static final String ADMIN_ROLE = "caseworker-publiclaw-courtadmin";
 
-    @MockBean
-    private RequestData requestData;
+    private static final DocumentReference UPLOADED_DOCUMENT = testDocumentReference();
+    private static final DocumentReference SEALED_DOCUMENT = testDocumentReference();
 
     @MockBean
     private DocumentSealingService documentSealingService;
@@ -88,16 +81,16 @@ class UploadAdditionalApplicationsAboutToSubmitControllerTest extends AbstractCa
 
     @BeforeEach
     void before() {
-        given(requestData.authorisation()).willReturn(USER_AUTH_TOKEN);
-        given(idamClient.getUserDetails(eq(USER_AUTH_TOKEN))).willReturn(createUserDetailsWithHmctsRole());
-        given(documentSealingService.sealDocument(uploadedDocument)).willReturn(sealedDocument);
+        givenCurrentUser(createUserDetailsWithHmctsRole());
+        given(documentSealingService.sealDocument(UPLOADED_DOCUMENT)).willReturn(SEALED_DOCUMENT);
     }
 
     @Test
     void shouldCreateAdditionalApplicationsBundleWithC2DocumentWhenC2OrderIsSelectedAndSupplementsIncluded() {
         PBAPayment temporaryPbaPayment = createPbaPayment();
-        Element<Representative> representativeElement = element(Representative.builder()
-            .servingPreferences(EMAIL).email("test@test.com").build());
+        Element<Representative> representativeElement = element(
+            Representative.builder().servingPreferences(EMAIL).email("test@test.com").build()
+        );
 
         CaseData caseData = CaseData.builder()
             .additionalApplicationType(List.of(AdditionalApplicationType.C2_ORDER))
@@ -107,19 +100,24 @@ class UploadAdditionalApplicationsAboutToSubmitControllerTest extends AbstractCa
             .representatives(List.of(representativeElement))
             .respondents1(wrapElements(Respondent.builder()
                 .representedBy(wrapElements(representativeElement.getId()))
-                .party(RespondentParty.builder().firstName("Margaret").lastName("Jones").build()).build()))
-            .others(Others.builder().firstOther(
-                    Other.builder().name("Tim Jones").address(Address.builder().postcode("SE1").build()).build())
-                .additionalOthers(wrapElements(Other.builder().name("Stephen Jones")
-                    .address(Address.builder().postcode("SW2").build()).build())).build())
+                .party(RespondentParty.builder().firstName("Margaret").lastName("Jones").build())
+                .build()
+            ))
+            .others(Others.builder()
+                .firstOther(
+                    Other.builder().name("Tim Jones").address(Address.builder().postcode("SE1").build()).build()
+                )
+                .additionalOthers(wrapElements(
+                    Other.builder().name("Stephen Jones").address(Address.builder().postcode("SW2").build()).build()
+                ))
+                .build())
             .personSelector(Selector.newSelector(3))
             .notifyApplicationsToAllOthers(YesNo.YES.getValue()).build();
 
-        AboutToStartOrSubmitCallbackResponse callbackResponse = postAboutToSubmitEvent(caseData);
-        CaseData updatedCaseData = mapper.convertValue(callbackResponse.getData(), CaseData.class);
+        CaseData updatedCaseData = extractCaseData(postAboutToSubmitEvent(caseData, ADMIN_ROLE));
 
-        AdditionalApplicationsBundle additionalApplicationsBundle
-            = updatedCaseData.getAdditionalApplicationsBundle().get(0).getValue();
+        AdditionalApplicationsBundle additionalApplicationsBundle =
+            updatedCaseData.getAdditionalApplicationsBundle().get(0).getValue();
 
         C2DocumentBundle uploadedC2DocumentBundle = additionalApplicationsBundle.getC2DocumentBundle();
 
@@ -127,11 +125,11 @@ class UploadAdditionalApplicationsAboutToSubmitControllerTest extends AbstractCa
         assertThat(uploadedC2DocumentBundle.getApplicantName()).isEqualTo(LOCAL_AUTHORITY_NAME);
         assertThat(additionalApplicationsBundle.getPbaPayment()).isEqualTo(temporaryPbaPayment);
 
-        assertThat(uploadedC2DocumentBundle.getOthersNotified())
-            .contains("Margaret Jones, Tim Jones, Stephen Jones");
-        assertThat(unwrapElements(uploadedC2DocumentBundle.getOthers()))
-            .contains(updatedCaseData.getOthers().getFirstOther(),
-                updatedCaseData.getOthers().getAdditionalOthers().get(0).getValue());
+        assertThat(uploadedC2DocumentBundle.getOthersNotified()).contains("Margaret Jones, Tim Jones, Stephen Jones");
+        assertThat(unwrapElements(uploadedC2DocumentBundle.getOthers())).contains(
+            updatedCaseData.getOthers().getFirstOther(),
+            updatedCaseData.getOthers().getAdditionalOthers().get(0).getValue()
+        );
 
         assertTemporaryFieldsAreRemoved(updatedCaseData);
     }
@@ -139,13 +137,19 @@ class UploadAdditionalApplicationsAboutToSubmitControllerTest extends AbstractCa
     @Test
     void shouldCreateAdditionalApplicationsBundleWithOtherApplicationsBundleWhenOtherOrderIsSelected() {
         PBAPayment temporaryPbaPayment = createPbaPayment();
-        Element<Representative> representative = element(Representative.builder()
-            .servingPreferences(EMAIL).email("rep@test.com").build());
-        Element<Respondent> respondentElement = element(Respondent.builder()
-            .representedBy(wrapElements(representative.getId()))
-            .party(RespondentParty.builder().firstName("Margaret").lastName("Jones").build()).build());
+        Element<Representative> representative = element(
+            Representative.builder().servingPreferences(EMAIL).email("rep@test.com").build()
+        );
+        Element<Respondent> respondentElement = element(
+            Respondent.builder()
+                .representedBy(wrapElements(representative.getId()))
+                .party(RespondentParty.builder().firstName("Margaret").lastName("Jones").build())
+                .build()
+        );
+        Selector personSelector = Selector.newSelector(3);
+        personSelector.setSelected(List.of(0, 2));
 
-        CaseData.CaseDataBuilder caseDataBuilder = CaseData.builder()
+        CaseData caseData = CaseData.builder()
             .additionalApplicationType(List.of(AdditionalApplicationType.OTHER_ORDER))
             .temporaryOtherApplicationsBundle(createTemporaryOtherApplicationDocument())
             .temporaryPbaPayment(temporaryPbaPayment)
@@ -154,21 +158,21 @@ class UploadAdditionalApplicationsAboutToSubmitControllerTest extends AbstractCa
             .representatives(List.of(representative))
             .respondents1(List.of(respondentElement))
             .others(Others.builder()
-                .firstOther(Other.builder().name("Stephen Miller")
-                    .address(Address.builder().postcode("SE1").build()).build())
-                .additionalOthers(wrapElements(Other.builder().name("Alex Smith")
-                    .address(Address.builder().postcode("SE2").build()).build())).build());
+                .firstOther(
+                    Other.builder().name("Stephen Miller").address(Address.builder().postcode("SE1").build()).build()
+                )
+                .additionalOthers(wrapElements(
+                    Other.builder().name("Alex Smith").address(Address.builder().postcode("SE2").build()).build()
+                ))
+                .build())
+            .personSelector(personSelector)
+            .notifyApplicationsToAllOthers("No")
+            .build();
 
-        Selector personSelector = Selector.newSelector(3);
-        personSelector.setSelected(List.of(0, 2));
-        caseDataBuilder.personSelector(personSelector)
-            .notifyApplicationsToAllOthers("No");
+        CaseData updatedCaseData = extractCaseData(postAboutToSubmitEvent(caseData, ADMIN_ROLE));
 
-        AboutToStartOrSubmitCallbackResponse callbackResponse = postAboutToSubmitEvent(caseDataBuilder.build());
-        CaseData caseData = mapper.convertValue(callbackResponse.getData(), CaseData.class);
-
-        AdditionalApplicationsBundle additionalApplicationsBundle
-            = caseData.getAdditionalApplicationsBundle().get(0).getValue();
+        AdditionalApplicationsBundle additionalApplicationsBundle =
+            updatedCaseData.getAdditionalApplicationsBundle().get(0).getValue();
 
         assertOtherApplicationsBundle(additionalApplicationsBundle.getOtherApplicationsBundle());
         assertThat(additionalApplicationsBundle.getOtherApplicationsBundle().getApplicantName())
@@ -177,13 +181,13 @@ class UploadAdditionalApplicationsAboutToSubmitControllerTest extends AbstractCa
         assertThat(additionalApplicationsBundle.getOtherApplicationsBundle().getOthersNotified())
             .isEqualTo("Margaret Jones, Alex Smith");
         assertThat(additionalApplicationsBundle.getOtherApplicationsBundle().getOthers())
-            .isEqualTo(List.of(caseData.getOthers().getAdditionalOthers().get(0)));
+            .isEqualTo(List.of(updatedCaseData.getOthers().getAdditionalOthers().get(0)));
         assertThat(additionalApplicationsBundle.getOtherApplicationsBundle().getRespondents())
             .hasSize(1)
             .containsExactly(respondentElement);
 
         assertThat(additionalApplicationsBundle.getPbaPayment()).isEqualTo(temporaryPbaPayment);
-        assertTemporaryFieldsAreRemoved(caseData);
+        assertTemporaryFieldsAreRemoved(updatedCaseData);
     }
 
     @Test
@@ -191,19 +195,22 @@ class UploadAdditionalApplicationsAboutToSubmitControllerTest extends AbstractCa
         PBAPayment temporaryPbaPayment = createPbaPayment();
         CaseData caseData = CaseData.builder()
             .additionalApplicationType(
-                List.of(AdditionalApplicationType.C2_ORDER, AdditionalApplicationType.OTHER_ORDER))
+                List.of(AdditionalApplicationType.C2_ORDER, AdditionalApplicationType.OTHER_ORDER)
+            )
             .temporaryC2Document(createTemporaryC2Document())
             .temporaryOtherApplicationsBundle(createTemporaryOtherApplicationDocument())
             .temporaryPbaPayment(temporaryPbaPayment)
             .applicantsList(createApplicantsDynamicList(APPLICANT))
             .others(Others.builder()
-                .firstOther(Other.builder().name("Stephen Miller")
-                    .address(Address.builder().postcode("SE1").build()).build()).build())
+                .firstOther(
+                    Other.builder().name("Stephen Miller").address(Address.builder().postcode("SE1").build()).build()
+                )
+                .build()
+            )
             .personSelector(Selector.newSelector(1))
             .notifyApplicationsToAllOthers("No").build();
 
-        AboutToStartOrSubmitCallbackResponse callbackResponse = postAboutToSubmitEvent(caseData);
-        CaseData updatedCaseData = mapper.convertValue(callbackResponse.getData(), CaseData.class);
+        CaseData updatedCaseData = extractCaseData(postAboutToSubmitEvent(caseData, ADMIN_ROLE));
 
         AdditionalApplicationsBundle additionalApplicationsBundle
             = updatedCaseData.getAdditionalApplicationsBundle().get(0).getValue();
@@ -224,12 +231,12 @@ class UploadAdditionalApplicationsAboutToSubmitControllerTest extends AbstractCa
 
     @Test
     void shouldAppendAnAdditionalC2DocumentBundleWhenAdditionalDocumentsBundleIsPresent() {
-        CaseDetails caseDetails = callbackRequest().getCaseDetails();
-        caseDetails.getData().put("applicantsList", createApplicantsDynamicList(APPLICANT));
-        caseDetails.getData().put("temporaryC2Document", Map.of("document", uploadedDocument));
+        CaseData caseData = extractCaseData(callbackRequest()).toBuilder()
+            .applicantsList(createApplicantsDynamicList(APPLICANT))
+            .temporaryC2Document(C2DocumentBundle.builder().document(UPLOADED_DOCUMENT).build())
+            .build();
 
-        AboutToStartOrSubmitCallbackResponse callbackResponse = postAboutToSubmitEvent(caseDetails);
-        CaseData returnedCaseData = mapper.convertValue(callbackResponse.getData(), CaseData.class);
+        CaseData returnedCaseData = extractCaseData(postAboutToSubmitEvent(caseData, ADMIN_ROLE));
 
         AdditionalApplicationsBundle appendedApplicationsBundle
             = returnedCaseData.getAdditionalApplicationsBundle().get(0).getValue();
@@ -242,7 +249,7 @@ class UploadAdditionalApplicationsAboutToSubmitControllerTest extends AbstractCa
         String expectedDateTime = formatLocalDateTimeBaseUsingFormat(now(), DATE_TIME);
         assertThat(appendedC2Document.getUploadedDateTime()).isEqualTo(expectedDateTime);
         assertDocument(existingC2Document.getDocument(), buildFromDocument(document()));
-        assertDocument(appendedC2Document.getDocument(), sealedDocument);
+        assertDocument(appendedC2Document.getDocument(), SEALED_DOCUMENT);
 
         assertThat(returnedCaseData.getTemporaryC2Document()).isNull();
         assertThat(appendedC2Document.getAuthor()).isEqualTo(USER_NAME);
@@ -263,13 +270,11 @@ class UploadAdditionalApplicationsAboutToSubmitControllerTest extends AbstractCa
                 "notifyApplicationsToAllOthers", "Yes"))
             .build();
 
-        AboutToStartOrSubmitCallbackResponse callbackResponse = postAboutToSubmitEvent(caseDetails);
+        AboutToStartOrSubmitCallbackResponse callbackResponse = postAboutToSubmitEvent(caseDetails, ADMIN_ROLE);
 
-        assertThat(callbackResponse.getData().get("c2Type")).isNull();
-        assertThat(callbackResponse.getData().get("people_label")).isNull();
-        assertThat(callbackResponse.getData().get("hasRespondentsOrOthers")).isNull();
+        assertThat(callbackResponse.getData()).doesNotContainKeys("c2Type", "people_label", "hasRespondentsOrOthers");
 
-        CaseData caseData = mapper.convertValue(callbackResponse.getData(), CaseData.class);
+        CaseData caseData = extractCaseData(callbackResponse);
         assertTemporaryFieldsAreRemoved(caseData);
     }
 
@@ -278,37 +283,33 @@ class UploadAdditionalApplicationsAboutToSubmitControllerTest extends AbstractCa
         C2DocumentBundle firstBundleAdded = C2DocumentBundle.builder()
             .type(WITHOUT_NOTICE)
             .uploadedDateTime("14 December 2020, 4:24pm")
-            .document(DocumentReference.builder()
-                .filename("Document 1")
-                .build()).build();
+            .document(DocumentReference.builder().filename("Document 1").build())
+            .build();
 
         C2DocumentBundle secondBundleAdded = C2DocumentBundle.builder()
             .type(WITH_NOTICE)
             .uploadedDateTime("15 December 2020, 4:24pm")
-            .document(DocumentReference.builder()
-                .filename("Document 2")
-                .build()).build();
+            .document(DocumentReference.builder().filename("Document 2").build())
+            .build();
 
         C2DocumentBundle thirdBundleAdded = C2DocumentBundle.builder()
             .type(WITH_NOTICE)
             .uploadedDateTime("16 December 2020, 4:24pm")
-            .document(DocumentReference.builder()
-                .filename("Document 3")
-                .build()).build();
-
-        CaseDetails caseDetails = CaseDetails.builder()
-            .data(Map.of(
-                "c2DocumentBundle", wrapElements(firstBundleAdded, secondBundleAdded, thirdBundleAdded),
-                "applicantsList", createApplicantsDynamicList(APPLICANT)))
+            .document(DocumentReference.builder().filename("Document 3").build())
             .build();
 
-        AboutToStartOrSubmitCallbackResponse callbackResponse = postAboutToSubmitEvent(caseDetails);
-        CaseData caseData = mapper.convertValue(callbackResponse.getData(), CaseData.class);
+        CaseData caseData = CaseData.builder()
+            .c2DocumentBundle(wrapElements(firstBundleAdded, secondBundleAdded, thirdBundleAdded))
+            .applicantsList(createApplicantsDynamicList(APPLICANT))
+            .build();
 
-        List<Element<C2DocumentBundle>> expectedC2DocumentBundle = wrapElements(thirdBundleAdded, secondBundleAdded,
-            firstBundleAdded);
+        CaseData updatedCaseData = extractCaseData(postAboutToSubmitEvent(caseData, ADMIN_ROLE));
 
-        assertThat(caseData.getC2DocumentBundle()).isEqualTo(expectedC2DocumentBundle);
+        List<Element<C2DocumentBundle>> expectedC2DocumentBundle = wrapElements(
+            thirdBundleAdded, secondBundleAdded, firstBundleAdded
+        );
+
+        assertThat(updatedCaseData.getC2DocumentBundle()).isEqualTo(expectedC2DocumentBundle);
     }
 
     private void assertC2DocumentBundle(C2DocumentBundle uploadedC2DocumentBundle) {
@@ -317,7 +318,7 @@ class UploadAdditionalApplicationsAboutToSubmitControllerTest extends AbstractCa
         assertThat(uploadedC2DocumentBundle.getUploadedDateTime()).isEqualTo(expectedDateTime);
 
         assertThat(uploadedC2DocumentBundle.getAuthor()).isEqualTo(USER_NAME);
-        assertDocument(uploadedC2DocumentBundle.getDocument(), sealedDocument);
+        assertDocument(uploadedC2DocumentBundle.getDocument(), SEALED_DOCUMENT);
         assertSupportingEvidenceBundle(uploadedC2DocumentBundle.getSupportingEvidenceBundle());
         assertSupplementsBundle(uploadedC2DocumentBundle.getSupplementsBundle());
     }
@@ -334,7 +335,7 @@ class UploadAdditionalApplicationsAboutToSubmitControllerTest extends AbstractCa
         assertSupportingEvidenceBundle(uploadedOtherApplicationsBundle.getSupportingEvidenceBundle());
         assertSupplementsBundle(uploadedOtherApplicationsBundle.getSupplementsBundle());
 
-        assertThat(uploadedOtherApplicationsBundle.getDocument()).isEqualTo(sealedDocument);
+        assertThat(uploadedOtherApplicationsBundle.getDocument()).isEqualTo(SEALED_DOCUMENT);
     }
 
     private void assertTemporaryFieldsAreRemoved(CaseData caseData) {
@@ -368,7 +369,7 @@ class UploadAdditionalApplicationsAboutToSubmitControllerTest extends AbstractCa
             "Supporting document",
             "Document notes",
             time.now(),
-            uploadedDocument,
+            UPLOADED_DOCUMENT,
             USER_NAME
         );
     }
@@ -386,7 +387,7 @@ class UploadAdditionalApplicationsAboutToSubmitControllerTest extends AbstractCa
             SupplementType.C13A_SPECIAL_GUARDIANSHIP,
             "Supplement notes",
             time.now(),
-            sealedDocument,
+            SEALED_DOCUMENT,
             USER_NAME
         );
     }
@@ -398,37 +399,32 @@ class UploadAdditionalApplicationsAboutToSubmitControllerTest extends AbstractCa
     private C2DocumentBundle createTemporaryC2Document() {
         return C2DocumentBundle.builder()
             .type(WITH_NOTICE)
-            .document(uploadedDocument)
+            .document(UPLOADED_DOCUMENT)
             .supplementsBundle(wrapElements(createSupplementsBundle()))
             .supportingEvidenceBundle(wrapElements(createSupportingEvidenceBundle()))
             .build();
     }
 
     private DynamicList createApplicantsDynamicList(String selected) {
-        DynamicListElement applicant = DynamicListElement.builder()
-            .code(APPLICANT).label(LOCAL_AUTHORITY_NAME).build();
+        DynamicListElement applicant = DynamicListElement.builder().code(APPLICANT).label(LOCAL_AUTHORITY_NAME).build();
 
         DynamicListElement other = DynamicListElement.builder()
-            .code(APPLICANT_SOMEONE_ELSE).label("Someone else").build();
+            .code(APPLICANT_SOMEONE_ELSE)
+            .label("Someone else")
+            .build();
 
         return DynamicList.builder()
             .value(APPLICANT.equals(selected) ? applicant : other)
-            .listItems(List.of(applicant, other)).build();
+            .listItems(List.of(applicant, other))
+            .build();
     }
 
     private OtherApplicationsBundle createTemporaryOtherApplicationDocument() {
         return OtherApplicationsBundle.builder()
             .applicationType(OtherApplicationType.C1_APPOINTMENT_OF_A_GUARDIAN)
-            .document(uploadedDocument)
+            .document(UPLOADED_DOCUMENT)
             .supplementsBundle(wrapElements(createSupplementsBundle()))
             .supportingEvidenceBundle(wrapElements(createSupportingEvidenceBundle()))
-            .build();
-    }
-
-    private CaseDetails createCase(Map<String, Object> data) {
-        return CaseDetails.builder()
-            .data(data)
-            .id(CASE_ID)
             .build();
     }
 
@@ -437,7 +433,7 @@ class UploadAdditionalApplicationsAboutToSubmitControllerTest extends AbstractCa
             .name("Supporting document")
             .notes("Document notes")
             .dateTimeUploaded(time.now())
-            .document(uploadedDocument)
+            .document(UPLOADED_DOCUMENT)
             .build();
     }
 
@@ -446,7 +442,7 @@ class UploadAdditionalApplicationsAboutToSubmitControllerTest extends AbstractCa
             .name(SupplementType.C13A_SPECIAL_GUARDIANSHIP)
             .notes("Supplement notes")
             .dateTimeUploaded(time.now())
-            .document(uploadedDocument)
+            .document(UPLOADED_DOCUMENT)
             .build();
     }
 
@@ -456,7 +452,7 @@ class UploadAdditionalApplicationsAboutToSubmitControllerTest extends AbstractCa
             .surname("Hudson")
             .forename("Steve")
             .email("steve.hudson@gov.uk")
-            .roles(asList(HMCTS_ADMIN.getRoleName(), JUDICIARY.getRoleName()))
+            .roles(List.of(ADMIN_ROLE))
             .build();
     }
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/UserService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/UserService.java
@@ -44,8 +44,7 @@ public class UserService {
 
     public boolean hasAnyCaseRoleFrom(List<CaseRole> caseRoles, Long caseId) {
         final Set<CaseRole> userCaseRoles = getCaseRoles(caseId);
-
-        return getCaseRoles(caseId).stream().anyMatch(caseRoles::contains);
+        return userCaseRoles.stream().anyMatch(caseRoles::contains);
     }
 
     public Set<CaseRole> getCaseRoles(Long caseId) {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/additionalapplications/UploadAdditionalApplicationsService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/additionalapplications/UploadAdditionalApplicationsService.java
@@ -20,6 +20,8 @@ import uk.gov.hmcts.reform.fpl.model.common.dynamic.DynamicList;
 import uk.gov.hmcts.reform.fpl.model.common.dynamic.DynamicListElement;
 import uk.gov.hmcts.reform.fpl.service.DocumentSealingService;
 import uk.gov.hmcts.reform.fpl.service.PeopleInCaseService;
+import uk.gov.hmcts.reform.fpl.service.UserService;
+import uk.gov.hmcts.reform.fpl.service.docmosis.DocumentConversionService;
 import uk.gov.hmcts.reform.fpl.service.time.Time;
 import uk.gov.hmcts.reform.fpl.utils.DocumentUploadHelper;
 
@@ -31,27 +33,28 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static java.util.Collections.emptyList;
 import static java.util.Comparator.comparing;
 import static java.util.Comparator.reverseOrder;
 import static java.util.Objects.isNull;
-import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+import static java.util.function.Predicate.not;
 import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
-import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static uk.gov.hmcts.reform.fpl.enums.ApplicationType.C2_APPLICATION;
 import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.DATE_TIME;
 import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.formatLocalDateTimeBaseUsingFormat;
+import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.nullSafeList;
 
 @Service
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class UploadAdditionalApplicationsService {
 
-    public static final String APPLICANT_SOMEONE_ELSE = "SOMEONE_ELSE";
+    private static final String APPLICANT_SOMEONE_ELSE = "SOMEONE_ELSE";
 
     private final Time time;
+    private final UserService user;
     private final DocumentUploadHelper documentUploadHelper;
     private final DocumentSealingService documentSealingService;
+    private final DocumentConversionService documentConversionService;
     private final PeopleInCaseService peopleInCaseService;
 
     public List<ApplicationType> getApplicationTypes(AdditionalApplicationsBundle bundle) {
@@ -68,44 +71,44 @@ public class UploadAdditionalApplicationsService {
     }
 
     public AdditionalApplicationsBundle buildAdditionalApplicationsBundle(CaseData caseData) {
-        final Optional<String> applicantName = getSelectedApplicantName(
-            caseData.getApplicantsList(), defaultIfNull(caseData.getOtherApplicant(), EMPTY)
-        );
-
-        if (applicantName.isEmpty()) {
-            throw new IllegalArgumentException("Applicant should not be empty");
-        }
+        String applicantName = getSelectedApplicantName(caseData.getApplicantsList(), caseData.getOtherApplicant())
+            .filter(not(String::isBlank))
+            .orElseThrow(() -> new IllegalArgumentException("Applicant should not be empty"));
 
         final String uploadedBy = documentUploadHelper.getUploadedDocumentUserDetails();
-        final LocalDateTime currentDateTime = time.now();
+        final LocalDateTime now = time.now();
 
         List<Element<Other>> selectedOthers = peopleInCaseService.getSelectedOthers(caseData);
         List<Element<Respondent>> selectedRespondents = peopleInCaseService.getSelectedRespondents(caseData);
         String othersNotified = peopleInCaseService.getPeopleNotified(
-            caseData.getRepresentatives(), selectedRespondents, selectedOthers);
+            caseData.getRepresentatives(), selectedRespondents, selectedOthers
+        );
 
         AdditionalApplicationsBundleBuilder additionalApplicationsBundleBuilder = AdditionalApplicationsBundle.builder()
             .pbaPayment(caseData.getTemporaryPbaPayment())
             .amountToPay(caseData.getAmountToPay())
             .author(uploadedBy)
-            .uploadedDateTime(formatLocalDateTimeBaseUsingFormat(currentDateTime, DATE_TIME));
+            .uploadedDateTime(formatLocalDateTimeBaseUsingFormat(now, DATE_TIME));
 
         List<AdditionalApplicationType> additionalApplicationTypeList = caseData.getAdditionalApplicationType();
         if (additionalApplicationTypeList.contains(AdditionalApplicationType.C2_ORDER)) {
-            additionalApplicationsBundleBuilder.c2DocumentBundle(
-                buildC2DocumentBundle(caseData, applicantName.get(), selectedOthers, selectedRespondents,
-                    othersNotified, uploadedBy, currentDateTime)
-            );
+            additionalApplicationsBundleBuilder.c2DocumentBundle(buildC2DocumentBundle(
+                caseData, applicantName, selectedOthers, selectedRespondents, othersNotified, uploadedBy, now
+            ));
         }
 
         if (additionalApplicationTypeList.contains(AdditionalApplicationType.OTHER_ORDER)) {
-            additionalApplicationsBundleBuilder.otherApplicationsBundle(
-                buildOtherApplicationsBundle(caseData, applicantName.get(), selectedOthers, selectedRespondents,
-                    othersNotified, uploadedBy, currentDateTime)
-            );
+            additionalApplicationsBundleBuilder.otherApplicationsBundle(buildOtherApplicationsBundle(
+                caseData, applicantName, selectedOthers, selectedRespondents, othersNotified, uploadedBy, now
+            ));
         }
 
         return additionalApplicationsBundleBuilder.build();
+    }
+
+    public List<Element<C2DocumentBundle>> sortOldC2DocumentCollection(List<Element<C2DocumentBundle>> bundles) {
+        bundles.sort(comparing(bundle -> bundle.getValue().getUploadedDateTime(), reverseOrder()));
+        return bundles;
     }
 
     private Optional<String> getSelectedApplicantName(DynamicList applicantsList, String otherApplicant) {
@@ -132,20 +135,19 @@ public class UploadAdditionalApplicationsService {
                                                    LocalDateTime uploadedTime) {
         C2DocumentBundle temporaryC2Document = caseData.getTemporaryC2Document();
 
-        DocumentReference sealedDocument = documentSealingService.sealDocument(temporaryC2Document.getDocument());
-
         List<Element<SupportingEvidenceBundle>> updatedSupportingEvidenceBundle = getSupportingEvidenceBundle(
-            temporaryC2Document.getSupportingEvidenceBundle(), uploadedBy, uploadedTime);
+            temporaryC2Document.getSupportingEvidenceBundle(), uploadedBy, uploadedTime
+        );
 
-        List<Element<Supplement>> updatedSupplementsBundle =
-            getSupplementsBundle(defaultIfNull(temporaryC2Document.getSupplementsBundle(), emptyList()),
-                uploadedBy, uploadedTime);
+        List<Element<Supplement>> updatedSupplementsBundle = getSupplementsBundle(
+            temporaryC2Document.getSupplementsBundle(), uploadedBy, uploadedTime
+        );
 
         return temporaryC2Document.toBuilder()
             .id(UUID.randomUUID())
             .applicantName(applicantName)
             .author(uploadedBy)
-            .document(sealedDocument)
+            .document(getDocumentToStore(temporaryC2Document.getDocument()))
             .uploadedDateTime(formatLocalDateTimeBaseUsingFormat(uploadedTime, DATE_TIME))
             .supplementsBundle(updatedSupplementsBundle)
             .supportingEvidenceBundle(updatedSupportingEvidenceBundle)
@@ -163,17 +165,15 @@ public class UploadAdditionalApplicationsService {
                                                                  String othersNotified,
                                                                  String uploadedBy,
                                                                  LocalDateTime uploadedTime) {
-
         OtherApplicationsBundle temporaryOtherApplicationsBundle = caseData.getTemporaryOtherApplicationsBundle();
 
-        DocumentReference sealedDocument =
-            documentSealingService.sealDocument(temporaryOtherApplicationsBundle.getDocument());
-
         List<Element<SupportingEvidenceBundle>> updatedSupportingEvidenceBundle = getSupportingEvidenceBundle(
-            temporaryOtherApplicationsBundle.getSupportingEvidenceBundle(), uploadedBy, uploadedTime);
+            temporaryOtherApplicationsBundle.getSupportingEvidenceBundle(), uploadedBy, uploadedTime
+        );
 
         List<Element<Supplement>> updatedSupplementsBundle = getSupplementsBundle(
-            temporaryOtherApplicationsBundle.getSupplementsBundle(), uploadedBy, uploadedTime);
+            temporaryOtherApplicationsBundle.getSupplementsBundle(), uploadedBy, uploadedTime
+        );
 
         return temporaryOtherApplicationsBundle.toBuilder()
             .author(uploadedBy)
@@ -181,19 +181,13 @@ public class UploadAdditionalApplicationsService {
             .applicantName(applicantName)
             .uploadedDateTime(formatLocalDateTimeBaseUsingFormat(uploadedTime, DATE_TIME))
             .applicationType(temporaryOtherApplicationsBundle.getApplicationType())
-            .document(sealedDocument)
+            .document(getDocumentToStore(temporaryOtherApplicationsBundle.getDocument()))
             .supportingEvidenceBundle(updatedSupportingEvidenceBundle)
             .supplementsBundle(updatedSupplementsBundle)
             .respondents(selectedRespondents)
             .others(selectedOthers)
             .othersNotified(othersNotified)
             .build();
-    }
-
-    public List<Element<C2DocumentBundle>> sortOldC2DocumentCollection(
-        List<Element<C2DocumentBundle>> c2DocumentBundle) {
-        c2DocumentBundle.sort(comparing(e -> e.getValue().getUploadedDateTime(), reverseOrder()));
-        return c2DocumentBundle;
     }
 
     private List<Element<SupportingEvidenceBundle>> getSupportingEvidenceBundle(
@@ -208,21 +202,24 @@ public class UploadAdditionalApplicationsService {
         return supportingEvidenceBundle;
     }
 
-    private List<Element<Supplement>> getSupplementsBundle(
-        List<Element<Supplement>> supplementsBundle, String uploadedBy, LocalDateTime dateTime) {
+    private List<Element<Supplement>> getSupplementsBundle(List<Element<Supplement>> supplementsBundle,
+                                                           String uploadedBy, LocalDateTime dateTime) {
+        return nullSafeList(supplementsBundle).stream()
+            .map(supplementElement -> {
+                Supplement incomingSupplement = supplementElement.getValue();
+                Supplement modifiedSupplement = incomingSupplement.toBuilder()
+                    .document(getDocumentToStore(incomingSupplement.getDocument()))
+                    .dateTimeUploaded(dateTime)
+                    .uploadedBy(uploadedBy)
+                    .build();
 
-        return supplementsBundle.stream().map(supplementElement -> {
-            Supplement incomingSupplement = supplementElement.getValue();
-
-            DocumentReference sealedDocument = documentSealingService.sealDocument(incomingSupplement.getDocument());
-            Supplement modifiedSupplement = incomingSupplement.toBuilder()
-                .document(sealedDocument)
-                .dateTimeUploaded(dateTime)
-                .uploadedBy(uploadedBy)
-                .build();
-
-            return supplementElement.toBuilder().value(modifiedSupplement).build();
-        }).collect(Collectors.toList());
+                return supplementElement.toBuilder().value(modifiedSupplement).build();
+            })
+            .collect(Collectors.toList());
     }
 
+    private DocumentReference getDocumentToStore(DocumentReference originalDoc) {
+        return user.isHmctsUser() ? documentSealingService.sealDocument(originalDoc)
+                                  : documentConversionService.convertToPdf(originalDoc);
+    }
 }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/additionalapplications/UploadAdditionalApplicationsServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/additionalapplications/UploadAdditionalApplicationsServiceTest.java
@@ -2,15 +2,10 @@ package uk.gov.hmcts.reform.fpl.service.additionalapplications;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.fpl.enums.ApplicationType;
 import uk.gov.hmcts.reform.fpl.enums.C2AdditionalOrdersRequested;
 import uk.gov.hmcts.reform.fpl.enums.ParentalResponsibilityType;
@@ -30,15 +25,13 @@ import uk.gov.hmcts.reform.fpl.model.common.Element;
 import uk.gov.hmcts.reform.fpl.model.common.OtherApplicationsBundle;
 import uk.gov.hmcts.reform.fpl.model.common.dynamic.DynamicList;
 import uk.gov.hmcts.reform.fpl.model.common.dynamic.DynamicListElement;
-import uk.gov.hmcts.reform.fpl.request.RequestData;
 import uk.gov.hmcts.reform.fpl.service.DocumentSealingService;
-import uk.gov.hmcts.reform.fpl.service.FeatureToggleService;
 import uk.gov.hmcts.reform.fpl.service.PeopleInCaseService;
+import uk.gov.hmcts.reform.fpl.service.UserService;
+import uk.gov.hmcts.reform.fpl.service.docmosis.DocumentConversionService;
 import uk.gov.hmcts.reform.fpl.service.time.Time;
 import uk.gov.hmcts.reform.fpl.utils.DocumentUploadHelper;
 import uk.gov.hmcts.reform.fpl.utils.FixedTimeConfiguration;
-import uk.gov.hmcts.reform.idam.client.IdamClient;
-import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 
 import java.util.Arrays;
 import java.util.List;
@@ -49,7 +42,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static uk.gov.hmcts.reform.fpl.Constants.USER_AUTH_TOKEN;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static uk.gov.hmcts.reform.fpl.enums.AdditionalApplicationType.C2_ORDER;
 import static uk.gov.hmcts.reform.fpl.enums.AdditionalApplicationType.OTHER_ORDER;
 import static uk.gov.hmcts.reform.fpl.enums.ApplicationType.C2_APPLICATION;
@@ -64,16 +58,18 @@ import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.element;
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.wrapElements;
 import static uk.gov.hmcts.reform.fpl.utils.TestDataHelper.testDocumentReference;
 
-@ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = {
-    UploadAdditionalApplicationsService.class,
-    FixedTimeConfiguration.class,
-    DocumentUploadHelper.class
-})
 class UploadAdditionalApplicationsServiceTest {
 
-    private static final String USER_ID = "1";
     private static final String HMCTS = "HMCTS";
+    private static final String USER_EMAIL = "user@email.random";
+
+    private static final String APPLICANT_NAME = "Swansea local authority, Applicant";
+    private static final String APPLICANT_SOMEONE_ELSE = "SOMEONE_ELSE";
+
+    private static final List<DynamicListElement> DYNAMIC_LIST_ELEMENTS = List.of(
+        DynamicListElement.builder().code("applicant").label(APPLICANT_NAME).build(),
+        DynamicListElement.builder().code(APPLICANT_SOMEONE_ELSE).label("Someone else").build()
+    );
 
     private static final DocumentReference DOCUMENT = testDocumentReference("TestDocument.doc");
     private static final DocumentReference SEALED_CONVERTED_DOCUMENT = testDocumentReference("TestDocument.pdf");
@@ -83,40 +79,26 @@ class UploadAdditionalApplicationsServiceTest {
 
     private static final DocumentReference SUPPORTING_DOCUMENT = testDocumentReference("SupportingEvidenceFile.doc");
 
-    @Autowired
-    private Time time;
+    private final Time time = new FixedTimeConfiguration().stoppedTime();
+    private final UserService user = mock(UserService.class);
+    private final DocumentUploadHelper uploadHelper = mock(DocumentUploadHelper.class);
+    private final DocumentSealingService sealingService = mock(DocumentSealingService.class);
+    private final DocumentConversionService conversionService = mock(DocumentConversionService.class);
+    private final PeopleInCaseService peopleInCaseService = mock(PeopleInCaseService.class);
 
-    @MockBean
-    private IdamClient idamClient;
-
-    @MockBean
-    private RequestData requestData;
-
-    @MockBean
-    private DocumentSealingService documentSealingService;
-
-    @MockBean
-    private PeopleInCaseService peopleInCaseService;
-
-    @MockBean
-    private FeatureToggleService featureToggleService;
-
-    @Autowired
     private UploadAdditionalApplicationsService underTest;
-
-    public static final String APPLICANT_NAME = "Swansea local authority, Applicant";
-    public static final String APPLICANT_SOMEONE_ELSE = "SOMEONE_ELSE";
-
-    private static final List<DynamicListElement> DYNAMIC_LIST_ELEMENTS = List.of(
-        DynamicListElement.builder().code("applicant").label(APPLICANT_NAME).build(),
-        DynamicListElement.builder().code(APPLICANT_SOMEONE_ELSE).label("Someone else").build());
 
     @BeforeEach()
     void init() {
-        given(idamClient.getUserDetails(USER_AUTH_TOKEN)).willReturn(createUserDetailsWithHmctsRole());
-        given(requestData.authorisation()).willReturn(USER_AUTH_TOKEN);
-        given(documentSealingService.sealDocument(DOCUMENT)).willReturn(SEALED_CONVERTED_DOCUMENT);
-        given(documentSealingService.sealDocument(SUPPLEMENT_DOCUMENT)).willReturn(SEALED_SUPPLEMENT_DOCUMENT);
+        underTest = new UploadAdditionalApplicationsService(
+            time, user, uploadHelper, sealingService, conversionService, peopleInCaseService
+        );
+
+        given(user.isHmctsUser()).willReturn(true);
+        given(uploadHelper.getUploadedDocumentUserDetails()).willReturn(HMCTS);
+
+        given(sealingService.sealDocument(DOCUMENT)).willReturn(SEALED_CONVERTED_DOCUMENT);
+        given(sealingService.sealDocument(SUPPLEMENT_DOCUMENT)).willReturn(SEALED_SUPPLEMENT_DOCUMENT);
     }
 
     @Test
@@ -126,7 +108,9 @@ class UploadAdditionalApplicationsServiceTest {
         PBAPayment pbaPayment = buildPBAPayment();
 
         DynamicList applicantsList = DynamicList.builder()
-            .value(DYNAMIC_LIST_ELEMENTS.get(0)).listItems(DYNAMIC_LIST_ELEMENTS).build();
+            .value(DYNAMIC_LIST_ELEMENTS.get(0))
+            .listItems(DYNAMIC_LIST_ELEMENTS)
+            .build();
 
         CaseData caseData = CaseData.builder()
             .additionalApplicationType(List.of(C2_ORDER))
@@ -143,6 +127,46 @@ class UploadAdditionalApplicationsServiceTest {
         assertThat(actual.getC2DocumentBundle().getApplicantName()).isEqualTo(APPLICANT_NAME);
 
         assertC2DocumentBundle(actual.getC2DocumentBundle(), supplement, supportingEvidenceBundle);
+
+        verifyNoInteractions(conversionService);
+    }
+
+    @Test
+    void shouldOnlyConvertApplicationsWhenNotHMCTS() {
+        given(user.isHmctsUser()).willReturn(false);
+        given(uploadHelper.getUploadedDocumentUserDetails()).willReturn(USER_EMAIL);
+
+        // Returning the same doc simulating the upload pdf flow
+        given(conversionService.convertToPdf(SUPPLEMENT_DOCUMENT)).willReturn(SUPPLEMENT_DOCUMENT);
+        given(conversionService.convertToPdf(DOCUMENT)).willReturn(DOCUMENT);
+
+        Supplement supplement = createSupplementsBundle();
+        SupportingEvidenceBundle supportingEvidenceBundle = createSupportingEvidenceBundle();
+        PBAPayment pbaPayment = buildPBAPayment();
+
+        DynamicList applicantsList = DynamicList.builder()
+            .value(DYNAMIC_LIST_ELEMENTS.get(0))
+            .listItems(DYNAMIC_LIST_ELEMENTS)
+            .build();
+
+        CaseData caseData = CaseData.builder()
+            .additionalApplicationType(List.of(C2_ORDER))
+            .temporaryC2Document(createC2DocumentBundle(supplement, supportingEvidenceBundle))
+            .temporaryPbaPayment(pbaPayment)
+            .applicantsList(applicantsList)
+            .c2Type(WITH_NOTICE)
+            .build();
+
+        AdditionalApplicationsBundle actual = underTest.buildAdditionalApplicationsBundle(caseData);
+
+        assertThat(actual.getAuthor()).isEqualTo(USER_EMAIL);
+        assertThat(actual.getC2DocumentBundle().getDocument()).isEqualTo(DOCUMENT);
+        assertThat(actual.getC2DocumentBundle().getSupplementsBundle()).hasSize(1)
+            .first()
+            .extracting(actualSupplement -> actualSupplement.getValue().getDocument())
+            .isEqualTo(SUPPLEMENT_DOCUMENT);
+
+        verifyNoInteractions(sealingService);
     }
 
     @Test
@@ -153,7 +177,9 @@ class UploadAdditionalApplicationsServiceTest {
 
         // select "Someone else"
         DynamicList applicantsList = DynamicList.builder()
-            .value(DYNAMIC_LIST_ELEMENTS.get(1)).listItems(DYNAMIC_LIST_ELEMENTS).build();
+            .value(DYNAMIC_LIST_ELEMENTS.get(1))
+            .listItems(DYNAMIC_LIST_ELEMENTS)
+            .build();
 
         CaseData caseData = CaseData.builder()
             .additionalApplicationType(List.of(OTHER_ORDER))
@@ -221,7 +247,8 @@ class UploadAdditionalApplicationsServiceTest {
 
         List<Element<Other>> selectedOthers = wrapElements(
             Other.builder().name("Other1").address(Address.builder().postcode("SE1").build()).build(),
-            Other.builder().name("Other2").address(Address.builder().postcode("SE2").build()).build());
+            Other.builder().name("Other2").address(Address.builder().postcode("SE2").build()).build()
+        );
 
         List<Element<Respondent>> selectedRespondents = wrapElements(
             Respondent.builder().party(
@@ -248,40 +275,6 @@ class UploadAdditionalApplicationsServiceTest {
 
         assertC2DocumentBundle(actual.getC2DocumentBundle(), c2Supplement, c2SupportingDocument);
         assertOtherDocumentBundle(actual.getOtherApplicationsBundle(), otherSupplement, otherSupportingDocument);
-    }
-
-    private void assertC2DocumentBundle(
-        C2DocumentBundle actualC2Bundle,
-        Supplement expectedSupplement,
-        SupportingEvidenceBundle expectedSupportingEvidence
-    ) {
-        assertThat(actualC2Bundle.getId()).isNotNull();
-        assertThat(actualC2Bundle.getDocument().getFilename()).isEqualTo(SEALED_CONVERTED_DOCUMENT.getFilename());
-        assertThat(actualC2Bundle.getType()).isEqualTo(WITH_NOTICE);
-        assertThat(actualC2Bundle.getSupportingEvidenceBundle()).hasSize(1);
-        assertThat(actualC2Bundle.getSupplementsBundle()).hasSize(1);
-
-        assertSupplementsBundle(actualC2Bundle.getSupplementsBundle().get(0).getValue(), expectedSupplement);
-        assertSupportingEvidenceBundle(
-            actualC2Bundle.getSupportingEvidenceBundle().get(0).getValue(), expectedSupportingEvidence);
-    }
-
-    private void assertOtherDocumentBundle(
-        OtherApplicationsBundle actual,
-        Supplement expectedSupplement,
-        SupportingEvidenceBundle expectedSupportingDocument
-    ) {
-        assertThat(actual.getId()).isNotNull();
-        assertThat(actual.getDocument().getFilename()).isEqualTo(SEALED_CONVERTED_DOCUMENT.getFilename());
-        assertThat(actual.getApplicationType()).isEqualTo(C1_PARENTAL_RESPONSIBILITY);
-        assertThat(actual.getParentalResponsibilityType()).isEqualTo(PR_BY_FATHER);
-        assertThat(actual.getAuthor()).isEqualTo(HMCTS);
-        assertThat(actual.getSupportingEvidenceBundle()).hasSize(1);
-        assertThat(actual.getSupplementsBundle()).hasSize(1);
-
-        assertSupplementsBundle(actual.getSupplementsBundle().get(0).getValue(), expectedSupplement);
-        assertSupportingEvidenceBundle(
-            actual.getSupportingEvidenceBundle().get(0).getValue(), expectedSupportingDocument);
     }
 
     @Test
@@ -330,25 +323,65 @@ class UploadAdditionalApplicationsServiceTest {
 
     private static Stream<Arguments> additionalApplicationBundlesData() {
         return Stream.of(
-            Arguments.of(AdditionalApplicationsBundle.builder().c2DocumentBundle(
-                    C2DocumentBundle.builder()
-                        .type(WITHOUT_NOTICE)
-                        .document(DocumentReference.builder().build()).build()).build(),
-                List.of(C2_APPLICATION)),
-            Arguments.of(AdditionalApplicationsBundle.builder().otherApplicationsBundle(
-                    OtherApplicationsBundle.builder()
-                        .applicationType(C1_PARENTAL_RESPONSIBILITY)
-                        .document(DocumentReference.builder().build()).build()).build(),
-                List.of(ApplicationType.C1_PARENTAL_RESPONSIBILITY)),
-            Arguments.of(AdditionalApplicationsBundle.builder().c2DocumentBundle(
+            Arguments.of(AdditionalApplicationsBundle.builder()
+                    .c2DocumentBundle(
                         C2DocumentBundle.builder()
-                            .type(WITH_NOTICE)
-                            .document(DocumentReference.builder().build()).build())
+                            .type(WITHOUT_NOTICE)
+                            .document(DocumentReference.builder().build())
+                            .build())
+                    .build(),
+                List.of(C2_APPLICATION)),
+            Arguments.of(AdditionalApplicationsBundle.builder()
                     .otherApplicationsBundle(
                         OtherApplicationsBundle.builder()
                             .applicationType(C1_PARENTAL_RESPONSIBILITY)
-                            .document(DocumentReference.builder().build()).build()).build(),
+                            .document(DocumentReference.builder().build())
+                            .build())
+                    .build(),
+                List.of(ApplicationType.C1_PARENTAL_RESPONSIBILITY)),
+            Arguments.of(AdditionalApplicationsBundle.builder()
+                    .c2DocumentBundle(
+                        C2DocumentBundle.builder()
+                            .type(WITH_NOTICE)
+                            .document(DocumentReference.builder().build())
+                            .build())
+                    .otherApplicationsBundle(
+                        OtherApplicationsBundle.builder()
+                            .applicationType(C1_PARENTAL_RESPONSIBILITY)
+                            .document(DocumentReference.builder().build())
+                            .build())
+                    .build(),
                 List.of(C2_APPLICATION, ApplicationType.C1_PARENTAL_RESPONSIBILITY))
+        );
+    }
+
+    private void assertC2DocumentBundle(C2DocumentBundle actualC2Bundle, Supplement expectedSupplement,
+                                        SupportingEvidenceBundle expectedSupportingEvidence) {
+        assertThat(actualC2Bundle.getId()).isNotNull();
+        assertThat(actualC2Bundle.getDocument().getFilename()).isEqualTo(SEALED_CONVERTED_DOCUMENT.getFilename());
+        assertThat(actualC2Bundle.getType()).isEqualTo(WITH_NOTICE);
+        assertThat(actualC2Bundle.getSupportingEvidenceBundle()).hasSize(1);
+        assertThat(actualC2Bundle.getSupplementsBundle()).hasSize(1);
+
+        assertSupplementsBundle(actualC2Bundle.getSupplementsBundle().get(0).getValue(), expectedSupplement);
+        assertSupportingEvidenceBundle(
+            actualC2Bundle.getSupportingEvidenceBundle().get(0).getValue(), expectedSupportingEvidence
+        );
+    }
+
+    private void assertOtherDocumentBundle(OtherApplicationsBundle actual, Supplement expectedSupplement,
+                                           SupportingEvidenceBundle expectedSupportingDocument) {
+        assertThat(actual.getId()).isNotNull();
+        assertThat(actual.getDocument().getFilename()).isEqualTo(SEALED_CONVERTED_DOCUMENT.getFilename());
+        assertThat(actual.getApplicationType()).isEqualTo(C1_PARENTAL_RESPONSIBILITY);
+        assertThat(actual.getParentalResponsibilityType()).isEqualTo(PR_BY_FATHER);
+        assertThat(actual.getAuthor()).isEqualTo(HMCTS);
+        assertThat(actual.getSupportingEvidenceBundle()).hasSize(1);
+        assertThat(actual.getSupplementsBundle()).hasSize(1);
+
+        assertSupplementsBundle(actual.getSupplementsBundle().get(0).getValue(), expectedSupplement);
+        assertSupportingEvidenceBundle(
+            actual.getSupportingEvidenceBundle().get(0).getValue(), expectedSupportingDocument
         );
     }
 
@@ -358,14 +391,17 @@ class UploadAdditionalApplicationsServiceTest {
             .uploadedBy(HMCTS)
             .document(SEALED_SUPPLEMENT_DOCUMENT)
             .build();
+
         assertThat(actual).isEqualTo(expectedSupplement);
     }
 
     private void assertSupportingEvidenceBundle(SupportingEvidenceBundle actual, SupportingEvidenceBundle expected) {
-        assertThat(actual).isEqualTo(expected.toBuilder()
+        SupportingEvidenceBundle expectedBundle = expected.toBuilder()
             .dateTimeUploaded(time.now())
             .uploadedBy(HMCTS)
-            .build());
+            .build();
+
+        assertThat(actual).isEqualTo(expectedBundle);
     }
 
     private PBAPayment buildPBAPayment() {
@@ -383,8 +419,8 @@ class UploadAdditionalApplicationsServiceTest {
             .build();
     }
 
-    private C2DocumentBundle createC2DocumentBundle(
-        Supplement supplementsBundle, SupportingEvidenceBundle supportingEvidenceBundle) {
+    private C2DocumentBundle createC2DocumentBundle(Supplement supplementsBundle,
+                                                    SupportingEvidenceBundle supportingEvidenceBundle) {
         return C2DocumentBundle.builder()
             .type(WITH_NOTICE)
             .document(DOCUMENT)
@@ -418,16 +454,6 @@ class UploadAdditionalApplicationsServiceTest {
             .secureAccommodationType(name == C20_SECURE_ACCOMMODATION ? WALES : null)
             .notes("Document notes")
             .document(SUPPLEMENT_DOCUMENT)
-            .build();
-    }
-
-    private UserDetails createUserDetailsWithHmctsRole() {
-        return UserDetails.builder()
-            .id(USER_ID)
-            .surname("Hudson")
-            .forename("Steve")
-            .email("steve.hudson@gov.uk")
-            .roles(Arrays.asList("caseworker-publiclaw-courtadmin", "caseworker-publiclaw-judiciary"))
             .build();
     }
 }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/docmosis/DocumentConversionServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/docmosis/DocumentConversionServiceTest.java
@@ -1,11 +1,6 @@
 package uk.gov.hmcts.reform.fpl.service.docmosis;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Spy;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -15,75 +10,113 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
+import uk.gov.hmcts.reform.document.domain.Document;
 import uk.gov.hmcts.reform.fpl.config.DocmosisConfiguration;
 import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
-import uk.gov.hmcts.reform.fpl.utils.TestDataHelper;
+import uk.gov.hmcts.reform.fpl.service.DocumentDownloadService;
+import uk.gov.hmcts.reform.fpl.service.UploadDocumentService;
 
 import static com.google.common.net.HttpHeaders.CONTENT_DISPOSITION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA;
-import static uk.gov.hmcts.reform.fpl.utils.ResourceReader.readBytes;
+import static uk.gov.hmcts.reform.fpl.utils.TestDataHelper.testDocument;
+import static uk.gov.hmcts.reform.fpl.utils.TestDataHelper.testDocumentBinaries;
+import static uk.gov.hmcts.reform.fpl.utils.TestDataHelper.testDocumentReference;
 
-@ExtendWith(MockitoExtension.class)
 class DocumentConversionServiceTest {
 
-    @Mock
-    private RestTemplate restTemplate;
+    private static final String BASE_URL = "baseUrl";
+    private static final String ACCESS_KEY = "accessKey";
+    private static final String DOCX_FILE_NAME = "cmo.docx";
+    private static final String PDF_FILE_NAME = "cmo.pdf";
 
-    @Spy
-    private DocmosisConfiguration configuration = new DocmosisConfiguration("baseUrl", "accessKey");
+    private final RestTemplate restTemplate = mock(RestTemplate.class);
+    private final DocmosisConfiguration configuration = mock(DocmosisConfiguration.class);
+    private final DocumentDownloadService downloadService = mock(DocumentDownloadService.class);
+    private final UploadDocumentService uploadService = mock(UploadDocumentService.class);
 
-    @InjectMocks
-    private DocumentConversionService documentConversionService;
+    private final DocumentConversionService underTest = new DocumentConversionService(
+        restTemplate, configuration, downloadService, uploadService
+    );
 
     @Test
-    void shouldReturnSameDocumentIfItIsPdf() {
-        byte[] inputDocumentBinaries = TestDataHelper.testDocumentBinaries();
+    void shouldReturnSameDocumentReferenceIfItIsPdf() {
         final DocumentReference inputDocumentReference = DocumentReference.builder()
-            .filename("cmo.pdf")
+            .filename(PDF_FILE_NAME)
             .build();
 
-        final byte[] converted = documentConversionService.convertToPdf(inputDocumentBinaries,
-            inputDocumentReference.getFilename());
+        DocumentReference converted = underTest.convertToPdf(inputDocumentReference);
 
-        assertThat(converted).isEqualTo(inputDocumentBinaries);
-        verifyNoMoreInteractions(restTemplate);
+        assertThat(converted).isEqualTo(inputDocumentReference);
+        verifyNoMoreInteractions(restTemplate, downloadService, uploadService, configuration);
     }
 
     @Test
-    @SuppressWarnings("unchecked")
-    void shouldConvertNonPdfDocumentToPdf() {
-        final String fileName = "cmo.docx";
-        final String newFileName = "cmo.pdf";
-        byte[] inputDocumentBinaries = TestDataHelper.testDocumentBinaries();
-        byte[] convertedDocumentBinaries = readBytes("documents/document.pdf");
-        final DocumentReference inputDocumentReference = DocumentReference.builder().filename(fileName).build();
+    void shouldConvertNonPdfDocumentReferenceToPdf() {
+        final byte[] inputDocumentBinaries = testDocumentBinaries();
+        final byte[] convertedDocumentBinaries = testDocumentBinaries();
+        final DocumentReference originalDocument = testDocumentReference(DOCX_FILE_NAME);
+
+        when(downloadService.downloadDocument(originalDocument.getBinaryUrl())).thenReturn(inputDocumentBinaries);
+
+        when(configuration.getUrl()).thenReturn(BASE_URL);
+        when(configuration.getAccessKey()).thenReturn(ACCESS_KEY);
+
+        // exact payload is tested in shouldConvertNonPdfDocumentBinariesToPdf
+        when(restTemplate.exchange(
+            eq(String.format("%s/rs/convert", BASE_URL)), eq(HttpMethod.POST), any(), eq(byte[].class))
+        ).thenReturn(new ResponseEntity<>(convertedDocumentBinaries, HttpStatus.OK));
+
+        final Document uploadedDocument = testDocument();
+        when(uploadService.uploadPDF(convertedDocumentBinaries, PDF_FILE_NAME)).thenReturn(uploadedDocument);
+
+        final DocumentReference uploadedReference = DocumentReference.buildFromDocument(uploadedDocument);
+
+        final DocumentReference converted = underTest.convertToPdf(originalDocument);
+
+        assertThat(converted).isEqualTo(uploadedReference);
+    }
+
+    @Test
+    void shouldReturnSameDocumentBinariesIfItIsPdf() {
+        final byte[] inputDocumentBinaries = testDocumentBinaries();
+        final byte[] converted = underTest.convertToPdf(inputDocumentBinaries, PDF_FILE_NAME);
+
+        assertThat(converted).isEqualTo(inputDocumentBinaries);
+        verifyNoMoreInteractions(restTemplate, configuration);
+    }
+
+    @Test
+    void shouldConvertNonPdfDocumentBinariesToPdf() {
+        final byte[] inputDocumentBinaries = testDocumentBinaries();
+        final byte[] convertedDocumentBinaries = testDocumentBinaries();
+
+        when(configuration.getUrl()).thenReturn(BASE_URL);
+        when(configuration.getAccessKey()).thenReturn(ACCESS_KEY);
 
         when(restTemplate.exchange(
-            eq(String.format("%s/rs/convert", configuration.getUrl())),
-            eq(HttpMethod.POST),
-            any(),
-            eq(byte[].class)))
-            .thenReturn(new ResponseEntity(convertedDocumentBinaries, HttpStatus.OK));
+            eq(String.format("%s/rs/convert", BASE_URL)), eq(HttpMethod.POST), any(), eq(byte[].class))
+        ).thenReturn(new ResponseEntity<>(convertedDocumentBinaries, HttpStatus.OK));
 
-        byte[] converted = documentConversionService.convertToPdf(inputDocumentBinaries,
-            inputDocumentReference.getFilename());
+        final byte[] converted = underTest.convertToPdf(inputDocumentBinaries, DOCX_FILE_NAME);
 
         verify(restTemplate).exchange(
-            String.format("%s/rs/convert", configuration.getUrl()),
-            HttpMethod.POST,
-            getExpectedPayload(inputDocumentBinaries, fileName, newFileName),
-            byte[].class);
+            String.format("%s/rs/convert", BASE_URL), HttpMethod.POST,
+            getExpectedPayload(inputDocumentBinaries, DOCX_FILE_NAME, PDF_FILE_NAME),
+            byte[].class
+        );
 
         assertThat(converted).isEqualTo(convertedDocumentBinaries);
     }
 
-    private HttpEntity getExpectedPayload(byte[] fileToBeConverted, String oldFilename, String newFilename) {
+    private HttpEntity<MultiValueMap<String, Object>> getExpectedPayload(byte[] fileToBeConverted,
+                                                                         String oldFilename, String newFilename) {
         final HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MULTIPART_FORM_DATA);
 
@@ -99,7 +132,7 @@ class DocumentConversionServiceTest {
         final MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
         body.add("file", new HttpEntity<>(fileToBeConverted, fileMap));
         body.add("outputName", newFilename);
-        body.add("accessKey", configuration.getAccessKey());
+        body.add("accessKey", ACCESS_KEY);
 
         return new HttpEntity<>(body, headers);
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###

[DFPL-241](https://tools.hmcts.net/jira/browse/DFPL-241)

### Change description ###

Update the sealing of applications to only occur if the user is a HMCTS user as originally specified in [FPLA-2751](https://tools.hmcts.net/jira/browse/FPLA-2752).
To reduce the number of errors occuring from [DFPL-240](https://tools.hmcts.net/jira/browse/DFPL-240) and to maintain exisiting notification functionality the supplemental documents and applications are still converted to pdf doucments.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
