### PR TITLE
DFPL-1118: Remove validator stopping the main representative from changing

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/children/validation/representative/LocalAuthorityUserMainRepresentativeValidator.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/children/validation/representative/LocalAuthorityUserMainRepresentativeValidator.java
@@ -63,10 +63,9 @@ public final class LocalAuthorityUserMainRepresentativeValidator extends LocalAu
         }
 
         // already set so just need to check if the representatives are equal
-        RespondentSolicitor oldRepresentative = sanitizer.sanitize(oldData.getChildrenMainRepresentative());
-        RespondentSolicitor currentRepresentative = sanitizer.sanitize(currentData.getChildrenMainRepresentative());
-        return !Objects.equals(oldRepresentative, currentRepresentative)
-               ? List.of(MAIN_REP_MODIFICATION_ERROR)
-               : List.of();
+        // No other checks necessary?
+        // Allowing the main rep to be removed/swapped out - the NoC service will handle if there are any roles that
+        // need to be cleaned up/orgs to be swapped.
+        return List.of();
     }
 }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/children/validation/representative/LocalAuthorityUserMainRepresentativeValidatorTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/children/validation/representative/LocalAuthorityUserMainRepresentativeValidatorTest.java
@@ -158,7 +158,7 @@ class LocalAuthorityUserMainRepresentativeValidatorTest {
     }
 
     @DisplayName("Validate with errors when the main solicitor was changed")
-    @Test
+    // @Test // Commenting out this test as it may not be needed anymore - now allowing child sols to be changed
     void validateSolicitorChanged() {
         when(caseData.getChildrenEventData()).thenReturn(currentEventData);
         when(caseDataBefore.getChildrenEventData()).thenReturn(previousEventData);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-1118


### Change description ###
 - Allow the main child representative to be updated, to help stop using a workaround where they are fully removed, causing organisation roles to go haywire


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
