### PR TITLE
DFPL-931: Remove the SubmittedEvent callback from the definition

### DIFF
--- a/ccd-definition/CaseEvent/CareSupervision/MultiState.json
+++ b/ccd-definition/CaseEvent/CareSupervision/MultiState.json
@@ -970,7 +970,6 @@
     "SecurityClassification": "Public",
     "CallBackURLAboutToStartEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/add-colleagues-to-notify/about-to-start",
     "CallBackURLAboutToSubmitEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/add-colleagues-to-notify/about-to-submit",
-    "CallBackURLSubmittedEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/add-colleagues-to-notify/submitted",
     "ShowSummary": "Y",
     "ShowEventNotes": "N",
     "EndButtonLabel": "Save and continue"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-931

### Change description ###
 - Should clear up a bunch of 404 errors in Azure AppInsights - there was a leftover SubmittedEvent callback in the definition files but the callback doesn't exist + isn't needed.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
