### PR TITLE
DFPL-WA: Add utility function to create the work allocation dummy event

### DIFF
--- a/ccd-definition/AuthorisationCaseEvent/CareSupervision/AuthorisationCaseEvent.json
+++ b/ccd-definition/AuthorisationCaseEvent/CareSupervision/AuthorisationCaseEvent.json
@@ -639,6 +639,13 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseEventID": "create-work-allocation-task",
+    "UserRole": "caseworker-publiclaw-systemupdate",
+    "CRUD": "CR"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
     "CaseEventID": "internal-change-upload-add-apps",
     "UserRole": "caseworker-publiclaw-systemupdate",
     "CRUD": "CR"

--- a/ccd-definition/AuthorisationCaseField/CareSupervision/system-update.json
+++ b/ccd-definition/AuthorisationCaseField/CareSupervision/system-update.json
@@ -1188,5 +1188,12 @@
     "CaseFieldID": "others_label",
     "UserRole": "caseworker-publiclaw-systemupdate",
     "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseFieldID": "lastCreatedWATask",
+    "UserRole": "caseworker-publiclaw-systemupdate",
+    "CRUD": "CRU"
   }
 ]

--- a/ccd-definition/CaseEvent/CareSupervision/MultiState.json
+++ b/ccd-definition/CaseEvent/CareSupervision/MultiState.json
@@ -1043,5 +1043,19 @@
     "ShowSummary": "N",
     "ShowEventNotes": "N",
     "EndButtonLabel": "Done"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "ID": "create-work-allocation-task",
+    "Name": "Create work allocation task",
+    "Description": "Creates a task for work allocation",
+    "DisplayOrder": 1000,
+    "PreConditionState(s)": "*",
+    "PostConditionState": "*",
+    "SecurityClassification": "Public",
+    "ShowSummary": "N",
+    "ShowEventNotes": "N",
+    "EndButtonLabel": "Done"
   }
 ]

--- a/ccd-definition/CaseField/CareSupervision/workAllocation.json
+++ b/ccd-definition/CaseField/CareSupervision/workAllocation.json
@@ -1,0 +1,12 @@
+[
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "ID": "lastCreatedWATask",
+    "FieldType": "FixedList",
+    "FieldTypeParameter": "WorkAllocationTaskType",
+    "Label": "Last created work allocation task",
+    "SecurityClassification": "Public",
+    "Searchable": "N"
+  }
+]

--- a/ccd-definition/FixedLists/CareSupervision/WorkAllocationTaskType.json
+++ b/ccd-definition/FixedLists/CareSupervision/WorkAllocationTaskType.json
@@ -1,0 +1,23 @@
+[
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "WorkAllocationTaskType",
+    "ListElementCode": "FAILED_PAYMENT",
+    "ListElement": "Failed Payment",
+    "DisplayOrder": 0
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "WorkAllocationTaskType",
+    "ListElementCode": "ORDER_NOT_UPLOADED",
+    "ListElement": "Order not uploaded",
+    "DisplayOrder": 1
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "WorkAllocationTaskType",
+    "ListElementCode": "CORRESPONDENCE_UPLOADED",
+    "ListElement": "Correspondence Uploaded",
+    "DisplayOrder": 2
+  }
+]

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/enums/WorkAllocationTaskType.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/enums/WorkAllocationTaskType.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.reform.fpl.enums;
+
+public enum WorkAllocationTaskType {
+    FAILED_PAYMENT,
+    ORDER_NOT_UPLOADED,
+    CORRESPONDENCE_UPLOADED
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/workallocation/WorkAllocationTaskService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/workallocation/WorkAllocationTaskService.java
@@ -16,13 +16,14 @@ import java.util.Map;
 public class WorkAllocationTaskService {
 
     private static final String WORK_ALLOCATION_DUMMY_EVENT = "create-work-allocation-task";
+    private static final String WORK_ALLOCATION_DUMMY_CASE_FIELD = "lastCreatedWATask";
 
     private final CoreCaseDataService coreCaseDataService;
 
     public void createWorkAllocationTask(CaseData caseData, WorkAllocationTaskType taskType) {
         log.info("Creating work allocation task - " + taskType.name());
         coreCaseDataService.triggerEvent(caseData.getId(), WORK_ALLOCATION_DUMMY_EVENT, Map.of(
-            "lastCreatedWATask", taskType
+            WORK_ALLOCATION_DUMMY_CASE_FIELD, taskType
         ));
     }
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/workallocation/WorkAllocationTaskService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/workallocation/WorkAllocationTaskService.java
@@ -1,0 +1,29 @@
+package uk.gov.hmcts.reform.fpl.service.workallocation;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.fpl.enums.WorkAllocationTaskType;
+import uk.gov.hmcts.reform.fpl.model.CaseData;
+import uk.gov.hmcts.reform.fpl.service.ccd.CoreCaseDataService;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+public class WorkAllocationTaskService {
+
+    private static final String WORK_ALLOCATION_DUMMY_EVENT = "create-work-allocation-task";
+
+    private final CoreCaseDataService coreCaseDataService;
+
+    public void createWorkAllocationTask(CaseData caseData, WorkAllocationTaskType taskType) {
+        log.info("Creating work allocation task - " + taskType.name());
+        coreCaseDataService.triggerEvent(caseData.getId(), WORK_ALLOCATION_DUMMY_EVENT, Map.of(
+            "lastCreatedWATask", taskType
+        ));
+    }
+
+}

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/workallocation/WorkAllocationTaskServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/workallocation/WorkAllocationTaskServiceTest.java
@@ -1,0 +1,41 @@
+package uk.gov.hmcts.reform.fpl.service.workallocation;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.fpl.model.CaseData;
+import uk.gov.hmcts.reform.fpl.service.ccd.CoreCaseDataService;
+
+import java.util.Map;
+
+import static org.mockito.Mockito.verify;
+import static uk.gov.hmcts.reform.fpl.enums.WorkAllocationTaskType.FAILED_PAYMENT;
+
+@ExtendWith(MockitoExtension.class)
+public class WorkAllocationTaskServiceTest {
+
+    @Mock
+    private CoreCaseDataService ccdService;
+
+    @InjectMocks
+    private WorkAllocationTaskService underTest;
+
+    private static final long CASE_ID = 1L;
+    private static final String WORK_ALLOCATION_DUMMY_EVENT = "create-work-allocation-task";
+    private static final String WORK_ALLOCATION_DUMMY_CASE_FIELD = "lastCreatedWATask";
+
+    @Test
+    void shouldTriggerWorkAllocationDummyEvent() {
+        CaseData caseData = CaseData.builder()
+            .id(CASE_ID)
+            .build();
+
+        underTest.createWorkAllocationTask(caseData, FAILED_PAYMENT);
+
+        verify(ccdService).triggerEvent(CASE_ID, WORK_ALLOCATION_DUMMY_EVENT, Map.of(
+            WORK_ALLOCATION_DUMMY_CASE_FIELD, FAILED_PAYMENT
+        ));
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
Part of https://tools.hmcts.net/jira/browse/DFPL-1095


### Change description ###
 - Adds utility code to quickly start the work allocation task and save the given enum onto the case
     - Call it from any submitted callback as it creates a CCD event that will be used for Work Allocation


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
