### PR TITLE
DFPL-911-V4: Remove 35a due to permissions

### DIFF
--- a/service/src/functionalTest/java/uk/gov/hmcts/reform/fpl/AdminManagesOrdersApiTests.java
+++ b/service/src/functionalTest/java/uk/gov/hmcts/reform/fpl/AdminManagesOrdersApiTests.java
@@ -68,7 +68,6 @@ public class AdminManagesOrdersApiTests extends AbstractApiTest {
         parametrizedTests("c33", "C33_INTERIM_CARE_ORDER");
     }
 
-    @Test
     public void adminManagesOrderTest35a() {
         parametrizedTests("c35a", "C35A_SUPERVISION_ORDER");
     }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DFPL-911

Remove 35a due to permissions issues with preview vs master

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
