### PR TITLE
DFPL-517 NPE in managing hearings: When Clicking "Edit a hearing that has taken place..." without previous hearing

### DIFF
--- a/charts/fpl-case-service/Chart.yaml
+++ b/charts/fpl-case-service/Chart.yaml
@@ -1,7 +1,7 @@
 name: fpl-case-service
 apiVersion: v2
 home: https://github.com/hmcts/fpl-ccd-configuration
-version: 1.12.37
+version: 1.12.38
 description: FPL Case Service
 maintainers:
   - name: HMCTS Family Public Law team

--- a/charts/fpl-case-service/Chart.yaml
+++ b/charts/fpl-case-service/Chart.yaml
@@ -1,7 +1,7 @@
 name: fpl-case-service
 apiVersion: v2
 home: https://github.com/hmcts/fpl-ccd-configuration
-version: 1.12.38
+version: 1.12.37
 description: FPL Case Service
 maintainers:
   - name: HMCTS Family Public Law team

--- a/charts/fpl-case-service/Chart.yaml
+++ b/charts/fpl-case-service/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
     email: fpl-developers@HMCTS.NET
 dependencies:
   - name: java
-    version: 3.7.0
+    version: 3.6.0
     repository: '@hmctspublic'
   - name: ccd
     version: 6.0.0

--- a/charts/fpl-case-service/Chart.yaml
+++ b/charts/fpl-case-service/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
     email: fpl-developers@HMCTS.NET
 dependencies:
   - name: java
-    version: 3.6.0
+    version: 3.7.0
     repository: '@hmctspublic'
   - name: ccd
     version: 6.0.0

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/HearingVenueLookUpService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/HearingVenueLookUpService.java
@@ -41,6 +41,9 @@ public class HearingVenueLookUpService {
 
     public HearingVenue getHearingVenue(final HearingBooking hearingBooking) {
         if (!HEARING_VENUE_ID_OTHER.equals(hearingBooking.getVenue())) {
+            if (hearingBooking.getVenue() == null) {
+                throw new IllegalStateException("Unexpected null venue." + hearingBooking);
+            }
             return getHearingVenue(hearingBooking.getVenue());
         } else {
             return HearingVenue.builder()

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/validation/validators/IsValidHearingEditValidator.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/validation/validators/IsValidHearingEditValidator.java
@@ -1,25 +1,32 @@
 package uk.gov.hmcts.reform.fpl.validation.validators;
 
-import uk.gov.hmcts.reform.fpl.model.CaseData;
-import uk.gov.hmcts.reform.fpl.validation.interfaces.IsValidHearingEdit;
-
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 
 import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 import static uk.gov.hmcts.reform.fpl.enums.HearingOptions.ADJOURN_HEARING;
 import static uk.gov.hmcts.reform.fpl.enums.HearingOptions.EDIT_FUTURE_HEARING;
+import static uk.gov.hmcts.reform.fpl.enums.HearingOptions.EDIT_PAST_HEARING;
 import static uk.gov.hmcts.reform.fpl.enums.HearingOptions.VACATE_HEARING;
+
+import uk.gov.hmcts.reform.fpl.model.CaseData;
+import uk.gov.hmcts.reform.fpl.validation.interfaces.IsValidHearingEdit;
 
 public class IsValidHearingEditValidator implements ConstraintValidator<IsValidHearingEdit, CaseData> {
     @Override
     public boolean isValid(CaseData caseData, ConstraintValidatorContext constraintValidatorContext) {
-        return !isInvalidHearingEdit(caseData)
+        return !isInvalidHearingEditFuture(caseData)
+            && !isInvalidHearingEditPast(caseData)
             && !isInvalidHearingAdjournment(caseData)
             && !isInvalidHearingVacate(caseData);
     }
 
-    private boolean isInvalidHearingEdit(CaseData caseData) {
+    private boolean isInvalidHearingEditPast(CaseData caseData) {
+        return EDIT_PAST_HEARING.equals(caseData.getHearingOption())
+            && isEmpty(caseData.getPastHearings());
+    }
+
+    private boolean isInvalidHearingEditFuture(CaseData caseData) {
         return EDIT_FUTURE_HEARING.equals(caseData.getHearingOption())
             && isEmpty(caseData.getAllNonCancelledHearings());
     }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/validation/validators/IsValidHearingEditValidator.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/validation/validators/IsValidHearingEditValidator.java
@@ -1,5 +1,8 @@
 package uk.gov.hmcts.reform.fpl.validation.validators;
 
+import uk.gov.hmcts.reform.fpl.model.CaseData;
+import uk.gov.hmcts.reform.fpl.validation.interfaces.IsValidHearingEdit;
+
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 
@@ -8,9 +11,6 @@ import static uk.gov.hmcts.reform.fpl.enums.HearingOptions.ADJOURN_HEARING;
 import static uk.gov.hmcts.reform.fpl.enums.HearingOptions.EDIT_FUTURE_HEARING;
 import static uk.gov.hmcts.reform.fpl.enums.HearingOptions.EDIT_PAST_HEARING;
 import static uk.gov.hmcts.reform.fpl.enums.HearingOptions.VACATE_HEARING;
-
-import uk.gov.hmcts.reform.fpl.model.CaseData;
-import uk.gov.hmcts.reform.fpl.validation.interfaces.IsValidHearingEdit;
 
 public class IsValidHearingEditValidator implements ConstraintValidator<IsValidHearingEdit, CaseData> {
     @Override

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/validation/validators/IsValidHearingEditValidator.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/validation/validators/IsValidHearingEditValidator.java
@@ -28,7 +28,7 @@ public class IsValidHearingEditValidator implements ConstraintValidator<IsValidH
 
     private boolean isInvalidHearingEditFuture(CaseData caseData) {
         return EDIT_FUTURE_HEARING.equals(caseData.getHearingOption())
-            && isEmpty(caseData.getFutureHearings());
+            && isEmpty(caseData.getFutureAndTodayHearings());
     }
 
     private boolean isInvalidHearingAdjournment(CaseData caseData) {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/validation/validators/IsValidHearingEditValidator.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/validation/validators/IsValidHearingEditValidator.java
@@ -28,7 +28,7 @@ public class IsValidHearingEditValidator implements ConstraintValidator<IsValidH
 
     private boolean isInvalidHearingEditFuture(CaseData caseData) {
         return EDIT_FUTURE_HEARING.equals(caseData.getHearingOption())
-            && isEmpty(caseData.getAllNonCancelledHearings());
+            && isEmpty(caseData.getFutureHearings());
     }
 
     private boolean isInvalidHearingAdjournment(CaseData caseData) {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/validation/validators/IsValidHearingEditValidator.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/validation/validators/IsValidHearingEditValidator.java
@@ -28,7 +28,7 @@ public class IsValidHearingEditValidator implements ConstraintValidator<IsValidH
 
     private boolean isInvalidHearingEditFuture(CaseData caseData) {
         return EDIT_FUTURE_HEARING.equals(caseData.getHearingOption())
-            && isEmpty(caseData.getFutureAndTodayHearings());
+            && isEmpty(caseData.getFutureHearings());
     }
 
     private boolean isInvalidHearingAdjournment(CaseData caseData) {

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/validation/validators/IsValidHearingEditValidatorTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/validation/validators/IsValidHearingEditValidatorTest.java
@@ -176,6 +176,19 @@ class IsValidHearingEditValidatorTest extends AbstractValidationTest {
             List<String> validationErrors = validate(caseData, HearingBookingGroup.class);
             assertThat(validationErrors).isEmpty();
         }
+
+        @Test
+        void shouldReturnAnErrorWhenEditingFutureHearingWithCurrentHearing() {
+            CaseData caseData = CaseData.builder()
+                .hearingOption(EDIT_FUTURE_HEARING)
+                .hearingDetails(List.of(element(HearingBooking.builder()
+                    .startDate(time.now())
+                    .build())))
+                .build();
+
+            List<String> validationErrors = validate(caseData, HearingBookingGroup.class);
+            assertThat(validationErrors).contains(ERROR_MESSAGE);
+        }
     }
 
     @Nested
@@ -288,6 +301,19 @@ class IsValidHearingEditValidatorTest extends AbstractValidationTest {
             CaseData caseData = CaseData.builder()
                 .hearingOption(EDIT_PAST_HEARING)
                 .hearingDetails(getFutureAndPastHearings())
+                .build();
+
+            List<String> validationErrors = validate(caseData, HearingBookingGroup.class);
+            assertThat(validationErrors).isEmpty();
+        }
+
+        @Test
+        void shouldNotReturnAnErrorWhenEditingPastHearingWithCurrentHearing() {
+            CaseData caseData = CaseData.builder()
+                .hearingOption(EDIT_PAST_HEARING)
+                .hearingDetails(List.of(element(HearingBooking.builder()
+                    .startDate(time.now())
+                    .build())))
                 .build();
 
             List<String> validationErrors = validate(caseData, HearingBookingGroup.class);

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/validation/validators/IsValidHearingEditValidatorTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/validation/validators/IsValidHearingEditValidatorTest.java
@@ -28,32 +28,31 @@ class IsValidHearingEditValidatorTest extends AbstractValidationTest {
 
     private static final String ERROR_MESSAGE = "There are no relevant hearings to change.";
 
-
-    HearingBooking getTomorrowHearingBooking() {
+    private HearingBooking getTomorrowHearingBooking() {
         return HearingBooking.builder()
             .startDate(time.now().plusDays(1))
             .build();
     }
 
-    HearingBooking getYesterdayHearingBooking() {
+    private HearingBooking getYesterdayHearingBooking() {
         return HearingBooking.builder()
             .startDate(time.now().minusDays(1))
             .build();
     }
 
-    List<Element<HearingBooking>> getFutureHearings() {
+    private List<Element<HearingBooking>> getFutureHearings() {
         return List.of(
             element(getTomorrowHearingBooking())
         );
     }
 
-    List<Element<HearingBooking>> getPastHearings() {
+    private List<Element<HearingBooking>> getPastHearings() {
         return List.of(
             element(getYesterdayHearingBooking())
         );
     }
 
-    List<Element<HearingBooking>> getFutureAndPastHearings() {
+    private List<Element<HearingBooking>> getFutureAndPastHearings() {
         return List.of(
             element(getYesterdayHearingBooking()),
             element(getTomorrowHearingBooking())

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/validation/validators/IsValidHearingEditValidatorTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/validation/validators/IsValidHearingEditValidatorTest.java
@@ -39,7 +39,7 @@ class IsValidHearingEditValidatorTest extends AbstractValidationTest {
         }
 
         @Test
-        void shouldReturnAnErrorWhenEditingAHearingButNoPastHearingsAreAvailable2() {
+        void shouldReturnAnErrorWhenEditingPastHearingButOnlyFutureHearingsAvailable() {
             List<Element<HearingBooking>> pastHearings = List.of(
                 element(HearingBooking.builder()
                     .startDate(time.now().plusDays(1))

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/validation/validators/IsValidHearingEditValidatorTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/validation/validators/IsValidHearingEditValidatorTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.reform.fpl.enums.HearingOptions.ADJOURN_HEARING;
 import static uk.gov.hmcts.reform.fpl.enums.HearingOptions.EDIT_FUTURE_HEARING;
+import static uk.gov.hmcts.reform.fpl.enums.HearingOptions.EDIT_PAST_HEARING;
 import static uk.gov.hmcts.reform.fpl.enums.HearingOptions.VACATE_HEARING;
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.element;
 
@@ -29,6 +30,32 @@ class IsValidHearingEditValidatorTest extends AbstractValidationTest {
 
     @Nested
     class EditingHearings {
+        @Test
+        void shouldReturnAnErrorWhenEditingAHearingButNoPastHearingsAreAvailable() {
+            CaseData caseData = CaseData.builder().hearingOption(EDIT_PAST_HEARING).build();
+            List<String> validationErrors = validate(caseData, HearingBookingGroup.class);
+
+            assertThat(validationErrors).contains(ERROR_MESSAGE);
+        }
+
+        @Test
+        void shouldReturnAnErrorWhenEditingAHearingButNoPastHearingsAreAvailable2() {
+            List<Element<HearingBooking>> pastHearings = List.of(
+                element(HearingBooking.builder()
+                    .startDate(time.now().plusDays(1))
+                    .build())
+            );
+
+            CaseData caseData = CaseData.builder()
+                .hearingOption(EDIT_PAST_HEARING)
+                .hearingDetails(pastHearings)
+                .build();
+
+            List<String> validationErrors = validate(caseData, HearingBookingGroup.class);
+
+            assertThat(validationErrors).contains(ERROR_MESSAGE);
+        }
+
         @Test
         void shouldReturnAnErrorWhenEditingAHearingButNoHearingsAreAvailable() {
             CaseData caseData = CaseData.builder().hearingOption(EDIT_FUTURE_HEARING).build();
@@ -56,15 +83,15 @@ class IsValidHearingEditValidatorTest extends AbstractValidationTest {
 
         @Test
         void shouldNotReturnAnErrorWhenEditingAHearingWithPastHearingsAvailable() {
-            List<Element<HearingBooking>> futureHearings = List.of(
+            List<Element<HearingBooking>> pastHearings = List.of(
                 element(HearingBooking.builder()
                     .startDate(time.now().minusDays(2))
                     .build())
                 );
 
             CaseData caseData = CaseData.builder()
-                .hearingOption(EDIT_FUTURE_HEARING)
-                .hearingDetails(futureHearings)
+                .hearingOption(EDIT_PAST_HEARING)
+                .hearingDetails(pastHearings)
                 .build();
 
             List<String> validationErrors = validate(caseData, HearingBookingGroup.class);

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/validation/validators/IsValidHearingEditValidatorTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/validation/validators/IsValidHearingEditValidatorTest.java
@@ -142,8 +142,7 @@ class IsValidHearingEditValidatorTest extends AbstractValidationTest {
         }
 
         @Test
-        void shouldNotReturnAnErrorWhenEditingFutureHearingButOnlyFutureHearingsAvailableHavingCancelledFutureHearing()
-        {
+        void shouldNotReturnAnErrorWhenEditingFutureHearingButOnlyFutureHearingAvailableHavingCancelledFutureHearing() {
             CaseData caseData = CaseData.builder()
                 .hearingOption(EDIT_FUTURE_HEARING)
                 .cancelledHearingDetails(getFutureHearings())

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/validation/validators/IsValidHearingEditValidatorTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/validation/validators/IsValidHearingEditValidatorTest.java
@@ -28,87 +28,266 @@ class IsValidHearingEditValidatorTest extends AbstractValidationTest {
 
     private static final String ERROR_MESSAGE = "There are no relevant hearings to change.";
 
-    @Nested
-    class EditingHearings {
-        @Test
-        void shouldReturnAnErrorWhenEditingAHearingButNoPastHearingsAreAvailable() {
-            CaseData caseData = CaseData.builder().hearingOption(EDIT_PAST_HEARING).build();
-            List<String> validationErrors = validate(caseData, HearingBookingGroup.class);
 
+    HearingBooking getTomorrowHearingBooking() {
+        return HearingBooking.builder()
+            .startDate(time.now().plusDays(1))
+            .build();
+    }
+
+    HearingBooking getYesterdayHearingBooking() {
+        return HearingBooking.builder()
+            .startDate(time.now().minusDays(1))
+            .build();
+    }
+
+    List<Element<HearingBooking>> getFutureHearings() {
+        return List.of(
+            element(getTomorrowHearingBooking())
+        );
+    }
+
+    List<Element<HearingBooking>> getPastHearings() {
+        return List.of(
+            element(getYesterdayHearingBooking())
+        );
+    }
+
+    List<Element<HearingBooking>> getFutureAndPastHearings() {
+        return List.of(
+            element(getYesterdayHearingBooking()),
+            element(getTomorrowHearingBooking())
+        );
+    }
+
+    @Nested
+    class EditFutureHearings {
+
+        @Test
+        void shouldReturnAnErrorWhenEditingFutureHearingButHearingsAreNotAvailable() {
+            CaseData caseData = CaseData.builder()
+                .hearingOption(EDIT_FUTURE_HEARING)
+                .build();
+
+            List<String> validationErrors = validate(caseData, HearingBookingGroup.class);
             assertThat(validationErrors).contains(ERROR_MESSAGE);
+        }
+
+        @Test
+        void shouldReturnAnErrorWhenEditingFutureHearingWithPastHearingAvailable() {
+            CaseData caseData = CaseData.builder()
+                .hearingOption(EDIT_FUTURE_HEARING)
+                .hearingDetails(getPastHearings())
+                .build();
+
+            List<String> validationErrors = validate(caseData, HearingBookingGroup.class);
+            assertThat(validationErrors).contains(ERROR_MESSAGE);
+        }
+
+        @Test
+        void shouldReturnAnErrorWhenEditingFutureHearingButHearingsAreNotAvailableHavingCancelledFutureHearing() {
+            CaseData caseData = CaseData.builder()
+                .hearingOption(EDIT_FUTURE_HEARING)
+                .cancelledHearingDetails(getFutureHearings())
+                .build();
+
+            List<String> validationErrors = validate(caseData, HearingBookingGroup.class);
+            assertThat(validationErrors).contains(ERROR_MESSAGE);
+        }
+
+        @Test
+        void shouldReturnAnErrorWhenEditingFutureHearingWithPastHearingAndCancelledFutureHearing() {
+            CaseData caseData = CaseData.builder()
+                .hearingOption(EDIT_FUTURE_HEARING)
+                .cancelledHearingDetails(getFutureHearings())
+                .hearingDetails(getPastHearings())
+                .build();
+
+            List<String> validationErrors = validate(caseData, HearingBookingGroup.class);
+            assertThat(validationErrors).contains(ERROR_MESSAGE);
+        }
+
+        @Test
+        void shouldReturnAnErrorWhenEditingFutureHearingButHearingsAreNotAvailableHavingCancelledPastHearing() {
+            CaseData caseData = CaseData.builder()
+                .hearingOption(EDIT_FUTURE_HEARING)
+                .cancelledHearingDetails(getPastHearings())
+                .build();
+
+            List<String> validationErrors = validate(caseData, HearingBookingGroup.class);
+            assertThat(validationErrors).contains(ERROR_MESSAGE);
+        }
+
+        @Test
+        void shouldReturnAnErrorWhenEditingFutureHearingWithPastHearingsAndCancelledPastHearing() {
+            CaseData caseData = CaseData.builder()
+                .hearingOption(EDIT_FUTURE_HEARING)
+                .cancelledHearingDetails(getPastHearings())
+                .hearingDetails(getPastHearings())
+                .build();
+
+            List<String> validationErrors = validate(caseData, HearingBookingGroup.class);
+            assertThat(validationErrors).contains(ERROR_MESSAGE);
+        }
+
+        @Test
+        void shouldNotReturnAnErrorWhenEditingFutureHearingButOnlyFutureHearingsAvailable() {
+            CaseData caseData = CaseData.builder()
+                .hearingOption(EDIT_FUTURE_HEARING)
+                .hearingDetails(getFutureHearings())
+                .build();
+
+            List<String> validationErrors = validate(caseData, HearingBookingGroup.class);
+            assertThat(validationErrors).isEmpty();
+        }
+
+        @Test
+        void shouldNotReturnAnErrorWhenEditingFutureHearingButOnlyFutureHearingsAvailableHavingCancelledFutureHearing()
+        {
+            CaseData caseData = CaseData.builder()
+                .hearingOption(EDIT_FUTURE_HEARING)
+                .cancelledHearingDetails(getFutureHearings())
+                .hearingDetails(getFutureHearings())
+                .build();
+
+            List<String> validationErrors = validate(caseData, HearingBookingGroup.class);
+            assertThat(validationErrors).isEmpty();
+        }
+
+        @Test
+        void shouldNotReturnAnErrorWhenEditingFutureHearingButOnlyFutureHearingsAvailableHavingCancelledPastHearing() {
+            CaseData caseData = CaseData.builder()
+                .hearingOption(EDIT_FUTURE_HEARING)
+                .cancelledHearingDetails(getPastHearings())
+                .hearingDetails(getFutureHearings())
+                .build();
+
+            List<String> validationErrors = validate(caseData, HearingBookingGroup.class);
+            assertThat(validationErrors).isEmpty();
+        }
+
+        @Test
+        void shouldNotReturnAnErrorWhenEditingFutureHearingWithPastAndFutureHearing() {
+            CaseData caseData = CaseData.builder()
+                .hearingOption(EDIT_FUTURE_HEARING)
+                .hearingDetails(getFutureAndPastHearings())
+                .build();
+
+            List<String> validationErrors = validate(caseData, HearingBookingGroup.class);
+            assertThat(validationErrors).isEmpty();
+        }
+    }
+
+    @Nested
+    class EditingPastHearings {
+        @Test
+        void shouldReturnAnErrorWhenEditingPastHearingButHearingsAreNotAvailable() {
+            CaseData caseData = CaseData.builder()
+                .hearingOption(EDIT_PAST_HEARING)
+                .build();
+
+            List<String> validationErrors = validate(caseData, HearingBookingGroup.class);
+            assertThat(validationErrors).contains(ERROR_MESSAGE);
+        }
+
+        @Test
+        void shouldNotReturnAnErrorWhenEditingPastHearingWithPastHearingAvailable() {
+            CaseData caseData = CaseData.builder()
+                .hearingOption(EDIT_PAST_HEARING)
+                .hearingDetails(getPastHearings())
+                .build();
+
+            List<String> validationErrors = validate(caseData, HearingBookingGroup.class);
+            assertThat(validationErrors).isEmpty();
+        }
+
+        @Test
+        void shouldReturnAnErrorWhenEditingPastHearingButHearingsAreNotAvailableHavingCancelledFutureHearing() {
+            CaseData caseData = CaseData.builder()
+                .hearingOption(EDIT_PAST_HEARING)
+                .cancelledHearingDetails(getFutureHearings())
+                .build();
+
+            List<String> validationErrors = validate(caseData, HearingBookingGroup.class);
+            assertThat(validationErrors).contains(ERROR_MESSAGE);
+        }
+
+        @Test
+        void shouldNotReturnAnErrorWhenEditingPastHearingButHearingsWithPastHearingAndCancelledFutureHearing() {
+            CaseData caseData = CaseData.builder()
+                .hearingOption(EDIT_PAST_HEARING)
+                .cancelledHearingDetails(getFutureHearings())
+                .hearingDetails(getPastHearings())
+                .build();
+
+            List<String> validationErrors = validate(caseData, HearingBookingGroup.class);
+            assertThat(validationErrors).isEmpty();
+        }
+
+        @Test
+        void shouldReturnAnErrorWhenEditingPastHearingButHearingsAreNotAvailableHavingCancelledPastHearing() {
+            CaseData caseData = CaseData.builder()
+                .hearingOption(EDIT_PAST_HEARING)
+                .cancelledHearingDetails(getPastHearings())
+                .build();
+
+            List<String> validationErrors = validate(caseData, HearingBookingGroup.class);
+            assertThat(validationErrors).contains(ERROR_MESSAGE);
+        }
+
+
+        @Test
+        void shouldNotReturnAnErrorWhenEditingPastHearingWithPastHearingsAndCancelledPastHearing() {
+            CaseData caseData = CaseData.builder()
+                .hearingOption(EDIT_PAST_HEARING)
+                .cancelledHearingDetails(getPastHearings())
+                .hearingDetails(getPastHearings())
+                .build();
+
+            List<String> validationErrors = validate(caseData, HearingBookingGroup.class);
+            assertThat(validationErrors).isEmpty();
         }
 
         @Test
         void shouldReturnAnErrorWhenEditingPastHearingButOnlyFutureHearingsAvailable() {
-            List<Element<HearingBooking>> pastHearings = List.of(
-                element(HearingBooking.builder()
-                    .startDate(time.now().plusDays(1))
-                    .build())
-            );
-
             CaseData caseData = CaseData.builder()
                 .hearingOption(EDIT_PAST_HEARING)
-                .hearingDetails(pastHearings)
+                .hearingDetails(getFutureHearings())
                 .build();
 
             List<String> validationErrors = validate(caseData, HearingBookingGroup.class);
-
             assertThat(validationErrors).contains(ERROR_MESSAGE);
         }
 
         @Test
-        void shouldReturnAnErrorWhenEditingAHearingButNoHearingsAreAvailable() {
-            CaseData caseData = CaseData.builder().hearingOption(EDIT_FUTURE_HEARING).build();
-            List<String> validationErrors = validate(caseData, HearingBookingGroup.class);
+        void shouldReturnAnErrorWhenEditingPastHearingButOnlyFutureHearingsAvailableHavingCancelledFutureHearing() {
+            CaseData caseData = CaseData.builder()
+                .hearingOption(EDIT_PAST_HEARING)
+                .cancelledHearingDetails(getFutureHearings())
+                .hearingDetails(getFutureHearings())
+                .build();
 
+            List<String> validationErrors = validate(caseData, HearingBookingGroup.class);
             assertThat(validationErrors).contains(ERROR_MESSAGE);
         }
 
         @Test
-        void shouldNotReturnAnErrorWhenEditingAHearingWithFutureHearingsAvailable() {
-            List<Element<HearingBooking>> futureHearings = List.of(
-                element(HearingBooking.builder()
-                    .startDate(time.now().plusDays(2))
-                    .build())
-            );
-
-            CaseData caseData = CaseData.builder()
-                .hearingOption(EDIT_FUTURE_HEARING)
-                .hearingDetails(futureHearings)
-                .build();
-
-            List<String> validationErrors = validate(caseData, HearingBookingGroup.class);
-            assertThat(validationErrors).isEmpty();
-        }
-
-        @Test
-        void shouldNotReturnAnErrorWhenEditingAHearingWithPastHearingsAvailable() {
-            List<Element<HearingBooking>> pastHearings = List.of(
-                element(HearingBooking.builder()
-                    .startDate(time.now().minusDays(2))
-                    .build())
-                );
-
+        void shouldReturnAnErrorWhenEditingPastHearingButOnlyFutureHearingsAvailableHavingCancelledPastHearing() {
             CaseData caseData = CaseData.builder()
                 .hearingOption(EDIT_PAST_HEARING)
-                .hearingDetails(pastHearings)
+                .cancelledHearingDetails(getPastHearings())
+                .hearingDetails(getFutureHearings())
                 .build();
 
             List<String> validationErrors = validate(caseData, HearingBookingGroup.class);
-            assertThat(validationErrors).isEmpty();
+            assertThat(validationErrors).contains(ERROR_MESSAGE);
         }
 
         @Test
-        void shouldNotReturnAnErrorWhenEditingAHearingWithCurrentHearingsAvailable() {
-            List<Element<HearingBooking>> futureHearings = List.of(
-                element(HearingBooking.builder()
-                    .startDate(time.now())
-                    .build())
-            );
-
+        void shouldNotReturnAnErrorWhenEditingPastHearingWithPastAndFutureHearing() {
             CaseData caseData = CaseData.builder()
-                .hearingOption(EDIT_FUTURE_HEARING)
-                .hearingDetails(futureHearings)
+                .hearingOption(EDIT_PAST_HEARING)
+                .hearingDetails(getFutureAndPastHearings())
                 .build();
 
             List<String> validationErrors = validate(caseData, HearingBookingGroup.class);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-517

### Change description ###
Bug fix for NullPointerException when editing previous hearing for case without previous hearing.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
