### PR TITLE
Stop NPEs from breaking validators in case submission

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/Orders.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/Orders.java
@@ -71,11 +71,11 @@ public class Orders {
     }
 
     public boolean isSecureAccommodationOrder() {
-        return this.getOrderType().contains(SECURE_ACCOMMODATION_ORDER);
+        return isNotEmpty(orderType) && this.getOrderType().contains(SECURE_ACCOMMODATION_ORDER);
     }
 
     public boolean isRefuseContactWithChildApplication() {
-        return this.getOrderType().contains(REFUSE_CONTACT_WITH_CHILD);
+        return isNotEmpty(orderType) && this.getOrderType().contains(REFUSE_CONTACT_WITH_CHILD);
     }
 
     public boolean isChildRecoveryOrder() {


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
 - Adds isNotEmpty checks to the missing two types to stop the validators breaking, stopping apps from being submitted


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
