### PR TITLE
DFPL-348: Added London Borough of Camden to the authority fix list

### DIFF
--- a/ccd-definition/FixedLists/CareSupervision/AuthorityFixedList.json
+++ b/ccd-definition/FixedLists/CareSupervision/AuthorityFixedList.json
@@ -445,13 +445,20 @@
     "ID": "AuthorityFixedList",
     "ListElementCode": "BRE",
     "ListElement": "London Borough of Brent",
-    "DisplayOrder": 183
+    "DisplayOrder": 182
   },
   {
     "LiveFrom": "01/01/2017",
     "ID": "AuthorityFixedList",
     "ListElementCode": "BRO",
     "ListElement": "London Borough of Bromley",
+    "DisplayOrder": 183
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "AuthorityFixedList",
+    "ListElementCode": "CDN",
+    "ListElement": "London Borough of Camden",
     "DisplayOrder": 184
   },
   {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-348


### Change description ###
Added London Borough of Camden to the authority fix list 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
