### PR TITLE
Revert "Updating ccd helm chart to v8.0.27 (#4291)"

### DIFF
--- a/charts/fpl-case-service/Chart.yaml
+++ b/charts/fpl-case-service/Chart.yaml
@@ -1,7 +1,7 @@
 name: fpl-case-service
 apiVersion: v2
 home: https://github.com/hmcts/fpl-ccd-configuration
-version: 1.12.52
+version: 1.12.53
 description: FPL Case Service
 maintainers:
   - name: HMCTS Family Public Law team
@@ -11,7 +11,7 @@ dependencies:
     version: 4.0.13
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
   - name: ccd
-    version: 8.0.27
+    version: 8.0.23
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     tags:
       - fpl-ccd-stack

--- a/charts/fpl-case-service/values.preview.template.yaml
+++ b/charts/fpl-case-service/values.preview.template.yaml
@@ -241,9 +241,10 @@ ccd:
       enabled: false
 
   logstash:
-    image: hmctspublic.azurecr.io/imported/logstash/logstash
-    imageTag: 8.5.1
-    imagePullPolicy: "IfNotPresent"
+    image:
+      repository: hmctspublic.azurecr.io/ccd/logstash
+      tag: latest
+      pullPolicy: Always
     logstashJavaOpts: -Xmx1g -Xms512M
     persistence:
       enabled: false


### PR DESCRIPTION
This reverts commit 25e4d96c



### Change description ###
 - Rollback of CCD chart change, logstash has broken and can't see case lists in preview **ONLY**


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
