### PR TITLE
DFPL-1291: Add migration to add a court to an old case

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -43,10 +43,11 @@ public class MigrateCaseController extends CallbackController {
         "DFPL-1241", this::run1241,
         "DFPL-1244", this::run1244,
         "DFPL-1243", this::run1243,
-        "DFPL-1282", this::run1282,      
+        "DFPL-1282", this::run1282,
         "DFPL-1270", this::run1270,
         "DFPL-1297", this::run1297,
-        "DFPL-1263", this::run1263
+        "DFPL-1263", this::run1263,
+        "DFPL-1291", this::run1291
     );
 
     @PostMapping("/about-to-submit")
@@ -150,4 +151,12 @@ public class MigrateCaseController extends CallbackController {
         migrateCaseService.doCaseIdCheckList(caseDetails.getId(), possibleCaseIds, migrationId);
         caseDetails.getData().putAll(migrateCaseService.renameApplicationDocuments(getCaseData(caseDetails)));
     }
+
+    private void run1291(CaseDetails caseDetails) {
+        var migrationId = "DFPL-1291";
+        var possibleCaseIds = List.of(1620403322799028L);
+        migrateCaseService.doCaseIdCheckList(caseDetails.getId(), possibleCaseIds, migrationId);
+        caseDetails.getData().putAll(migrateCaseService.addCourt("165")); // Carlisle
+    }
+
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseService.java
@@ -8,6 +8,7 @@ import uk.gov.hmcts.reform.fpl.model.ApplicationDocument;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.CaseSummary;
 import uk.gov.hmcts.reform.fpl.model.Child;
+import uk.gov.hmcts.reform.fpl.model.Court;
 import uk.gov.hmcts.reform.fpl.model.HearingBooking;
 import uk.gov.hmcts.reform.fpl.model.IncorrectCourtCodeConfig;
 import uk.gov.hmcts.reform.fpl.model.Placement;
@@ -42,6 +43,7 @@ public class MigrateCaseService {
     private static final String PLACEMENT_NON_CONFIDENTIAL = "placementsNonConfidential";
     private static final String PLACEMENT_NON_CONFIDENTIAL_NOTICES = "placementsNonConfidentialNotices";
     private final CaseNoteService caseNoteService;
+    private final CourtService courtService;
 
     public Map<String, Object> removeHearingOrderBundleDraft(CaseData caseData, String migrationId, UUID bundleId,
                                                              UUID orderId) {
@@ -415,6 +417,16 @@ public class MigrateCaseService {
             }).collect(toList());
 
         return Map.of("applicationDocuments", updatedList);
+    }
+
+    public Map<String, Object> addCourt(String courtId) {
+        Optional<Court> court = courtService.getCourt(courtId);
+
+        if (court.isPresent()) {
+            return Map.of("court", court.get());
+        } else {
+            throw new IllegalArgumentException(format("Court not found with ID %s", courtId));
+        }
     }
 
     private String stripIllegalCharacters(String str) {

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseServiceTest.java
@@ -38,6 +38,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import static java.lang.String.format;
@@ -45,6 +46,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.element;
 
 @ExtendWith({MockitoExtension.class})
@@ -55,6 +57,9 @@ class MigrateCaseServiceTest {
 
     @Mock
     private CaseNoteService caseNoteService;
+
+    @Mock
+    private CourtService courtService;
 
     @InjectMocks
     private MigrateCaseService underTest;
@@ -1051,4 +1056,20 @@ class MigrateCaseServiceTest {
             assertThat(updates).extracting("applicationDocuments").asList().containsExactly(expectedDoc1, expectedDoc2);
         }
     }
+
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @Nested
+    class AddCourt {
+
+        @Test
+        void shouldGetCourtFieldToUpdate() {
+            Court court = Court.builder().code("165").name("Carlisle").build();
+            when(courtService.getCourt("165")).thenReturn(Optional.of(court));
+
+            Map<String, Object> updatedFields = underTest.addCourt("165");
+
+            assertThat(updatedFields).extracting("court").isEqualTo(court);
+        }
+    }
+
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-1291


### Change description ###
 - Add a court to an old case before the court field was mandatory


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
