### PR TITLE
DFPL-934: Child and Respondent Statements being overwritten

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/document/ManageDocumentService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/document/ManageDocumentService.java
@@ -441,7 +441,8 @@ public class ManageDocumentService {
     }
 
     private List<Element<PositionStatementRespondent>> buildRespondentPositionStatementList(CaseData caseData,
-                List<Element<PositionStatementRespondent>> hearingDocumentList, PositionStatementRespondent respondentStatement) {
+                List<Element<PositionStatementRespondent>> hearingDocumentList,
+                PositionStatementRespondent respondentStatement) {
 
         if (isNotEmpty(caseData.getHearingDetails())) {
             hearingDocumentList.add(element(respondentStatement));
@@ -451,7 +452,8 @@ public class ManageDocumentService {
     }
 
     private List<Element<PositionStatementChild>> buildChildPositionStatementList(CaseData caseData,
-                List<Element<PositionStatementChild>> hearingDocumentList, PositionStatementChild respondentStatement) {
+                List<Element<PositionStatementChild>> hearingDocumentList,
+                PositionStatementChild respondentStatement) {
 
         if (isNotEmpty(caseData.getHearingDetails())) {
             hearingDocumentList.add(element(respondentStatement));

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/document/ManageDocumentService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/document/ManageDocumentService.java
@@ -399,7 +399,7 @@ public class ManageDocumentService {
                 break;
             case POSITION_STATEMENT_CHILD :
                 List<Element<PositionStatementChild>> positionStatementChildList =
-                    buildChildPositionStatementList(caseData, selectedHearingId,
+                    buildChildPositionStatementList(caseData,
                         caseData.getHearingDocuments().getPositionStatementChildListV2(),
                         caseData.getManageDocumentsPositionStatementChild().toBuilder()
                             .childId(caseData.getManageDocumentsChildrenList().getValueCodeAsUUID())
@@ -414,7 +414,7 @@ public class ManageDocumentService {
                 break;
             case POSITION_STATEMENT_RESPONDENT :
                 List<Element<PositionStatementRespondent>> positionStatementRespondentList =
-                    buildRespondentPositionStatementList(caseData, selectedHearingId,
+                    buildRespondentPositionStatementList(caseData,
                         caseData.getHearingDocuments().getPositionStatementRespondentListV2(),
                         caseData.getManageDocumentsPositionStatementRespondent().toBuilder()
                             .respondentId(caseData.getHearingDocumentsRespondentList().getValueCodeAsUUID())
@@ -441,35 +441,20 @@ public class ManageDocumentService {
     }
 
     private List<Element<PositionStatementRespondent>> buildRespondentPositionStatementList(CaseData caseData,
-                UUID selectedHearingId, List<Element<PositionStatementRespondent>> hearingDocumentList,
-                PositionStatementRespondent respondentStatement) {
-        // remove those position statements which is not belonging to the selected hearing id
-        // and replace the existing uploaded statement of the selected respondent with the new statement.
+                List<Element<PositionStatementRespondent>> hearingDocumentList, PositionStatementRespondent respondentStatement) {
+
         if (isNotEmpty(caseData.getHearingDetails())) {
-            List<Element<PositionStatementRespondent>> resultList = hearingDocumentList.stream()
-                .filter(doc -> doc.getValue().getHearingId().equals(selectedHearingId)
-                               && !doc.getValue().getRespondentId().equals(respondentStatement.getRespondentId()))
-                .collect(Collectors.toList());
-            resultList.add(element(respondentStatement));
-            return resultList;
+            hearingDocumentList.add(element(respondentStatement));
         }
 
         return hearingDocumentList;
     }
 
     private List<Element<PositionStatementChild>> buildChildPositionStatementList(CaseData caseData,
-                UUID selectedHearingId, List<Element<PositionStatementChild>> hearingDocumentList,
-                PositionStatementChild respondentStatement) {
-        // remove those position statements which is not belonging to the selected hearing id
-        // and replace the existing uploaded statement of the selected child with the new statement.
-        if (isNotEmpty(caseData.getHearingDetails())) {
-            List<Element<PositionStatementChild>> resultList = hearingDocumentList.stream()
-                .filter(doc -> doc.getValue().getHearingId().equals(selectedHearingId)
-                               && !doc.getValue().getChildId().equals(respondentStatement.getChildId()))
-                .collect(Collectors.toList());
+                List<Element<PositionStatementChild>> hearingDocumentList, PositionStatementChild respondentStatement) {
 
-            resultList.add(element(respondentStatement));
-            return resultList;
+        if (isNotEmpty(caseData.getHearingDetails())) {
+            hearingDocumentList.add(element(respondentStatement));
         }
 
         return hearingDocumentList;


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DFPL-934

Remove functionality to delete any other respondent statements if they're not for a single hearing

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
