### PR TITLE
chore(tests): Fix enter other api test

### DIFF
--- a/service/src/functionalTest/resources/enter-others/extract-confidential-data.json
+++ b/service/src/functionalTest/resources/enter-others/extract-confidential-data.json
@@ -36,7 +36,9 @@
               "telephone": null,
               "childInformation": null,
               "litigationIssues": "NO",
-              "detailsHidden": "Yes"
+              "detailsHidden": "Yes",
+              "addressKnow": null,
+              "addressNotKnowReason": null
             },
             "additionalOthers": []
           }
@@ -92,9 +94,7 @@
             "detailsHidden": "Yes",
             "detailsHiddenReason": null,
             "representedBy": [],
-            "DOB": "2000-07-12",
-            "addressKnow": null,
-            "addressNotKnowReason": null
+            "DOB": "2000-07-12"
           },
           "additionalOthers": []
         },
@@ -122,9 +122,7 @@
               "detailsHidden": null,
               "detailsHiddenReason": null,
               "representedBy": [],
-              "DOB": null,
-              "addressKnow": null,
-              "addressNotKnowReason": null
+              "DOB": null
             }
           }
         ]

--- a/service/src/functionalTest/resources/enter-others/extract-confidential-data.json
+++ b/service/src/functionalTest/resources/enter-others/extract-confidential-data.json
@@ -36,9 +36,7 @@
               "telephone": null,
               "childInformation": null,
               "litigationIssues": "NO",
-              "detailsHidden": "Yes",
-              "addressKnow": null,
-              "addressNotKnowReason": null
+              "detailsHidden": "Yes"
             },
             "additionalOthers": []
           }


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A (introduced in DFPL-84)


### Change description ###
Fixes the API test which is failing only in Nightly at the moment - these two fields aren't required in this case as the fixture has an address, only need these fields when you don't know the address.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
