### PR TITLE
DFPL-775: Stop 'Upload additional applications' from duplicating existing draft orders

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/UploadAdditionalApplicationsController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/UploadAdditionalApplicationsController.java
@@ -116,17 +116,19 @@ public class UploadAdditionalApplicationsController extends CallbackController {
         CaseDetails caseDetails = callbackRequest.getCaseDetails();
         CaseData caseData = getCaseData(caseDetails);
 
-        if (!isNull(caseData.getTemporaryC2Document())) {
-            List<Element<HearingOrder>> unsealedCMOs = caseData.getDraftUploadedCMOs();
+        if (!isNull(caseData.getTemporaryC2Document())
+            && !caseData.getTemporaryC2Document().getDraftOrdersBundle().isEmpty()) {
+
             List<Element<DraftOrder>> draftOrders = caseData.getTemporaryC2Document().getDraftOrdersBundle();
-            unsealedCMOs.addAll(draftOrders.stream()
+            List<Element<HearingOrder>> newDrafts = draftOrders.stream()
                 .map(Element::getValue)
                 .map(HearingOrder::from)
                 .map(ElementUtils::element)
-                .collect(Collectors.toList()));
+                .collect(Collectors.toList());
+
             List<Element<HearingOrdersBundle>> bundles = draftOrderService.migrateCmoDraftToOrdersBundles(caseData);
 
-            draftOrderService.additionalApplicationUpdateCase(unsealedCMOs, bundles);
+            draftOrderService.additionalApplicationUpdateCase(newDrafts, bundles);
 
             caseDetails.getData().put("hearingOrdersBundlesDrafts", bundles);
         }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-775


### Change description ###
- Removes the duplication bug for existing draft orders
- Adds branching to only attempt to update with new draft orders if any exist in the application
- Adds a controller test for the above


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
