### PR TITLE
DFPL-595: Upload Draft Orders with Additional Applications

### DIFF
--- a/ccd-definition/AuthorisationComplexType/caseDocuments/AdditionalApplicationsBundle.json
+++ b/ccd-definition/AuthorisationComplexType/caseDocuments/AdditionalApplicationsBundle.json
@@ -1569,6 +1569,60 @@
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
     "CaseFieldID": "additionalApplicationsBundle",
+    "ListElementCode": "c2DocumentBundle.draftOrdersBundle",
+    "AccessControl": [
+      {
+        "UserRoles": [
+          "[LABARRISTER]",
+          "[LASHARED]",
+          "[SOLICITOR]",
+          "[SOLICITORA]",
+          "[SOLICITORB]",
+          "[SOLICITORC]",
+          "[SOLICITORD]",
+          "[SOLICITORE]",
+          "[SOLICITORF]",
+          "[SOLICITORG]",
+          "[SOLICITORH]",
+          "[SOLICITORI]",
+          "[SOLICITORJ]",
+          "[LASOLICITOR]",
+          "[CAFCASSSOLICITOR]",
+          "[CHILDSOLICITORA]",
+          "[CHILDSOLICITORB]",
+          "[CHILDSOLICITORC]",
+          "[CHILDSOLICITORD]",
+          "[CHILDSOLICITORE]",
+          "[CHILDSOLICITORF]",
+          "[CHILDSOLICITORG]",
+          "[CHILDSOLICITORH]",
+          "[CHILDSOLICITORI]",
+          "[CHILDSOLICITORJ]",
+          "[CHILDSOLICITORK]",
+          "[CHILDSOLICITORL]",
+          "[CHILDSOLICITORM]",
+          "[CHILDSOLICITORN]",
+          "[CHILDSOLICITORO]",
+          "caseworker-publiclaw-courtadmin",
+          "caseworker-publiclaw-cafcass"
+        ],
+        "CRUD": "CRU"
+      },
+      {
+        "UserRoles": [
+          "caseworker-publiclaw-gatekeeper",
+          "caseworker-publiclaw-judiciary",
+          "caseworker-publiclaw-magistrate",
+          "[BARRISTER]"
+        ],
+        "CRUD": "R"
+      }
+    ]
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseFieldID": "additionalApplicationsBundle",
     "ListElementCode": "otherApplicationsBundle.othersNotified",
     "AccessControl": [
       {

--- a/ccd-definition/CaseEventToComplexTypes/upload-c2/C2DocumentBundle.json
+++ b/ccd-definition/CaseEventToComplexTypes/upload-c2/C2DocumentBundle.json
@@ -85,8 +85,8 @@
     "ID": "C2DocumentBundle",
     "CaseEventID": "uploadAdditionalApplications",
     "CaseFieldID": "temporaryC2Document",
-    "EventElementLabel": "Supporting Documents",
-    "ListElementCode": "supportingEvidenceBundle",
+    "EventElementLabel": "Draft Orders",
+    "ListElementCode": "draftOrdersBundle",
     "FieldDisplayOrder": "9",
     "DisplayContext": "OPTIONAL"
   },
@@ -96,7 +96,7 @@
     "CaseEventID": "uploadAdditionalApplications",
     "CaseFieldID": "temporaryC2Document",
     "EventElementLabel": "File name",
-    "ListElementCode": "supportingEvidenceBundle.name",
+    "ListElementCode": "draftOrdersBundle.title",
     "FieldDisplayOrder": "10",
     "DisplayContext": "MANDATORY"
   },
@@ -105,8 +105,47 @@
     "ID": "C2DocumentBundle",
     "CaseEventID": "uploadAdditionalApplications",
     "CaseFieldID": "temporaryC2Document",
-    "ListElementCode": "supportingEvidenceBundle.notes",
+    "ListElementCode": "draftOrdersBundle.notes",
     "FieldDisplayOrder": "11",
+    "DisplayContext": "OPTIONAL"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "C2DocumentBundle",
+    "CaseEventID": "uploadAdditionalApplications",
+    "CaseFieldID": "temporaryC2Document",
+    "ListElementCode": "draftOrdersBundle.document",
+    "EventElementLabel": "Upload document",
+    "FieldDisplayOrder": "12",
+    "DisplayContext": "MANDATORY"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "C2DocumentBundle",
+    "CaseEventID": "uploadAdditionalApplications",
+    "CaseFieldID": "temporaryC2Document",
+    "EventElementLabel": "Supporting Documents",
+    "ListElementCode": "supportingEvidenceBundle",
+    "FieldDisplayOrder": "13",
+    "DisplayContext": "OPTIONAL"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "C2DocumentBundle",
+    "CaseEventID": "uploadAdditionalApplications",
+    "CaseFieldID": "temporaryC2Document",
+    "EventElementLabel": "File name",
+    "ListElementCode": "supportingEvidenceBundle.name",
+    "FieldDisplayOrder": "14",
+    "DisplayContext": "MANDATORY"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "C2DocumentBundle",
+    "CaseEventID": "uploadAdditionalApplications",
+    "CaseFieldID": "temporaryC2Document",
+    "ListElementCode": "supportingEvidenceBundle.notes",
+    "FieldDisplayOrder": "15",
     "DisplayContext": "OPTIONAL"
   },
   {
@@ -125,7 +164,7 @@
     "CaseFieldID": "temporaryC2Document",
     "ListElementCode": "supportingEvidenceBundle.document",
     "EventElementLabel": "Upload document",
-    "FieldDisplayOrder": "12",
+    "FieldDisplayOrder": "16",
     "DisplayContext": "MANDATORY"
   }
 ]

--- a/ccd-definition/ComplexTypes/CareSupervision/1_SupportingDocuments/DraftOrder.json
+++ b/ccd-definition/ComplexTypes/CareSupervision/1_SupportingDocuments/DraftOrder.json
@@ -1,0 +1,26 @@
+[
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "DraftOrder",
+    "ListElementCode": "title",
+    "FieldType": "Text",
+    "ElementLabel": "Document name",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "DraftOrder",
+    "ListElementCode": "dateTimeUploaded",
+    "FieldType": "DateTime",
+    "ElementLabel": "Date and time uploaded",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "DraftOrder",
+    "ListElementCode": "document",
+    "FieldType": "Document",
+    "ElementLabel": "File",
+    "SecurityClassification": "Public"
+  }
+]

--- a/ccd-definition/ComplexTypes/CareSupervision/1_SupportingDocuments/DraftOrdersTest.json
+++ b/ccd-definition/ComplexTypes/CareSupervision/1_SupportingDocuments/DraftOrdersTest.json
@@ -1,0 +1,55 @@
+[
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "DraftOrdersTest",
+    "ListElementCode": "documentType",
+    "FieldType": "FixedList",
+    "FieldTypeParameter": "ApplicationDocumentType",
+    "ElementLabel": "Type of document",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "DraftOrdersTest",
+    "ListElementCode": "documentName",
+    "FieldType": "Text",
+    "ElementLabel": "Document name",
+    "HintText": "Use a meaningful name. For example, medical report",
+    "SecurityClassification": "Public",
+    "FieldShowCondition": "documentType=\"OTHER\""
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "DraftOrdersTest",
+    "ListElementCode": "includedInSWET",
+    "FieldType": "TextArea",
+    "ElementLabel": "Included in SWET",
+    "HintText": "Use a meaningful name. For example, Genogram",
+    "SecurityClassification": "Public",
+    "FieldShowCondition": "documentType=\"SWET\""
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "DraftOrdersTest",
+    "ListElementCode": "document",
+    "FieldType": "Document",
+    "ElementLabel": "File",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "DraftOrdersTest",
+    "ListElementCode": "dateTimeUploaded",
+    "FieldType": "DateTime",
+    "ElementLabel": "Date and time uploaded",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "DraftOrdersTest",
+    "ListElementCode": "uploadedBy",
+    "FieldType": "Text",
+    "ElementLabel": "Uploaded by",
+    "SecurityClassification": "Public"
+  }
+]

--- a/ccd-definition/ComplexTypes/CareSupervision/4_C2DocumentBundle.json
+++ b/ccd-definition/ComplexTypes/CareSupervision/4_C2DocumentBundle.json
@@ -102,6 +102,15 @@
   {
     "LiveFrom": "01/01/2017",
     "ID": "C2DocumentBundle",
+    "ListElementCode": "draftOrdersBundle",
+    "ElementLabel": "Draft Orders",
+    "FieldType": "Collection",
+    "FieldTypeParameter": "DraftOrder",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "C2DocumentBundle",
     "ListElementCode": "supplementsBundle",
     "ElementLabel": "Supplements",
     "FieldType": "Collection",

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/UploadAdditionalApplicationsController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/UploadAdditionalApplicationsController.java
@@ -16,21 +16,30 @@ import uk.gov.hmcts.reform.fnp.exception.PaymentsApiException;
 import uk.gov.hmcts.reform.fpl.events.AdditionalApplicationsPbaPaymentNotTakenEvent;
 import uk.gov.hmcts.reform.fpl.events.AdditionalApplicationsUploadedEvent;
 import uk.gov.hmcts.reform.fpl.events.FailedPBAPaymentEvent;
+import uk.gov.hmcts.reform.fpl.events.cmo.DraftOrdersUploaded;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.FeesData;
 import uk.gov.hmcts.reform.fpl.model.PBAPayment;
 import uk.gov.hmcts.reform.fpl.model.common.AdditionalApplicationsBundle;
 import uk.gov.hmcts.reform.fpl.model.common.C2DocumentBundle;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
+import uk.gov.hmcts.reform.fpl.model.event.UploadDraftOrdersData;
+import uk.gov.hmcts.reform.fpl.model.order.DraftOrder;
+import uk.gov.hmcts.reform.fpl.model.order.HearingOrder;
+import uk.gov.hmcts.reform.fpl.model.order.HearingOrdersBundle;
 import uk.gov.hmcts.reform.fpl.service.PbaNumberService;
 import uk.gov.hmcts.reform.fpl.service.PeopleInCaseService;
 import uk.gov.hmcts.reform.fpl.service.additionalapplications.ApplicantsListGenerator;
 import uk.gov.hmcts.reform.fpl.service.additionalapplications.ApplicationsFeeCalculator;
 import uk.gov.hmcts.reform.fpl.service.additionalapplications.UploadAdditionalApplicationsService;
+import uk.gov.hmcts.reform.fpl.service.cmo.DraftOrderService;
 import uk.gov.hmcts.reform.fpl.service.payment.PaymentService;
+import uk.gov.hmcts.reform.fpl.utils.ElementUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static java.util.Objects.isNull;
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
@@ -52,6 +61,7 @@ public class UploadAdditionalApplicationsController extends CallbackController {
     private static final String TEMPORARY_C2_DOCUMENT = "temporaryC2Document";
     private static final String TEMPORARY_OTHER_APPLICATIONS_BUNDLE = "temporaryOtherApplicationsBundle";
 
+    private final DraftOrderService draftOrderService;
     private final PaymentService paymentService;
     private final PbaNumberService pbaNumberService;
     private final UploadAdditionalApplicationsService uploadAdditionalApplicationsService;
@@ -108,6 +118,19 @@ public class UploadAdditionalApplicationsController extends CallbackController {
         CaseDetails caseDetails = callbackRequest.getCaseDetails();
         CaseData caseData = getCaseData(caseDetails);
 
+        List<Element<HearingOrder>> unsealedCMOs = caseData.getDraftUploadedCMOs();
+        List<Element<DraftOrder>> draftOrders = caseData.getTemporaryC2Document().getDraftOrdersBundle();
+        unsealedCMOs.addAll(draftOrders.stream()
+            .map(Element::getValue)
+            .map(HearingOrder::from)
+            .map(ElementUtils::element)
+            .collect(Collectors.toList()));
+        List<Element<HearingOrdersBundle>> bundles = draftOrderService.migrateCmoDraftToOrdersBundles(caseData);
+
+        draftOrderService.additionalApplicationUpdateCase(unsealedCMOs, bundles);
+
+        caseDetails.getData().put("hearingOrdersBundlesDrafts", bundles);
+
         List<Element<AdditionalApplicationsBundle>> additionalApplications = defaultIfNull(
             caseData.getAdditionalApplicationsBundle(), new ArrayList<>()
         );
@@ -145,6 +168,8 @@ public class UploadAdditionalApplicationsController extends CallbackController {
 
         publishEvent(new AdditionalApplicationsUploadedEvent(caseData, getCaseDataBefore(callbackRequest),
             applicantsListGenerator.getApplicant(caseData, lastBundle)));
+
+        publishEvent(new DraftOrdersUploaded(caseData));
 
         if (isNotPaidByPba(pbaPayment)) {
             log.info("Payment for case {} not taken due to user decision", caseDetails.getId());

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/common/C2DocumentBundle.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/common/C2DocumentBundle.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.reform.fpl.model.Respondent;
 import uk.gov.hmcts.reform.fpl.model.Supplement;
 import uk.gov.hmcts.reform.fpl.model.SupportingEvidenceBundle;
 import uk.gov.hmcts.reform.fpl.model.interfaces.ApplicationsBundle;
+import uk.gov.hmcts.reform.fpl.model.order.DraftOrder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -42,6 +43,7 @@ public class C2DocumentBundle implements ApplicationsBundle {
     private final String uploadedDateTime;
     private final String author;
     private List<Element<SupportingEvidenceBundle>> supportingEvidenceBundle;
+    private List<Element<DraftOrder>> draftOrdersBundle;
     private final List<Element<Supplement>> supplementsBundle;
     private final List<C2AdditionalOrdersRequested> c2AdditionalOrdersRequested;
     private final ParentalResponsibilityType parentalResponsibilityType;

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/order/DraftOrder.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/order/DraftOrder.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.reform.fpl.model.order;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Data;
+import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
+import java.time.LocalDate;
+
+@Data
+@Builder(toBuilder = true)
+@JsonInclude(value = JsonInclude.Include.NON_NULL)
+public class DraftOrder {
+    private String title;
+    private DocumentReference document;
+    private LocalDate dateTimeUploaded;
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/order/HearingOrder.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/order/HearingOrder.java
@@ -80,6 +80,20 @@ public class HearingOrder implements RemovableOrder, AmendableOrder, Translatabl
             .build();
     }
 
+    public static HearingOrder from(DraftOrder draftOrder) {
+        return HearingOrder.builder()
+            .type(C21)
+            .title(draftOrder.getTitle())
+            .order(draftOrder.getDocument())
+            .hearing("No hearing")
+            .dateSent(draftOrder.getDateTimeUploaded())
+            .status(SEND_TO_JUDGE)
+            .judgeTitleAndName("")
+            .supportingDocs(null)
+            .translationRequirements(NO)
+            .build();
+    }
+
     @JsonIgnore
     public boolean isRemovable() {
         return true;

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/cmo/DraftOrderService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/cmo/DraftOrderService.java
@@ -8,10 +8,12 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.fpl.enums.CMOStatus;
 import uk.gov.hmcts.reform.fpl.enums.HearingOrderKind;
 import uk.gov.hmcts.reform.fpl.enums.HearingOrderType;
+import uk.gov.hmcts.reform.fpl.enums.LanguageTranslationRequirement;
 import uk.gov.hmcts.reform.fpl.enums.YesNo;
 import uk.gov.hmcts.reform.fpl.exceptions.CMONotFoundException;
 import uk.gov.hmcts.reform.fpl.exceptions.HearingNotFoundException;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
+import uk.gov.hmcts.reform.fpl.model.Hearing;
 import uk.gov.hmcts.reform.fpl.model.HearingBooking;
 import uk.gov.hmcts.reform.fpl.model.HearingFurtherEvidenceBundle;
 import uk.gov.hmcts.reform.fpl.model.SupportingEvidenceBundle;
@@ -199,6 +201,19 @@ public class DraftOrderService {
         return selectedHearingId;
     }
 
+    public void additionalApplicationUpdateCase(List<Element<HearingOrder>> draftOrders,
+                                                 List<Element<HearingOrdersBundle>> bundles) {
+
+        for (int i = 0; i < draftOrders.size(); i++) {
+            Element<HearingOrder> hearingOrder = draftOrders.get(i);
+            hearingOrder.getValue().setDateSent(time.now().toLocalDate());
+            hearingOrder.getValue().setStatus(SEND_TO_JUDGE);
+            hearingOrder.getValue().setTranslationRequirements(LanguageTranslationRequirement.NO);
+        }
+
+        addOrdersToBundle(bundles, draftOrders, null, C21);
+    }
+
     public List<Element<HearingOrdersBundle>> migrateCmoDraftToOrdersBundles(CaseData caseData) {
 
         List<Element<HearingOrder>> cmoDrafts = caseData.getDraftUploadedCMOs();
@@ -278,7 +293,7 @@ public class DraftOrderService {
         HearingBooking hearingBooking = Optional.ofNullable(hearing).map(Element::getValue).orElse(null);
 
         HearingOrdersBundle hearingOrdersBundle = bundles.stream()
-            .filter(bundle -> Objects.equals(bundle.getValue().getHearingId(), hearingId))
+                .filter(bundle -> Objects.equals(bundle.getValue().getHearingId(), hearingId))
             .map(Element::getValue)
             .findFirst()
             .orElseGet(() -> addNewDraftBundle(bundles));


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DFPL-545

Add the ability to upload draft orders with additional application flow along with supplements and additional documents

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
