### PR TITLE
DFPL-626: Remove exception as the null check is already handled

### DIFF
--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ManageHearingsControllerEditHearingMidEventTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ManageHearingsControllerEditHearingMidEventTest.java
@@ -47,19 +47,6 @@ class ManageHearingsControllerEditHearingMidEventTest extends ManageHearingsCont
     }
 
     @Test
-    void shouldStillAllowHearingCreationWhenPreviousVenueIsNull() {
-        // Past case was created with a null venue
-        Element<HearingBooking> pastHearing1 = element(testHearing(now().minusDays(3), null, null));
-
-        CaseData initialCaseData = CaseData.builder()
-            .hearingOption(NEW_HEARING)
-            .hearingDetails(List.of(pastHearing1))
-            .build();
-
-        assertDoesNotThrow(() -> extractCaseData(postEditHearingMidEvent(initialCaseData)));
-    }
-
-    @Test
     void shouldSetHasPreviousHearingVenueAsNoWhenPreviousHearingVenueIsNull() {
         Element<HearingBooking> pastHearing1 = element(testHearing(now().minusDays(3), true));
 
@@ -69,6 +56,7 @@ class ManageHearingsControllerEditHearingMidEventTest extends ManageHearingsCont
             .build();
 
         CaseData updatedCaseData = extractCaseData(postEditHearingMidEvent(initialCaseData));
+        assertDoesNotThrow(() -> extractCaseData(postEditHearingMidEvent(initialCaseData)));
         assertThat(updatedCaseData.getHasPreviousHearingVenue()).isEqualTo("No");
     }
 

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ManageHearingsControllerEditHearingMidEventTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ManageHearingsControllerEditHearingMidEventTest.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.reform.fpl.model.common.Element;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static uk.gov.hmcts.reform.fpl.enums.HearingOptions.ADJOURN_HEARING;
 import static uk.gov.hmcts.reform.fpl.enums.HearingOptions.EDIT_FUTURE_HEARING;
 import static uk.gov.hmcts.reform.fpl.enums.HearingOptions.EDIT_PAST_HEARING;
@@ -43,6 +44,19 @@ class ManageHearingsControllerEditHearingMidEventTest extends ManageHearingsCont
             .previousVenue("Aberdeen Tribunal Hearing Centre, 48 Huntly Street, AB1, Aberdeen, AB10 1SH")
             .build());
         assertThat(updatedCaseData.getHasPreviousHearingVenue()).isEqualTo("Yes");
+    }
+
+    @Test
+    void shouldStillAllowHearingCreationWhenPreviousVenueIsNull() {
+        // Past case was created with a null venue
+        Element<HearingBooking> pastHearing1 = element(testHearing(now().minusDays(3), null, null));
+
+        CaseData initialCaseData = CaseData.builder()
+            .hearingOption(NEW_HEARING)
+            .hearingDetails(List.of(pastHearing1))
+            .build();
+
+        assertDoesNotThrow(() -> extractCaseData(postEditHearingMidEvent(initialCaseData)));
     }
 
     @Test

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ManageHearingsControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ManageHearingsControllerTest.java
@@ -48,7 +48,7 @@ abstract class ManageHearingsControllerTest extends AbstractCallbackTest {
     }
 
     HearingBooking testHearing(LocalDateTime startDate, boolean nullVenue) {
-        return testHearing(startDate, nullVenue ? "" : "96");
+        return testHearing(startDate, nullVenue ? null : "96");
     }
 
     HearingBooking testHearing(LocalDateTime startDate, UUID cmoId) {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/HearingVenueLookUpService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/HearingVenueLookUpService.java
@@ -41,9 +41,6 @@ public class HearingVenueLookUpService {
 
     public HearingVenue getHearingVenue(final HearingBooking hearingBooking) {
         if (!HEARING_VENUE_ID_OTHER.equals(hearingBooking.getVenue())) {
-            if (hearingBooking.getVenue() == null) {
-                throw new IllegalStateException("Unexpected null venue." + hearingBooking);
-            }
             return getHearingVenue(hearingBooking.getVenue());
         } else {
             return HearingVenue.builder()


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-626


### Change description ###
Removes the exception being thrown - the null check is handled in the next function to be called `getHearingVenue(hearingBooking.getVenue());`

Currently blocking users making new hearings.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
