### PR TITLE
DFPL-929: Do not clear old hearing docs when saving newly uploaded docs

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/document/ManageDocumentService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/document/ManageDocumentService.java
@@ -431,13 +431,24 @@ public class ManageDocumentService {
         return map;
     }
 
-    private <T> List<Element<T>> buildHearingDocumentList(CaseData caseData, UUID selectedHearingId,
-                                                          List<Element<T>> hearingDocumentList, T hearingDocument) {
+    private <T> List<Element<T>> buildCourtBundleList(CaseData caseData, UUID selectedHearingId,
+                                                      List<Element<T>> hearingDocumentList, T hearingDocument) {
         if (isNotEmpty(caseData.getHearingDetails())) {
             return List.of(element(selectedHearingId, hearingDocument));
         }
 
         return hearingDocumentList;
+    }
+
+    private <T extends HearingDocument> List<Element<T>> buildHearingDocumentList(CaseData caseData, UUID selectedHearingId,
+                                                                                  List<Element<T>> hearingDocumentList, T hearingDocument) {
+        List<Element<T>> list = hearingDocumentList.stream().filter(el -> !el.getId().equals(selectedHearingId))
+            .collect(Collectors.toList());
+        if (isNotEmpty(caseData.getHearingDetails())) {
+            list.add(element(selectedHearingId, hearingDocument));
+        }
+
+        return list;
     }
 
     private List<Element<PositionStatementRespondent>> buildRespondentPositionStatementList(CaseData caseData,
@@ -447,8 +458,8 @@ public class ManageDocumentService {
         // and replace the existing uploaded statement of the selected respondent with the new statement.
         if (isNotEmpty(caseData.getHearingDetails())) {
             List<Element<PositionStatementRespondent>> resultList = hearingDocumentList.stream()
-                .filter(doc -> doc.getValue().getHearingId().equals(selectedHearingId)
-                               && !doc.getValue().getRespondentId().equals(respondentStatement.getRespondentId()))
+                .filter(doc -> !(doc.getValue().getHearingId().equals(selectedHearingId)
+                               && doc.getValue().getRespondentId().equals(respondentStatement.getRespondentId())))
                 .collect(Collectors.toList());
             resultList.add(element(respondentStatement));
             return resultList;
@@ -464,8 +475,8 @@ public class ManageDocumentService {
         // and replace the existing uploaded statement of the selected child with the new statement.
         if (isNotEmpty(caseData.getHearingDetails())) {
             List<Element<PositionStatementChild>> resultList = hearingDocumentList.stream()
-                .filter(doc -> doc.getValue().getHearingId().equals(selectedHearingId)
-                               && !doc.getValue().getChildId().equals(respondentStatement.getChildId()))
+                .filter(doc -> !(doc.getValue().getHearingId().equals(selectedHearingId)
+                               && doc.getValue().getChildId().equals(respondentStatement.getChildId())))
                 .collect(Collectors.toList());
 
             resultList.add(element(respondentStatement));
@@ -481,7 +492,7 @@ public class ManageDocumentService {
             .filter(doc -> !doc.getValue().isConfidentialDocument())
             .collect(Collectors.toList());
 
-        return buildHearingDocumentList(caseData, selectedHearingId,
+        return buildCourtBundleList(caseData, selectedHearingId,
             caseData.getHearingDocuments().getCourtBundleListV2(),
             HearingCourtBundle.builder()
                 .hearing(hearingBooking.toLabel())

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/document/ManageDocumentService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/document/ManageDocumentService.java
@@ -390,7 +390,7 @@ public class ManageDocumentService {
                         caseData.getHearingDocuments().getCourtBundleListV2(), courtBundles));
                 break;
             case CASE_SUMMARY :
-                List<Element<CaseSummary>> caseSummaries = buildHearingDocumentList(caseData, selectedHearingId,
+                List<Element<CaseSummary>> caseSummaries = buildHearingDocumentsList(caseData, selectedHearingId,
                     caseData.getHearingDocuments().getCaseSummaryList(), caseData.getManageDocumentsCaseSummary());
                 map.put(CASE_SUMMARY_LIST_KEY, caseSummaries);
                 map.put(DOCUMENT_WITH_CONFIDENTIAL_ADDRESS_KEY,
@@ -431,7 +431,7 @@ public class ManageDocumentService {
         return map;
     }
 
-    private <T> List<Element<T>> buildCourtBundleList(CaseData caseData, UUID selectedHearingId,
+    private <T> List<Element<T>> buildCourtBundlesList(CaseData caseData, UUID selectedHearingId,
                                                       List<Element<T>> hearingDocumentList, T hearingDocument) {
         if (isNotEmpty(caseData.getHearingDetails())) {
             return List.of(element(selectedHearingId, hearingDocument));
@@ -440,8 +440,8 @@ public class ManageDocumentService {
         return hearingDocumentList;
     }
 
-    private <T extends HearingDocument> List<Element<T>> buildHearingDocumentList(CaseData caseData, UUID selectedHearingId,
-                                                                                  List<Element<T>> hearingDocumentList, T hearingDocument) {
+    private <T extends HearingDocument> List<Element<T>> buildHearingDocumentsList(CaseData caseData,
+           UUID selectedHearingId, List<Element<T>> hearingDocumentList, T hearingDocument) {
         List<Element<T>> list = hearingDocumentList.stream().filter(el -> !el.getId().equals(selectedHearingId))
             .collect(Collectors.toList());
         if (isNotEmpty(caseData.getHearingDetails())) {
@@ -492,7 +492,7 @@ public class ManageDocumentService {
             .filter(doc -> !doc.getValue().isConfidentialDocument())
             .collect(Collectors.toList());
 
-        return buildCourtBundleList(caseData, selectedHearingId,
+        return buildCourtBundlesList(caseData, selectedHearingId,
             caseData.getHearingDocuments().getCourtBundleListV2(),
             HearingCourtBundle.builder()
                 .hearing(hearingBooking.toLabel())

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ManageDocumentServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ManageDocumentServiceTest.java
@@ -2292,6 +2292,38 @@ class ManageDocumentServiceTest {
     }
 
     @Test
+    void shouldReplaceCaseSummaryIfSameHearing() {
+        UUID hearingOne = randomUUID();
+        UUID hearingTwo = randomUUID();
+        String hearingOneLabel = "Hearing one";
+        String hearingTwoLabel = "Hearing two";
+
+        LocalDateTime today = LocalDateTime.now();
+        HearingBooking hearingBookingOne = createHearingBooking(today, today.plusDays(3));
+        HearingBooking hearingBookingTwo = createHearingBooking(today, today.plusDays(5));
+        List<Element<HearingBooking>> hearingBookings = List.of(element(hearingOne, hearingBookingOne),
+            element(hearingTwo, hearingBookingTwo));
+
+        CaseSummary existingHearingOne = CaseSummary.builder().hearing(hearingOneLabel).build();
+        CaseSummary existingHearingTwo = CaseSummary.builder().hearing(hearingTwoLabel).build();
+        CaseSummary newHearingTwo = CaseSummary.builder().hearing(hearingTwoLabel).build();
+
+        CaseData caseData = CaseData.builder()
+            .manageDocumentsHearingDocumentType(HearingDocumentType.CASE_SUMMARY)
+            .hearingDetails(hearingBookings)
+            .manageDocumentsCaseSummary(newHearingTwo)
+            .hearingDocumentsHearingList(hearingTwo.toString())
+            .hearingDocuments(HearingDocuments.builder()
+                .caseSummaryList(List.of(element(hearingOne, existingHearingOne),
+                    element(hearingTwo, existingHearingTwo)))
+                .build())
+            .build();
+
+        assertThat(unwrapElements((List<Element<CaseSummary>>) underTest.buildHearingDocumentList(caseData)
+            .get(CASE_SUMMARY_LIST_KEY))).containsExactlyInAnyOrder(existingHearingOne, newHearingTwo);
+    }
+
+    @Test
     void shouldUpdatePlacementNoticesForLA() {
         final DocumentReference laResponseRef = testDocumentReference();
 

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ManageDocumentServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ManageDocumentServiceTest.java
@@ -2112,7 +2112,7 @@ class ManageDocumentServiceTest {
     }
 
     @Test
-    void shouldReturnNewPositionStatementChildListWhenExistingListPresentForOtherHearing() {
+    void shouldReturnCombinedPositionStatementChildListWhenExistingListPresentForOtherHearing() {
         UUID selectedHearingId = randomUUID();
         LocalDateTime today = LocalDateTime.now();
 
@@ -2155,7 +2155,7 @@ class ManageDocumentServiceTest {
         assertThat(
             unwrapElements((List<Element<PositionStatementChild>>)
                 underTest.buildHearingDocumentList(caseData).get(POSITION_STATEMENT_CHILD_LIST_KEY)))
-            .isEqualTo(List.of(caseData.getManageDocumentsPositionStatementChild()));
+            .containsExactlyInAnyOrder(positionStatementChild, positionStatementChildTwo);
     }
 
     @Test
@@ -2288,7 +2288,7 @@ class ManageDocumentServiceTest {
         assertThat(
             unwrapElements((List<Element<PositionStatementRespondent>>) underTest
                 .buildHearingDocumentList(caseData).get(POSITION_STATEMENT_RESPONDENT_LIST_KEY)))
-            .isEqualTo(List.of(caseData.getManageDocumentsPositionStatementRespondent()));
+            .containsExactlyInAnyOrder(positionStatementRespondent, positionStatementRespondentTwo);
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-929


### Change description ###
 - Stops clearing the old hearing documents from the 3 collections (case summary, respondent position statements, child position statements) during about-to-submit
 - Still allows the user to upload a new version (if same hearing (and same respondent/child) then it will just replace that hearing's version)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
