### PR TITLE
DFPL-525: Handle NPE at HearingBooking.startsAfterToday where we have a null startDate

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/HearingBooking.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/HearingBooking.java
@@ -105,7 +105,9 @@ public class HearingBooking implements TranslatableItem {
     }
 
     public boolean startsAfterToday() {
-        return startDate.isAfter(ZonedDateTime.now(ZoneId.of("Europe/London")).toLocalDateTime());
+        return ofNullable(startDate)
+            .map(date -> date.isAfter(ZonedDateTime.now(ZoneId.of("Europe/London")).toLocalDateTime()))
+            .orElse(false);
     }
 
     public boolean startsTodayOrBefore() {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DFPL-525

### Change description ###

Bug fix for NullPointerException at HearingBooking.startsAfterToday where we have a null startDate.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
