### PR TITLE
DFPL-1009: Catch cases where the notice has been removed after incident

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/jobs/ResendCafcassEmails.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/jobs/ResendCafcassEmails.java
@@ -254,22 +254,27 @@ public class ResendCafcassEmails implements Job {
         int resentEmails = 0;
         for (Element<HearingBooking> booking : hearings) {
 
-            NoticeOfHearingCafcassData noticeOfHearingCafcassData =
-                noticeOfHearingEmailContentProvider.buildNewNoticeOfHearingNotificationCafcassData(
-                    caseData,
-                    booking.getValue()
-                );
+            if (!isEmpty(booking.getValue().getNoticeOfHearing())) {
+                NoticeOfHearingCafcassData noticeOfHearingCafcassData =
+                    noticeOfHearingEmailContentProvider.buildNewNoticeOfHearingNotificationCafcassData(
+                        caseData,
+                        booking.getValue()
+                    );
 
-            if (featureToggleService.isResendCafcassEmailsEnabled()) {
-                cafcassNotificationService.sendEmail(caseData,
-                    of(booking.getValue().getNoticeOfHearing()),
-                    NOTICE_OF_HEARING,
-                    noticeOfHearingCafcassData);
+                if (featureToggleService.isResendCafcassEmailsEnabled()) {
+                    cafcassNotificationService.sendEmail(caseData,
+                        of(booking.getValue().getNoticeOfHearing()),
+                        NOTICE_OF_HEARING,
+                        noticeOfHearingCafcassData);
+                } else {
+                    log.info("Would have resent notice of hearing email about {}, {}", caseData.getId(),
+                        booking.getValue().getStartDate().format(DATE_FORMATTER));
+                }
+                resentEmails++;
             } else {
-                log.info("Would have resent notice of hearing email about {}, {}", caseData.getId(),
-                    booking.getValue().getStartDate().format(DATE_FORMATTER));
+                log.info("Skipping notice of hearing email for {}, {} as notice document no longer present",
+                    caseData.getId(), booking.getValue().getStartDate().format(DATE_FORMATTER));
             }
-            resentEmails++;
         }
         return resentEmails;
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-1009


### Change description ###
 - Adds logging to catch the cases where a notice of hearing was present but later was removed (Stops NPEs)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
