### PR TITLE
DFPL-698 Update Cafcass Wales templates to Digital Preference

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/CaseManagementOrderIssuedEventHandler.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/CaseManagementOrderIssuedEventHandler.java
@@ -91,7 +91,7 @@ public class CaseManagementOrderIssuedEventHandler {
             HearingOrder issuedCmo = event.getCmo();
 
             final IssuedCMOTemplate cafcassParameters = contentProvider.buildCMOIssuedNotificationParameters(
-                    caseData, issuedCmo, EMAIL);
+                    caseData, issuedCmo, DIGITAL_SERVICE);
 
             notificationService.sendEmail(
                     CMO_ORDER_ISSUED_NOTIFICATION_TEMPLATE,

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/SendNoticeOfHearingHandler.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/SendNoticeOfHearingHandler.java
@@ -88,7 +88,7 @@ public class SendNoticeOfHearingHandler {
             final String recipient = cafcassLookupConfiguration.getCafcass(caseData.getCaseLocalAuthority()).getEmail();
 
             NotifyData notifyData = noticeOfHearingEmailContentProvider.buildNewNoticeOfHearingNotification(
-                caseData, event.getSelectedHearing(), EMAIL
+                caseData, event.getSelectedHearing(), DIGITAL_SERVICE
             );
             notificationService.sendEmail(NOTICE_OF_NEW_HEARING, recipient, notifyData, caseData.getId());
         }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/cmo/DraftOrdersApprovedEventHandler.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/cmo/DraftOrdersApprovedEventHandler.java
@@ -120,7 +120,7 @@ public class DraftOrdersApprovedEventHandler {
                 .map(Element::getValue)
                 .orElse(null);
 
-            NotifyData content = contentProvider.buildOrdersApprovedContent(caseData, hearing, approvedOrders, EMAIL);
+            NotifyData content = contentProvider.buildOrdersApprovedContent(caseData, hearing, approvedOrders, DIGITAL_SERVICE);
 
             notificationService.sendEmail(
                     JUDGE_APPROVES_DRAFT_ORDERS,

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/CaseManagementOrderIssuedEventHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/CaseManagementOrderIssuedEventHandlerTest.java
@@ -134,7 +134,7 @@ class CaseManagementOrderIssuedEventHandlerTest {
         given(CASE_DATA.getCaseLocalAuthority()).willReturn(LOCAL_AUTHORITY_CODE);
         given(cafcassLookupConfiguration.getCafcassWelsh(LOCAL_AUTHORITY_CODE))
             .willReturn(Optional.of(new Cafcass(LOCAL_AUTHORITY_CODE, CAFCASS_EMAIL_ADDRESS)));
-        given(cmoContentProvider.buildCMOIssuedNotificationParameters(CASE_DATA, CMO, EMAIL))
+        given(cmoContentProvider.buildCMOIssuedNotificationParameters(CASE_DATA, CMO, DIGITAL_SERVICE))
             .willReturn(EMAIL_REP_CMO_TEMPLATE_DATA);
 
         underTest.notifyCafcass(EVENT);

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/DraftOrdersApprovedEventHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/DraftOrdersApprovedEventHandlerTest.java
@@ -162,7 +162,7 @@ class DraftOrdersApprovedEventHandlerTest {
         given(cafcassLookupConfiguration.getCafcassWelsh(LOCAL_AUTHORITY_CODE))
                 .willReturn(Optional.of(cafcass));
         given(reviewDraftOrdersEmailContentProvider.buildOrdersApprovedContent(
-            caseData, HEARING.getValue(), orders, EMAIL)).willReturn(EXPECTED_TEMPLATE);
+            caseData, HEARING.getValue(), orders, DIGITAL_SERVICE)).willReturn(EXPECTED_TEMPLATE);
 
         underTest.sendNotificationToCafcass(new DraftOrdersApproved(caseData, orders));
 

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/SendNoticeOfHearingHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/SendNoticeOfHearingHandlerTest.java
@@ -130,7 +130,7 @@ class SendNoticeOfHearingHandlerTest {
         given(CASE_DATA.getId()).willReturn(CASE_ID);
         given(CASE_DATA.getCaseLocalAuthority()).willReturn(LOCAL_AUTHORITY_CODE);
         given(cafcassLookup.getCafcass(LOCAL_AUTHORITY_CODE)).willReturn(new Cafcass("", CAFCASS_EMAIL_ADDRESS));
-        given(contentProvider.buildNewNoticeOfHearingNotification(CASE_DATA, HEARING, EMAIL))
+        given(contentProvider.buildNewNoticeOfHearingNotification(CASE_DATA, HEARING, DIGITAL_SERVICE))
             .willReturn(EMAIL_REP_NOTIFY_DATA);
         given(cafcassLookup.getCafcassWelsh(LOCAL_AUTHORITY_CODE))
             .willReturn(Optional.of(
@@ -292,7 +292,7 @@ class SendNoticeOfHearingHandlerTest {
         underTest.sendNoticeOfHearingByPost(new SendNoticeOfHearing(CASE_DATA, HearingBooking.builder()
             .translationRequirements(LanguageTranslationRequirement.WELSH_TO_ENGLISH)
             .build()));
-        
+
         verifyNoInteractions(sendDocumentService, otherRecipientsInbox, notificationService);
     }
 


### PR DESCRIPTION
Update the cafcass wales to use digital preference so the new templates for 669 correctly show the case url links.

https://tools.hmcts.net/jira/browse/DFPL-698

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
