### PR TITLE
chore: suppress audit warnings

### DIFF
--- a/audit.json
+++ b/audit.json
@@ -331,5 +331,8 @@
   "10096_Timestamp Disclosure - Unix_http://fpl-case-service-aat.service.core-compute-aat.internal/callback/add-gatekeeping-order/direction-selection/mid-event_POST": "ignore",
   "10096_Timestamp Disclosure - Unix_http://fpl-case-service-aat.service.core-compute-aat.internal/callback/add-gatekeeping-order/pre-populate/mid-event_POST": "ignore",
   "10096_Timestamp Disclosure - Unix_http://fpl-case-service-aat.service.core-compute-aat.internal/callback/add-gatekeeping-order/prepare-decision/mid-event_POST": "ignore",
+  "10096_Timestamp Disclosure - Unix_http://fpl-case-service-aat.service.core-compute-aat.internal/callback/approve-draft-orders/validate-review-decision/mid-event_POST": "ignore",
+  "10096_Timestamp Disclosure - Unix_http://fpl-case-service-aat.service.core-compute-aat.internal/callback/case-extension/mid-event_POST": "ignore",
+  "10096_Timestamp Disclosure - Unix_http://fpl-case-service-aat.service.core-compute-aat.internal/callback/case-initiation/submitted_POST": "ignore",
   "10062_PII Disclosure_http://fpl-case-service-aat.service.core-compute-aat.internal/callback/draft-standard-directions/about-to-start_POST": "ignore"
 }


### PR DESCRIPTION
### Change description ###

Add suppressions to `audit.json`, should ensure that the nightly pipeline passes the security scan stage
