### PR TITLE
DFPL-447: Adding logging to catch erros in sendDocuments call

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/AdditionalApplicationsUploadedEventHandler.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/AdditionalApplicationsUploadedEventHandler.java
@@ -1,10 +1,12 @@
 package uk.gov.hmcts.reform.fpl.handlers;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
 import uk.gov.hmcts.reform.fpl.enums.RepresentativeServingPreferences;
 import uk.gov.hmcts.reform.fpl.enums.UserRole;
 import uk.gov.hmcts.reform.fpl.events.AdditionalApplicationsUploadedEvent;
@@ -54,6 +56,7 @@ import static uk.gov.hmcts.reform.fpl.enums.RepresentativeServingPreferences.POS
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.unwrapElements;
 
 @Component
+@Slf4j
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class AdditionalApplicationsUploadedEventHandler {
     private final RequestData requestData;
@@ -74,7 +77,14 @@ public class AdditionalApplicationsUploadedEventHandler {
         final List<DocumentReference> documents = getApplicationDocuments(uploadedBundle);
 
         Set<Recipient> recipientsToNotify = getRecipientsToNotifyByPost(caseData, uploadedBundle);
-        sendDocumentService.sendDocuments(caseData, documents, new ArrayList<>(recipientsToNotify));
+
+        try {
+            sendDocumentService.sendDocuments(caseData, documents, new ArrayList<>(recipientsToNotify));
+        } catch(HttpClientErrorException exception) {
+            documents.forEach(document -> log.info("Exception sending additional application by post for case ID {}" +
+                    " and document {}.",
+                caseData.getId(), document.getFilename()));
+        }
     }
 
     private Set<Recipient> getRecipientsToNotifyByPost(CaseData caseData, AdditionalApplicationsBundle uploadedBundle) {


### PR DESCRIPTION
### JIRA link (if applicable) ###
DFPL-410


### Change description ###
Adding logging to catch errors from sendDocuments being generated when additional documents are uploaded.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
