### PR TITLE
DFPL-542: Stop represented respondents from receiving documents via post

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/email/RepresentativesInbox.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/email/RepresentativesInbox.java
@@ -119,7 +119,7 @@ public class RepresentativesInbox {
     public Set<Recipient> getSelectedRecipientsWithNoRepresentation(List<Element<Respondent>> selectedRespondents) {
         return selectedRespondents.stream()
             .map(Element::getValue)
-            .filter(respondent -> isEmpty(respondent.getRepresentedBy()) && respondent.hasAddress())
+            .filter(respondent -> isEmpty(respondent.getRepresentedBy()) && isEmpty(respondent.getSolicitor()) && respondent.hasAddress())
             .map(Respondent::toParty)
             .collect(Collectors.toCollection(LinkedHashSet::new));
     }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/email/RepresentativesInboxTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/email/RepresentativesInboxTest.java
@@ -35,6 +35,7 @@ import static uk.gov.hmcts.reform.fpl.enums.RepresentativeServingPreferences.POS
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.element;
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.wrapElements;
 import static uk.gov.hmcts.reform.fpl.utils.TestDataHelper.testAddress;
+import static uk.gov.hmcts.reform.fpl.utils.TestDataHelper.testEmail;
 
 class RepresentativesInboxTest {
 
@@ -456,6 +457,15 @@ class RepresentativesInboxTest {
                 .build()
         );
 
+        Element<Respondent> respondentWithSolicitor = element(
+            Respondent.builder()
+                .party(RespondentParty.builder().address(Address.builder().build()).build())
+                .solicitor(RespondentSolicitor.builder()
+                    .email(testEmail().getEmail())
+                    .build())
+                .build()
+        );
+
         return Stream.of(
             Arguments.of(
                 List.of(RESPONDENT_WITH_EMAIL_REP, RESPONDENT_UNREPRESENTED),
@@ -466,7 +476,12 @@ class RepresentativesInboxTest {
                 Set.of(RESPONDENT_UNREPRESENTED.getValue().getParty())
             ),
             Arguments.of(List.of(RESPONDENT_WITH_EMAIL_REP, RESPONDENT_WITH_DIGITAL_REP), Set.of()),
-            Arguments.of(List.of(respondentWithIncompleteAddress, respondentWithoutAddress), Set.of())
+            Arguments.of(List.of(respondentWithIncompleteAddress, respondentWithoutAddress), Set.of()),
+            Arguments.of(List.of(respondentWithSolicitor), Set.of()),
+            Arguments.of(
+                List.of(respondentWithSolicitor, RESPONDENT_UNREPRESENTED),
+                Set.of(RESPONDENT_UNREPRESENTED.getValue().getParty())
+            )
         );
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-542

### Change description ###
Adds a check to the respondentSolicitor field (populated by respondent event) when checking to see if a respondent is represented for the purposes of sending post

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
