### PR TITLE
DFPL-551: Migration to remove C110a document from the case

### DIFF
--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseControllerTest.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.reform.fpl.model.SentDocument;
 import uk.gov.hmcts.reform.fpl.model.SentDocuments;
 import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
+import uk.gov.hmcts.reform.fpl.model.group.C110A;
 import uk.gov.hmcts.reform.fpl.service.TaskListRenderer;
 import uk.gov.hmcts.reform.fpl.service.TaskListService;
 import uk.gov.hmcts.reform.fpl.service.validators.CaseSubmissionChecker;
@@ -348,6 +349,78 @@ class MigrateCaseControllerTest extends AbstractCallbackTest {
                 .hasMessage("Migration {id = DFPL-482, case reference = 1643728359576136},"
                     + " expected case id 1636970654155393");
         }
+
+    }
+
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @Nested
+    class Dfpl551 {
+        private final String migrationId = "DFPL-551";
+        private final long validCaseId = 1641312631808724L;
+        private final long invalidCaseId = 1643728359576136L;
+
+        private final UUID validDocId = UUID.fromString("0de3ba95-e383-41b4-8a66-52bf0dce834e");
+        private final UUID invalidDocId = UUID.randomUUID();
+
+        @Test
+        void shouldPerformMigrationWhenDocIdMatches() {
+
+            CaseData caseData = CaseData.builder()
+                .id(validCaseId)
+                .c110A(C110A.builder()
+                    .submittedForm(DocumentReference.builder()
+                        .url(String.format("http://test.com/%s", validDocId))
+                        .build())
+                    .build())
+                .build();
+
+            AboutToStartOrSubmitCallbackResponse response = postAboutToSubmitEvent(
+                buildCaseDetails(caseData, migrationId)
+            );
+
+            CaseData responseData = extractCaseData(response);
+
+            assertThat(responseData.getC110A().getSubmittedForm()).isNull();
+        }
+
+        @Test
+        void shouldThrowAssersionErrorWhenCaseIdIsInvalid() {
+            CaseData caseData = CaseData.builder()
+                .id(invalidCaseId)
+                .state(State.SUBMITTED)
+                .c110A(C110A.builder()
+                    .submittedForm(DocumentReference.builder()
+                        .url(String.format("http://test.com/%s", validDocId))
+                        .build())
+                    .build())
+                .build();
+
+            assertThatThrownBy(() -> postAboutToSubmitEvent(buildCaseDetails(caseData, migrationId)))
+                .getRootCause()
+                .isInstanceOf(AssertionError.class)
+                .hasMessage("Migration {id = DFPL-551, case reference = 1643728359576136},"
+                    + " expected case id 1641312631808724");
+        }
+
+        @Test
+        void shouldThrowAssersionErrorWhenDocumentIdIsInvalid() {
+            CaseData caseData = CaseData.builder()
+                .id(validCaseId)
+                .state(State.SUBMITTED)
+                .c110A(C110A.builder()
+                    .submittedForm(DocumentReference.builder()
+                        .url(String.format("http://test.com/%s", invalidDocId))
+                        .build())
+                    .build())
+                .build();
+
+            assertThatThrownBy(() -> postAboutToSubmitEvent(buildCaseDetails(caseData, migrationId)))
+                .getRootCause()
+                .isInstanceOf(AssertionError.class)
+                .hasMessage("Migration {id = DFPL-551, case reference = 1641312631808724},"
+                    + " expected c110a document id 0de3ba95-e383-41b4-8a66-52bf0dce834e");
+        }
+
 
     }
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -114,9 +114,9 @@ public class MigrateCaseController extends CallbackController {
     private void run551(CaseDetails caseDetails) {
         CaseData caseData = getCaseData(caseDetails);
         var caseId = caseData.getId();
-        var expectedCaseId = 1642077834805293L;
+        var expectedCaseId = 1641312631808724L;
 
-        var expectedDocId = UUID.fromString("6ac68da6-05d1-4616-970a-bc53346173b3");
+        var expectedDocId = UUID.fromString("0de3ba95-e383-41b4-8a66-52bf0dce834e");
 
         if (caseId != expectedCaseId) {
             throw new AssertionError(format(

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -38,7 +38,8 @@ public class MigrateCaseController extends CallbackController {
     private final Map<String, Consumer<CaseDetails>> migrations = Map.of(
         "DFPL-500", this::run500,
         "DFPL-466", this::run466,
-        "DFPL-482", this::run482
+        "DFPL-482", this::run482,
+        "DFPL-551", this::run551
     );
 
     @PostMapping("/about-to-submit")
@@ -108,6 +109,31 @@ public class MigrateCaseController extends CallbackController {
         }
 
         updateDocumentsSentToParties(caseDetails, caseData, docIds);
+    }
+
+    private void run551(CaseDetails caseDetails) {
+        CaseData caseData = getCaseData(caseDetails);
+        var caseId = caseData.getId();
+        var expectedCaseId = 1642077834805293L;
+
+        var expectedDocId = UUID.fromString("6ac68da6-05d1-4616-970a-bc53346173b3");
+
+        if (caseId != expectedCaseId) {
+            throw new AssertionError(format(
+                "Migration {id = DFPL-551, case reference = %s}, expected case id %d",
+                caseId, expectedCaseId
+            ));
+        }
+
+        var documentUrl = caseData.getC110A().getDocument().getUrl();
+        var docId = UUID.fromString(documentUrl.substring(documentUrl.length() - 36));
+        if (!docId.equals(expectedDocId)) {
+            throw new AssertionError(format(
+                "Migration {id = DFPL-551, case reference = %s}, expected c110a document id %s",
+                caseId, expectedDocId
+            ));
+        }
+        caseDetails.getData().put("submittedForm", null);
     }
 
     private void updateDocumentsSentToParties(CaseDetails caseDetails, CaseData caseData, List<UUID> docIds) {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-551


### Change description ###
Removes the C110a document reference (submittedForm field) for the specified case.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
