### PR TITLE
DFPL-629: Update C110A removal migration

### DIFF
--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseControllerTest.java
@@ -356,12 +356,12 @@ class MigrateCaseControllerTest extends AbstractCallbackTest {
 
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     @Nested
-    class Dfpl576 {
-        private final String migrationId = "DFPL-576";
-        private final long validCaseId = 1647961407412501L;
+    class Dfpl629 {
+        private final String migrationId = "DFPL-629";
+        private final long validCaseId = 1638285652903217L;
         private final long invalidCaseId = 1643728359576136L;
 
-        private final UUID validDocId = UUID.fromString("2003a762-a9d0-483a-8a40-f4d043e7434c");
+        private final UUID validDocId = UUID.fromString("9da18cc4-418f-4b99-86e7-4fb5dc7a5648");
         private final UUID invalidDocId = UUID.randomUUID();
 
         @Test
@@ -400,8 +400,8 @@ class MigrateCaseControllerTest extends AbstractCallbackTest {
             assertThatThrownBy(() -> postAboutToSubmitEvent(buildCaseDetails(caseData, migrationId)))
                 .getRootCause()
                 .isInstanceOf(AssertionError.class)
-                .hasMessage("Migration {id = DFPL-576, case reference = 1643728359576136},"
-                    + " expected case id 1647961407412501");
+                .hasMessage("Migration {id = DFPL-629, case reference = 1643728359576136},"
+                    + " expected case id 1638285652903217");
         }
 
         @Test
@@ -419,8 +419,8 @@ class MigrateCaseControllerTest extends AbstractCallbackTest {
             assertThatThrownBy(() -> postAboutToSubmitEvent(buildCaseDetails(caseData, migrationId)))
                 .getRootCause()
                 .isInstanceOf(AssertionError.class)
-                .hasMessage("Migration {id = DFPL-576, case reference = 1647961407412501},"
-                    + " expected c110a document id 2003a762-a9d0-483a-8a40-f4d043e7434c");
+                .hasMessage("Migration {id = DFPL-629, case reference = 1638285652903217},"
+                    + " expected c110a document id 9da18cc4-418f-4b99-86e7-4fb5dc7a5648");
         }
 
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -40,7 +40,7 @@ public class MigrateCaseController extends CallbackController {
         "DFPL-451", this::run451,
         "DFPL-482", this::run482,
         "DFPL-572", this::run572,
-        "DFPL-576", this::run576
+        "DFPL-629", this::run629
     );
 
     @PostMapping("/about-to-submit")
@@ -113,17 +113,26 @@ public class MigrateCaseController extends CallbackController {
         updateDocumentsSentToParties(caseDetails, caseData, docIds);
     }
 
-    private void run576(CaseDetails caseDetails) {
+    /**
+     * Removes a C110A Generated PDF document from the case
+     * Make sure to update:
+     *  - expectedCaseId
+     *  - expectedDocId
+     *  - migrationId
+     * @param caseDetails
+     */
+    private void run629(CaseDetails caseDetails) {
+        var migrationId = "DFPL-629";
+        var expectedCaseId = 1638285652903217L;
+        var expectedDocId = UUID.fromString("9da18cc4-418f-4b99-86e7-4fb5dc7a5648");
+
         CaseData caseData = getCaseData(caseDetails);
         var caseId = caseData.getId();
-        var expectedCaseId = 1647961407412501L;
-
-        var expectedDocId = UUID.fromString("2003a762-a9d0-483a-8a40-f4d043e7434c");
 
         if (caseId != expectedCaseId) {
             throw new AssertionError(format(
-                "Migration {id = DFPL-576, case reference = %s}, expected case id %d",
-                caseId, expectedCaseId
+                "Migration {id = %s, case reference = %s}, expected case id %d",
+                migrationId, caseId, expectedCaseId
             ));
         }
 
@@ -131,8 +140,8 @@ public class MigrateCaseController extends CallbackController {
         var docId = UUID.fromString(documentUrl.substring(documentUrl.length() - 36));
         if (!docId.equals(expectedDocId)) {
             throw new AssertionError(format(
-                "Migration {id = DFPL-576, case reference = %s}, expected c110a document id %s",
-                caseId, expectedDocId
+                "Migration {id = %s, case reference = %s}, expected c110a document id %s",
+                migrationId, caseId, expectedDocId
             ));
         }
         caseDetails.getData().put("submittedForm", null);

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -114,12 +114,12 @@ public class MigrateCaseController extends CallbackController {
     }
 
     /**
-     * Removes a C110A Generated PDF document from the case
+     * Removes a C110A Generated PDF document from the case.
      * Make sure to update:
      *  - expectedCaseId
      *  - expectedDocId
      *  - migrationId
-     * @param caseDetails
+     * @param caseDetails - the caseDetails to update
      */
     private void run629(CaseDetails caseDetails) {
         var migrationId = "DFPL-629";


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-629


### Change description ###
Updates the C110A removal migration to be quicker to modify, and updates it with the latest case details to migrate.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
