### PR TITLE
Disable dep check on e2e deps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,9 @@ dependencyCheck {
     ossIndex {
       enabled = false
     }
+    nodeAudit {
+      yarnEnabled = false
+    }
   }
   analyzedTypes = ['jar']
   scanConfigurations = ['runtimeClasspath']

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -419,10 +419,12 @@ bootJar {
 }
 
 test {
+  maxHeapSize = "1024m"
   useJUnitPlatform()
 }
 
 integration {
+  maxHeapSize = "1024m"
   useJUnitPlatform()
 }
 


### PR DESCRIPTION
### Change description ###
 - Disables the dependency check tool for Javascript vulns (as only used for e2e tests) to revert it back to the behaviour we had before updating the tool


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
