### PR TITLE
FPL 729: Fix Spelling of court name on dropdown

### DIFF
--- a/ccd-definition/FixedLists/CareSupervision/Court.json
+++ b/ccd-definition/FixedLists/CareSupervision/Court.json
@@ -87,7 +87,7 @@
     "LiveFrom": "01/01/2017",
     "ID": "Court",
     "ListElementCode": "159",
-    "ListElement": "Caernafon",
+    "ListElement": "Caernarfon",
     "DisplayOrder": 130
   },
   {


### PR DESCRIPTION
Fix spelling of Caernarfon in court name dropdown list

https://tools.hmcts.net/jira/browse/DFPL-729

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
