### PR TITLE
Proof of concept of a migration tool within the fpl-case-service

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/config/MigrationConfig.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/config/MigrationConfig.java
@@ -1,0 +1,47 @@
+package uk.gov.hmcts.reform.fpl.config;
+
+import lombok.Data;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import uk.gov.hmcts.reform.fpl.jobs.MigrationJobMode;
+import uk.gov.hmcts.reform.fpl.utils.elasticsearch.BooleanQuery;
+import uk.gov.hmcts.reform.fpl.utils.elasticsearch.ESQuery;
+import uk.gov.hmcts.reform.fpl.utils.elasticsearch.ExistsQuery;
+import uk.gov.hmcts.reform.fpl.utils.elasticsearch.Filter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+@Data
+@Configuration
+public class MigrationConfig {
+
+    public final String migrationId;
+    public final MigrationJobMode migrationJobMode;
+    public final Map<String, Supplier<ESQuery>> migrationQueries;
+    public final Map<String, List<Long>> caseIdMapping;
+
+    public MigrationConfig(@Value("${fpl.migration.migrationId}") String migrationId,
+                           @Value("${fpl.migration.migrationType}") String jobMode) {
+        this.migrationId = migrationId;
+        this.migrationJobMode = MigrationJobMode.valueOf(jobMode);
+        this.migrationQueries = Map.of("DFPL-test", this::query1);
+        // TODO - find a better way of loading this in, perhaps can borrow key vault like onboarding
+        this.caseIdMapping = Map.of("DFPL-test", List.of(1678969312257533L));
+    }
+
+    public List<Long> getCaseIds() {
+        return this.caseIdMapping.getOrDefault(this.migrationId, List.of());
+    }
+
+    public ESQuery query1() {
+        return BooleanQuery.builder()
+            .filter(Filter.builder()
+                .clauses(List.of(ExistsQuery.of("data.court")))
+                .build())
+            .build();
+    }
+
+
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -32,7 +32,7 @@ import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 @Slf4j
 public class MigrateCaseController extends CallbackController {
-    private static final String MIGRATION_ID_KEY = "migrationId";
+    public static final String MIGRATION_ID_KEY = "migrationId";
 
     private final MigrateCaseService migrateCaseService;
     private final ManageOrderDocumentScopedFieldsCalculator fieldsCalculator;
@@ -47,7 +47,7 @@ public class MigrateCaseController extends CallbackController {
         "DFPL-1291", this::run1291,
         "DFPL-1310", this::run1310,
         "DFPL-1371", this::run1371,
-        "DFPL-1380", this::run1380
+        "DFPL-test", this::runTest
     );
 
     @PostMapping("/about-to-submit")
@@ -150,5 +150,9 @@ public class MigrateCaseController extends CallbackController {
         var possibleCaseIds = List.of(1662460879255241L);
         migrateCaseService.doCaseIdCheckList(caseDetails.getId(), possibleCaseIds, migrationId);
         caseDetails.getData().put("state", State.FINAL_HEARING);
+    }
+
+    private void runTest(CaseDetails caseDetails) {
+        log.info("Running test on " + caseDetails.getId().toString());
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/jobs/CaseMigrationJob.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/jobs/CaseMigrationJob.java
@@ -1,0 +1,126 @@
+package uk.gov.hmcts.reform.fpl.jobs;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.fpl.config.MigrationConfig;
+import uk.gov.hmcts.reform.fpl.service.ccd.CoreCaseDataService;
+import uk.gov.hmcts.reform.fpl.service.search.SearchService;
+import uk.gov.hmcts.reform.fpl.utils.elasticsearch.ESQuery;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.math.RoundingMode.UP;
+import static org.springframework.util.ObjectUtils.isEmpty;
+import static uk.gov.hmcts.reform.fpl.controllers.support.MigrateCaseController.MIGRATION_ID_KEY;
+import static uk.gov.hmcts.reform.fpl.service.search.SearchService.ES_DEFAULT_SIZE;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(value = "scheduler.enabled", havingValue = "true")
+@RequiredArgsConstructor(onConstructor_ = {@Autowired})
+public class CaseMigrationJob implements Job {
+
+    private final CoreCaseDataService coreCaseDataService;
+    private final SearchService searchService;
+    private final MigrationConfig migrationConfig;
+
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        final String jobName = context.getJobDetail().getKey().getName();
+        log.info("Job '{}' started", jobName);
+
+        switch (migrationConfig.getMigrationJobMode()) {
+            case ID_LIST:
+                log.info("Starting ID List Migration");
+                doIdListMigration(jobName);
+                break;
+            case ES_QUERY:
+                log.info("Starting ES Query Migration");
+                doEsQueryMigration(jobName);
+                break;
+            default:
+                log.error("Invalid Migration Job Mode");
+        }
+    }
+
+    public void doIdListMigration(String jobName) {
+        AtomicInteger updated = new AtomicInteger();
+        AtomicInteger failed = new AtomicInteger();
+
+        migrationConfig.getCaseIds()
+            .parallelStream().forEach(id -> {
+                    CaseDetails after = coreCaseDataService.performPostSubmitCallback(id, "migrateCase",
+                        caseDetails -> Map.of(MIGRATION_ID_KEY, migrationConfig.getMigrationId()));
+
+                    if (isEmpty(after)) {
+                        failed.getAndIncrement();
+                    } else {
+                        updated.getAndIncrement();
+                    }
+                }
+            );
+
+        log.info("Job '{}' completed, {} success, {} failed", jobName, updated.get(), failed.get());
+    }
+
+    public void doEsQueryMigration(String jobName) {
+        ESQuery query = migrationConfig.getMigrationQueries().get(migrationConfig.getMigrationId()).get();
+
+        int total;
+
+        try {
+            total = searchService.searchResultsSize(query);
+            log.info("Job '{}' found {} cases", jobName, total);
+        } catch (Exception e) {
+            log.error("Job '{}' could not determine the number of cases to search for due to {}",
+                jobName, e.getMessage(), e
+            );
+            log.info("Job '{}' finished unsuccessfully.", jobName);
+            return;
+        }
+
+        AtomicInteger updated = new AtomicInteger();
+        AtomicInteger failed = new AtomicInteger();
+
+        int pages = paginate(total);
+        log.debug("Job '{}' split the search query over {} pages", jobName, pages);
+        for (int i = 0; i < pages; i++) {
+            try {
+                List<CaseDetails> cases = searchService.search(query, ES_DEFAULT_SIZE, i * ES_DEFAULT_SIZE);
+                cases.parallelStream().forEach(caseDetails -> {
+                    final Long caseId = caseDetails.getId();
+
+                    CaseDetails after = coreCaseDataService.performPostSubmitCallback(caseId, "migrateCase",
+                        caseDetails1 -> Map.of(MIGRATION_ID_KEY, migrationConfig.getMigrationId()));
+
+                    if (isEmpty(after)) {
+                        failed.getAndIncrement();
+                    } else {
+                        updated.getAndIncrement();
+                    }
+
+                });
+            } catch (Exception e) {
+                log.error("Job '{}' could not search for cases due to {}", jobName, e.getMessage(), e);
+                failed.addAndGet(ES_DEFAULT_SIZE);
+            }
+        }
+
+        log.info("Job '{}' completed, {} success, {} failed", jobName, updated.get(), failed.get());
+    }
+
+    private int paginate(int total) {
+        return new BigDecimal(total).divide(new BigDecimal(ES_DEFAULT_SIZE), UP).intValue();
+    }
+
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/jobs/MigrationJobMode.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/jobs/MigrationJobMode.java
@@ -1,0 +1,5 @@
+package uk.gov.hmcts.reform.fpl.jobs;
+
+public enum MigrationJobMode {
+    ID_LIST, ES_QUERY
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/utils/elasticsearch/ExistsQuery.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/utils/elasticsearch/ExistsQuery.java
@@ -1,0 +1,26 @@
+package uk.gov.hmcts.reform.fpl.utils.elasticsearch;
+
+import lombok.EqualsAndHashCode;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+@EqualsAndHashCode
+public class ExistsQuery implements ESQuery {
+    private final String field;
+
+    public ExistsQuery(String field) {
+        requireNonNull(field);
+        this.field = field;
+    }
+
+    public static ExistsQuery of(String field) {
+        return new ExistsQuery(field);
+    }
+
+    @Override
+    public Map<String, Object> toMap() {
+        return Map.of("exists", Map.of("field", field));
+    }
+}

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -275,6 +275,12 @@ scheduler:
       description: 'Find undelivered emails'
       jobClass: 'uk.gov.hmcts.reform.fpl.jobs.UndeliveredEmailsFinder'
       cron: ${UPDATE_SUMMARY_TAB_CRON:0 0 8 ? * * *}
+    - name: 'Migration'
+      enabled: true
+      cronGroup: "NIGHTLY_CRON"
+      description: 'Perform Migrations'
+      jobClass: 'uk.gov.hmcts.reform.fpl.jobs.CaseMigrationJob'
+      cron: ${MIGRATION_TASK_CRON:0 52 14 26 4 ? *}
 
 testing:
   support:
@@ -330,3 +336,9 @@ contacts:
   passport_office:
     address: 'Glasgow CPST, HMPO Glasgow, 96 Milton Street, Glasgow, G4 0BT'
     email: 'Glasgowcaveats@hmpo.gov.uk'
+
+fpl:
+  migration:
+    migrationId: DFPL-test
+    # ID_LIST/ES_QUERY
+    migrationType: ID_LIST


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
 - Adds a migration job that takes either a set of case Ids or a ESQuery,
 - Loads in config for the type of migration
 - Uses existing CRON scheduled overnight jobs inside the `fpl-case-service`
 - TODO - Use existing onboarding config yaml parsing to load a list of caseIds instead of embedding them in the service config


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
