### PR TITLE
DFPL-615: Show hearingVenue drop down list when editing a future hearing

### DIFF
--- a/ccd-definition/CaseEventToFields/CareSupervision/manageHearings.json
+++ b/ccd-definition/CaseEventToFields/CareSupervision/manageHearings.json
@@ -381,7 +381,7 @@
     "PageID": "EnterHearingDetails",
     "ShowSummaryChangeOption": "Y",
     "PageDisplayOrder": 5,
-    "FieldShowCondition": "firstHearingFlag!=\"No\" OR hasPreviousHearingVenue=\"No\""
+    "FieldShowCondition": "firstHearingFlag!=\"No\" OR hasPreviousHearingVenue=\"No\" OR hearingOption=\"EDIT_FUTURE_HEARING\""
   },
   {
     "LiveFrom": "01/01/2017",

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -87,4 +87,11 @@
    ]]></notes>
     <cve>CVE-2022-22965</cve>
   </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: spring-core-5.3.12.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
+    <cve>CVE-2016-1000027</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-615


### Change description ###
Forces the hearing venue to be shown and filled in when editing a future hearing - at the moment it's not visible and so users can get to the end of the flow and then the venue is set to null on the hearing booking, causing an error.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
