### PR TITLE
DFPL-917 Judges receives error messages when approving Orders

### DIFF
--- a/ccd-definition/CaseField/CareSupervision/hearingOrders.json
+++ b/ccd-definition/CaseField/CareSupervision/hearingOrders.json
@@ -51,6 +51,16 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "ID": "uploadCMOMessageAcknowledge",
+    "FieldType": "MultiSelectList",
+    "FieldTypeParameter": "DocumentAcknowledge",
+    "Label": "Tick to confirm this document is related to Familyman Case number/Names/CCD",
+    "SecurityClassification": "Public",
+    "Searchable": "N"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
     "ID": "cmosSentToJudge",
     "Label": "Hearings with CMOs already being reviewed",
     "FieldType": "TextArea",

--- a/ccd-definition/FixedLists/CareSupervision/manage-documents/DocumentAcknowledge.json
+++ b/ccd-definition/FixedLists/CareSupervision/manage-documents/DocumentAcknowledge.json
@@ -1,0 +1,9 @@
+[
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "DocumentAcknowledge",
+    "ListElementCode": "ACK_RELATED_TO_CASE",
+    "ListElement": "Yes",
+    "DisplayOrder": 1
+  }
+]

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/UploadDraftOrdersAboutToSubmitControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/UploadDraftOrdersAboutToSubmitControllerTest.java
@@ -242,7 +242,8 @@ class UploadDraftOrdersAboutToSubmitControllerTest extends AbstractUploadDraftOr
             "orderToSendTranslationRequirements8",
             "orderToSend9",
             "orderToSendTranslationRequirements9",
-            "orderToSendOptionCount"
+            "orderToSendOptionCount",
+            "uploadCMOMessageAcknowledge"
         ));
 
         assertThat(response.getData().keySet()).isEqualTo(keys);

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/event/UploadDraftOrdersData.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/event/UploadDraftOrdersData.java
@@ -107,6 +107,8 @@ public class UploadDraftOrdersData {
     YesNo showCMOsSentToJudge;
     @Temp
     YesNo showReplacementCMO;
+    @Temp
+    List<String> uploadCMOMessageAcknowledge;
 
     @JsonIgnore
     public boolean isCmoAgreed() {

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/model/event/UploadDraftOrdersDataTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/model/event/UploadDraftOrdersDataTest.java
@@ -62,7 +62,8 @@ class UploadDraftOrdersDataTest {
                 "orderToSendTranslationRequirements8",
                 "orderToSend9",
                 "orderToSendTranslationRequirements9",
-                "orderToSendOptionCount"
+                "orderToSendOptionCount",
+                "uploadCMOMessageAcknowledge"
             );
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-917


### Change description ###
A quick fix for the new property `uploadCMOMessageAcknowledge` accidentally persisted due to the rollback of DFPL-766.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
