### PR TITLE
DFPL-544 fix empty option of old document

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/CourtBundle.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/CourtBundle.java
@@ -19,7 +19,14 @@ public class CourtBundle extends DocumentMetaData {
     private String hearing;
     private DocumentReference document;
     private List<String> confidential;
-    private YesNo hasConfidentialAddress;
+    private String hasConfidentialAddress;
+
+    public String getHasConfidentialAddress() {
+        return (document != null
+                && (!YesNo.YES.getValue().equalsIgnoreCase(hasConfidentialAddress)
+                     || !YesNo.NO.getValue().equalsIgnoreCase(hasConfidentialAddress)))
+            ? YesNo.NO.getValue() : hasConfidentialAddress;
+    }
 
     @JsonIgnore
     @Override
@@ -33,7 +40,7 @@ public class CourtBundle extends DocumentMetaData {
                        String uploadedBy,
                        String hearing,
                        List<String> confidential,
-                       YesNo hasConfidentialAddress) {
+                       String hasConfidentialAddress) {
         super.dateTimeUploaded = dateTimeUploaded;
         super.uploadedBy = uploadedBy;
         this.confidential = confidential;
@@ -45,6 +52,6 @@ public class CourtBundle extends DocumentMetaData {
     @JsonIgnore
     public boolean isConfidentialDocument() {
         return (confidential != null && confidential.contains("CONFIDENTIAL"))
-            || (YesNo.YES.equals(hasConfidentialAddress));
+            || (YesNo.YES.getValue().equalsIgnoreCase(hasConfidentialAddress));
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/SupportingEvidenceBundle.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/SupportingEvidenceBundle.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.DATE;
 import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.formatLocalDateTimeBaseUsingFormat;
 
@@ -43,12 +44,19 @@ public class SupportingEvidenceBundle implements TranslatableItem, FurtherDocume
     private final DocumentReference translatedDocument;
     private final LocalDateTime translationUploadDateTime;
     private final LanguageTranslationRequirement translationRequirements;
-    private YesNo hasConfidentialAddress;
+    private String hasConfidentialAddress;
+
+    public String getHasConfidentialAddress() {
+        return ((!isBlank(name) || document != null)
+                && (!YesNo.YES.getValue().equalsIgnoreCase(hasConfidentialAddress)
+                    || !YesNo.NO.getValue().equalsIgnoreCase(hasConfidentialAddress)))
+            ? YesNo.NO.getValue() : hasConfidentialAddress;
+    }
 
     @JsonIgnore
     public boolean isConfidentialDocument() {
         return (confidential != null && confidential.contains("CONFIDENTIAL"))
-               || YesNo.YES.equals(hasConfidentialAddress);
+               || YesNo.YES.getValue().equalsIgnoreCase(hasConfidentialAddress);
     }
 
     @JsonIgnore

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ManageDocumentServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ManageDocumentServiceTest.java
@@ -1551,12 +1551,12 @@ class ManageDocumentServiceTest {
             element(uuid, SupportingEvidenceBundle.builder()
                 .name("test bundle name 1")
                 .document(confidentialDoc)
-                .hasConfidentialAddress(YES)
+                .hasConfidentialAddress(YES.getValue())
                 .build()),
             element(uuid, SupportingEvidenceBundle.builder()
                 .name("test bundle name 2")
                 .document(normalDoc)
-                .hasConfidentialAddress(NO)
+                .hasConfidentialAddress(NO.getValue())
                 .build())
         );
 
@@ -1591,10 +1591,10 @@ class ManageDocumentServiceTest {
         List<Element<CourtBundle>> courtBundles = List.of(
             element(uuid1, CourtBundle.builder()
                 .document(confidentialDoc)
-                .hasConfidentialAddress(YES).build()),
+                .hasConfidentialAddress(YES.getValue()).build()),
             element(uuid2, CourtBundle.builder()
                 .document(normalDoc)
-                .hasConfidentialAddress(NO).build()));
+                .hasConfidentialAddress(NO.getValue()).build()));
 
         List<Element<HearingCourtBundle>> hearingCourtBundles = List.of(
             element(randomUUID(), HearingCourtBundle.builder()


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-544


### Change description ###
Fix mandatory Confidential Address YesNo question is empty for old document uploaded in the past.
It is tedious for user to answer the question multiple times if there are lots of old document.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
