### PR TITLE
DFPL-101 - Added document field type to Judicial Messages

### DIFF
--- a/ccd-definition/CaseEventToComplexTypes/messageJudge/judicialMessageReply.json
+++ b/ccd-definition/CaseEventToComplexTypes/messageJudge/judicialMessageReply.json
@@ -100,9 +100,20 @@
     "ID": "JudicialMessageReply",
     "CaseEventID": "messageJudgeOrLegalAdviser",
     "CaseFieldID": "judicialMessageReply",
+    "ListElementCode": "latestMessageDocument",
+    "FieldDisplayOrder": 10,
+    "DisplayContext": "MANDATORY",
+    "EventElementLabel": "Upload Document",
+    "FieldShowCondition": "judicialMessageReply.isReplying=\"Yes\""
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "JudicialMessageReply",
+    "CaseEventID": "messageJudgeOrLegalAdviser",
+    "CaseFieldID": "judicialMessageReply",
     "ListElementCode": "closeMessageLabel",
     "EventElementLabel": "This message will now be marked as closed",
-    "FieldDisplayOrder": 10,
+    "FieldDisplayOrder": 11,
     "DisplayContext": "READONLY",
     "FieldShowCondition": "judicialMessageReply.isReplying=\"No\""
   }

--- a/ccd-definition/ComplexTypes/CareSupervision/JudicialMessage/JudicialMessage.json
+++ b/ccd-definition/ComplexTypes/CareSupervision/JudicialMessage/JudicialMessage.json
@@ -78,6 +78,15 @@
   {
     "LiveFrom": "01/01/2017",
     "ID": "JudicialMessage",
+    "ListElementCode": "latestMessageDocument",
+    "FieldType": "Document",
+    "ElementLabel": "Latest message",
+    "SecurityClassification": "Public",
+    "FieldShowCondition": "status!=\"CLOSED\""
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "JudicialMessage",
     "ListElementCode": "status",
     "FieldType": "FixedRadioList",
     "FieldTypeParameter": "JudicialMessageStatus",


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DFPL-101

### Change description ###

**Ticket picked up shortly before moving to new team so currently only contains a few minor changes related to the Judicial Messages fields.**
- Added in document type field to judicial message reply screen

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
