### PR TITLE
Remove hearing option field from case (DFPL-466)

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -25,6 +25,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
+import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
 
 @Api
 @RestController
@@ -35,9 +36,9 @@ public class MigrateCaseController extends CallbackController {
     private static final String MIGRATION_ID_KEY = "migrationId";
 
     private final Map<String, Consumer<CaseDetails>> migrations = Map.of(
-        "DFPL-500", this::run500
+        "DFPL-500", this::run500,
+        "DFPL-466", this::run466
     );
-
 
     @PostMapping("/about-to-submit")
     public AboutToStartOrSubmitCallbackResponse handleAboutToSubmit(@RequestBody CallbackRequest callbackRequest) {
@@ -57,6 +58,22 @@ public class MigrateCaseController extends CallbackController {
 
         caseDetails.getData().remove(MIGRATION_ID_KEY);
         return respond(caseDetails);
+    }
+
+    private void run466(CaseDetails caseDetails) {
+        var caseId = caseDetails.getId();
+        if (caseId != 1611613172339094L) {
+            throw new AssertionError(format(
+                "Migration {id = DFPL-466, case reference = %s}, expected case id 1611613172339094",
+                caseId
+            ));
+        }
+
+        if (isNotEmpty(caseDetails.getData().get("hearingOption"))) {
+            caseDetails.getData().remove("hearingOption");
+        } else {
+            throw new IllegalStateException(format("Case %s does not have hearing option", caseId));
+        }
     }
 
     private void run500(CaseDetails caseDetails) {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-466

### Change description ###
Worcestershire case has the `HearingOption` value as "EDIT_HEARING" which fails to deserialise and throwing exception when closing the case. The data migration will clear the `hearingOption` field from the case.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
