### PR TITLE
DFPL-1190: Duplicate collection items on draft order uploads

### DIFF
--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/cmo/DraftOrderServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/cmo/DraftOrderServiceTest.java
@@ -625,7 +625,7 @@ class DraftOrderServiceTest {
             service.updateCase(eventData, hearings, emptyList(), ordersBundles);
 
             HearingOrdersBundle expectedOrdersBundle = originalOrdersBundle.toBuilder()
-                .orders(newArrayList(cmoOrder, hearingOrder1, hearingOrder2, hearingOrder1, hearingOrder3))
+                .orders(newArrayList(cmoOrder, hearingOrder1, hearingOrder2, hearingOrder3))
                 .build();
 
             assertThat(ordersBundles).hasSize(1).first()


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DFPL-1190

Prevent C21 being duplicated on orderUpdate method

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
