### PR TITLE
DFPL-1081 update migration script for removing last hearing booking

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseService.java
@@ -13,6 +13,7 @@ import uk.gov.hmcts.reform.fpl.model.order.HearingOrder;
 import uk.gov.hmcts.reform.fpl.model.order.HearingOrdersBundle;
 import uk.gov.hmcts.reform.fpl.utils.ElementUtils;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -176,10 +177,18 @@ public class MigrateCaseService {
 
             // remove the hearing from the hearing list
             hearingDetails.removeAll(hearingBookingsToBeRemoved);
-            return Map.of(
-                "hearingDetails", hearingDetails,
-                "selectedHearingId", hearingDetails.get(hearingDetails.size() - 1).getId()
-            );
+            if (hearingDetails.size() > 0) {
+                return Map.of(
+                    "hearingDetails", hearingDetails,
+                    "selectedHearingId", hearingDetails.get(hearingDetails.size() - 1).getId()
+                );
+            } else {
+                Map<String, Object> ret =  new HashMap<String, Object>(Map.of(
+                    "hearingDetails", hearingDetails
+                ));
+                ret.put("selectedHearingId", null);
+                return ret;
+            }
         } else {
             throw new AssertionError(format(
                 "Migration {id = %s, case reference = %s}, hearing details not found",

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseServiceTest.java
@@ -422,5 +422,24 @@ class MigrateCaseServiceTest {
                 .doesNotContainAnyElementsOf(List.of(hearingBookingToRemove));
 
         }
+
+        @Test
+        void shouldRemoveHearingBookingWithSingleHearing() {
+            List<Element<HearingBooking>> bookings = new ArrayList<>();
+            bookings.add(element(hearingBookingToRemove, HearingBooking.builder().build()));
+
+            CaseData caseData = CaseData.builder()
+                .hearingDetails(bookings)
+                .build();
+
+            Map<String, Object> updatedFields = underTest.removeHearingBooking(caseData, MIGRATION_ID,
+                hearingBookingToRemove);
+
+            assertThat(updatedFields).extracting("hearingDetails").asList().hasSize(0);
+            assertThat(updatedFields).extracting("hearingDetails").asList()
+                .doesNotContainAnyElementsOf(List.of(hearingBookingToRemove));
+            assertThat(updatedFields).extracting("selectedHearingId").isNull();
+
+        }
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-1081


### Change description ###
update migration script to support removing last hearing bookings and unset the selectedHearingId.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
