### PR TITLE
update gradle script to support local docmosis

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -492,6 +492,22 @@ bootWithCCD {
     environment 'SEND_LETTER_URL', 'http://dm-store-aat.service.core-compute-aat.internal'
     environment 'PRD_HOST', 'http://rd-professional-api-aat.service.core-compute-aat.internal'
     environment 'MANAGE_CASE_S2S_AUTHORISED_SERVICES', 'ccd_gw,xui_webapp,ccd_data,fpl_case_service'
+
+    if (project.hasProperty('docmosis')) {
+      println 'Setting up local Docmosis'
+      exec {
+        ignoreExitValue = true
+        commandLine 'docker', 'compose', '-f', '../fpla-docker/compose/docmosis.yml', 'create'
+      }
+      exec {
+        ignoreExitValue = false
+        commandLine 'docker', 'compose', '-f', '../fpla-docker/compose/docmosis.yml', 'start'
+      }
+      environment 'docmosis.tornado.url', 'http://localhost:5433'
+      environment 'docmosis.tornado.key', 'ACCESS_KEY'
+    } else {
+      println 'Using AAT Docmosis'
+    }
   }
 }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-819


### Change description ###
Update the gradle script to support using local docmosis

Run the command : 
_DOCMOSIS_KEY=<docmosis key> ./gradlew bootWithCCD -Pdocmosis_
Then the script will create the local docmosis docker container and point FPL boot to use the local docmosis


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
