### PR TITLE
DFPL-1263: Migration to remove angular braces from documentNames

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -41,7 +41,8 @@ public class MigrateCaseController extends CallbackController {
         "DFPL-1294", this::run1294,
         "DFPL-1238", this::run1238,
         "DFPL-1241", this::run1241,
-        "DFPL-1244", this::run1244
+        "DFPL-1244", this::run1244,
+        "DFPL-1263", this::run1263
     );
 
     @PostMapping("/about-to-submit")
@@ -96,7 +97,7 @@ public class MigrateCaseController extends CallbackController {
         caseDetails.getData().remove(PLACEMENT_NON_CONFIDENTIAL);
         caseDetails.getData().remove(PLACEMENT_NON_CONFIDENTIAL_NOTICES);
     }
-    
+
     private void run1262(CaseDetails caseDetails) {
         var migrationId = "DFPL-1262";
         var possibleCaseIds = List.of(1651753104228873L);
@@ -140,5 +141,12 @@ public class MigrateCaseController extends CallbackController {
         migrateCaseService.doCaseIdCheckList(caseDetails.getId(), possibleCaseIds, migrationId);
         caseDetails.getData().putAll(migrateCaseService.removePositionStatementChild(getCaseData(caseDetails),
             migrationId, expectedPositionStatementId));
+    }
+
+    private void run1263(CaseDetails caseDetails) {
+        var migrationId = "DFPL-1263";
+        var possibleCaseIds = List.of(1661171715678642L);
+        migrateCaseService.doCaseIdCheckList(caseDetails.getId(), possibleCaseIds, migrationId);
+        caseDetails.getData().putAll(migrateCaseService.renameApplicationDocuments(getCaseData(caseDetails)));
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseService.java
@@ -31,6 +31,7 @@ import static java.lang.String.format;
 import static java.util.Objects.nonNull;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
+import static org.springframework.util.ObjectUtils.isEmpty;
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.element;
 
 @Service
@@ -403,5 +404,24 @@ public class MigrateCaseService {
         ret.put(PLACEMENT_NON_CONFIDENTIAL_NOTICES, nonConfidentialNoticesPlacementsToKeep.isEmpty() ? null :
             nonConfidentialNoticesPlacementsToKeep);
         return ret;
+    }
+
+    public Map<String, Object> renameApplicationDocuments(CaseData caseData) {
+        List<Element<ApplicationDocument>> updatedList = caseData.getApplicationDocuments().stream()
+            .map(el -> {
+                String currentName = el.getValue().getDocumentName();
+                el.getValue().setDocumentName(stripIllegalCharacters(currentName));
+                return el;
+            }).collect(toList());
+
+        return Map.of("applicationDocuments", updatedList);
+    }
+
+    private String stripIllegalCharacters(String str) {
+        if (isEmpty(str)) {
+            return str;
+        }
+        return str.replace("<", "")
+            .replace(">", "");
     }
 }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseServiceTest.java
@@ -984,4 +984,71 @@ class MigrateCaseServiceTest {
         }
 
     }
+
+    @Nested
+    class RenameApplicationDocuments {
+
+        @Test
+        void shouldRemoveAngularBracketsFromDocumentNames() {
+            UUID docId = UUID.randomUUID();
+            Element<ApplicationDocument> appDoc = element(docId, ApplicationDocument.builder()
+                .documentName("PA>S")
+                .build());
+
+            Element<ApplicationDocument> expectedDoc = element(docId, ApplicationDocument.builder()
+                .documentName("PAS")
+                .build());
+
+            CaseData caseData = CaseData.builder()
+                .applicationDocuments(List.of(appDoc))
+                .build();
+
+            Map<String, Object> updates = underTest.renameApplicationDocuments(caseData);
+
+            assertThat(updates).extracting("applicationDocuments").asList().containsExactly(expectedDoc);
+        }
+
+        @Test
+        void shouldDoNothingIfNoAngularBrackets() {
+            Element<ApplicationDocument> appDoc = element(ApplicationDocument.builder()
+                .documentName("PAS")
+                .build());
+
+            CaseData caseData = CaseData.builder()
+                .applicationDocuments(List.of(appDoc))
+                .build();
+
+            Map<String, Object> updates = underTest.renameApplicationDocuments(caseData);
+
+            assertThat(updates).extracting("applicationDocuments").asList().containsExactly(appDoc);
+        }
+
+        @Test
+        void shouldRenameMultipleDocsIfAngularBrackets() {
+            UUID docId1 = UUID.randomUUID();
+            UUID docId2 = UUID.randomUUID();
+            Element<ApplicationDocument> appDoc1 = element(docId1, ApplicationDocument.builder()
+                .documentName("PA>S")
+                .build());
+            Element<ApplicationDocument> appDoc2 = element(docId2, ApplicationDocument.builder()
+                .documentName("PA<S")
+                .build());
+
+            Element<ApplicationDocument> expectedDoc1 = element(docId1, ApplicationDocument.builder()
+                .documentName("PAS")
+                .build());
+
+            Element<ApplicationDocument> expectedDoc2 = element(docId2, ApplicationDocument.builder()
+                .documentName("PAS")
+                .build());
+
+            CaseData caseData = CaseData.builder()
+                .applicationDocuments(List.of(appDoc1, appDoc2))
+                .build();
+
+            Map<String, Object> updates = underTest.renameApplicationDocuments(caseData);
+
+            assertThat(updates).extracting("applicationDocuments").asList().containsExactly(expectedDoc1, expectedDoc2);
+        }
+    }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-1263


### Change description ###
 - If an applicationDocument has either < or > in its documentName field, it'll be removed by this migration.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
