### PR TITLE
Add test document order to the prepareForHearing case fixture

### DIFF
--- a/e2e/fixtures/caseData/prepareForHearing.json
+++ b/e2e/fixtures/caseData/prepareForHearing.json
@@ -379,6 +379,11 @@
       }
     ],
     "standardDirectionOrder": {
+      "orderDoc": {
+        "document_url": "${TEST_DOCUMENT_URL}",
+        "document_filename": "sdo.pdf",
+        "document_binary_url": "${TEST_DOCUMENT_BINARY_URL}"
+      },
       "directions": [
         {
           "id": "749f29dc-c200-4377-9e12-a5b4bad631bc",


### PR DESCRIPTION
### JIRA link (if applicable) ###

Bug found when testing https://tools.hmcts.net/jira/browse/DFPL-104 but is unrelated and present on master.

### Change description ###
Fix the test fixture to have an actual (fake) document attached to the SDO. None of the tests which use this fixture expect the SDO to not have a document attached, and in the normal flow this (probably) shouldn't ever be possible.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
