### PR TITLE
DFPL-1437 Document removal for data breach on ZW23C50136

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -44,7 +44,8 @@ public class MigrateCaseController extends CallbackController {
         "DFPL-1291", this::run1291,
         "DFPL-1310", this::run1310,
         "DFPL-1371", this::run1371,
-        "DFPL-1380", this::run1380
+        "DFPL-1380", this::run1380,
+        "DFPL-1437", this::run1437
     );
 
     @PostMapping("/about-to-submit")
@@ -122,5 +123,17 @@ public class MigrateCaseController extends CallbackController {
         var possibleCaseIds = List.of(1662460879255241L);
         migrateCaseService.doCaseIdCheckList(caseDetails.getId(), possibleCaseIds, migrationId);
         caseDetails.getData().put("state", State.FINAL_HEARING);
+    }
+
+    private void run1437(CaseDetails caseDetails) {
+        var migrationId = "DFPL-1437";
+
+        migrateCaseService.doCaseIdCheckList(caseDetails.getId(), List.of(1680258979928537L), migrationId);
+        caseDetails.getData().putAll(migrateCaseService.removeFurtherEvidenceSolicitorDocuments(getCaseData(caseDetails), migrationId,
+            UUID.fromString("97d51061-4ca1-4af6-94da-61160a681e2f")));
+        caseDetails.getData().putAll(migrateCaseService.removeHearingFurtherEvidenceSolicitorDocuments(getCaseData(caseDetails), migrationId,
+            UUID.fromString("c696b0d4-b11b-492e-bcbb-4142d5e47258"),
+            UUID.fromString("94161ba0-c229-453d-a6ce-06228aa4cf66")));
+        caseDetails.getData().putAll(migrateCaseService.refreshDocumentViews(getCaseData(caseDetails)));
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -129,9 +129,10 @@ public class MigrateCaseController extends CallbackController {
         var migrationId = "DFPL-1437";
 
         migrateCaseService.doCaseIdCheckList(caseDetails.getId(), List.of(1680258979928537L), migrationId);
-        caseDetails.getData().putAll(migrateCaseService.removeFurtherEvidenceSolicitorDocuments(getCaseData(caseDetails), migrationId,
-            UUID.fromString("97d51061-4ca1-4af6-94da-61160a681e2f")));
-        caseDetails.getData().putAll(migrateCaseService.removeHearingFurtherEvidenceDocuments(getCaseData(caseDetails), migrationId,
+        caseDetails.getData().putAll(migrateCaseService.removeFurtherEvidenceSolicitorDocuments(
+            getCaseData(caseDetails), migrationId, UUID.fromString("97d51061-4ca1-4af6-94da-61160a681e2f")));
+        caseDetails.getData().putAll(migrateCaseService.removeHearingFurtherEvidenceDocuments(getCaseData(caseDetails),
+            migrationId,
             UUID.fromString("c696b0d4-b11b-492e-bcbb-4142d5e47258"),
             UUID.fromString("94161ba0-c229-453d-a6ce-06228aa4cf66")));
         caseDetails.getData().putAll(migrateCaseService.refreshDocumentViews(getCaseData(caseDetails)));

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -131,7 +131,7 @@ public class MigrateCaseController extends CallbackController {
         migrateCaseService.doCaseIdCheckList(caseDetails.getId(), List.of(1680258979928537L), migrationId);
         caseDetails.getData().putAll(migrateCaseService.removeFurtherEvidenceSolicitorDocuments(getCaseData(caseDetails), migrationId,
             UUID.fromString("97d51061-4ca1-4af6-94da-61160a681e2f")));
-        caseDetails.getData().putAll(migrateCaseService.removeHearingFurtherEvidenceSolicitorDocuments(getCaseData(caseDetails), migrationId,
+        caseDetails.getData().putAll(migrateCaseService.removeHearingFurtherEvidenceDocuments(getCaseData(caseDetails), migrationId,
             UUID.fromString("c696b0d4-b11b-492e-bcbb-4142d5e47258"),
             UUID.fromString("94161ba0-c229-453d-a6ce-06228aa4cf66")));
         caseDetails.getData().putAll(migrateCaseService.refreshDocumentViews(getCaseData(caseDetails)));

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -38,9 +38,6 @@ public class MigrateCaseController extends CallbackController {
     private final ManageOrderDocumentScopedFieldsCalculator fieldsCalculator;
 
     private final Map<String, Consumer<CaseDetails>> migrations = Map.of(
-        "DFPL-1303", this::run1303,
-        "DFPL-1320", this::run1320,
-        "DFPL-1335", this::run1335,
         "DFPL-1261", this::run1261,
         "DFPL-1226", this::run1226,
         "DFPL-1361", this::run1361,
@@ -83,31 +80,6 @@ public class MigrateCaseController extends CallbackController {
     private void run1226(CaseDetails caseDetails) {
         migrateCaseService.doDocumentViewNCCheck(caseDetails.getId(), "DFPL-1226", caseDetails);
         caseDetails.getData().putAll(migrateCaseService.refreshDocumentViews(getCaseData(caseDetails)));
-    }
-
-    private void run1320(CaseDetails caseDetails) {
-        String migrationId = "DFPL-1320";
-        migrateCaseService.doCaseIdCheckList(caseDetails.getId(), List.of(1667466628958196L), migrationId);
-        caseDetails.getData().putAll(
-            migrateCaseService.removeJudicialMessage(getCaseData(caseDetails), migrationId,
-                "afb1a77d-08c9-4ad1-a03f-e7b47c8eb8c3"));
-    }
-
-    private void run1335(CaseDetails caseDetails) {
-        var migrationId = "DFPL-1335";
-        var possibleCaseIds = List.of(1677078973744903L);
-        migrateCaseService.doCaseIdCheckList(caseDetails.getId(), possibleCaseIds, migrationId);
-        caseDetails.getData().putAll(migrateCaseService.removeSkeletonArgument(getCaseData(caseDetails),
-            "e4e70bf5-4905-4c13-9d59-d20a202b6c9a", migrationId));
-    }
-
-    private void run1303(CaseDetails caseDetails) {
-        var migrationId = "DFPL-1303";
-        var possibleCaseIds = List.of(1652697388556674L);
-        migrateCaseService.doCaseIdCheckList(caseDetails.getId(), possibleCaseIds, migrationId);
-        caseDetails.getData().putAll(migrateCaseService.removeApplicationDocument(getCaseData(caseDetails),
-            migrationId,
-            UUID.fromString("7b381f49-d6f9-4a17-a72a-5e39fb48a671")));
     }
 
     private void run1361(CaseDetails caseDetails) {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseService.java
@@ -539,10 +539,10 @@ public class MigrateCaseService {
             .replace(">", "");
     }
 
-    public Map<String, Object> removeHearingFurtherEvidenceSolicitorDocuments(CaseData caseData,
-                                                                              String migrationId,
-                                                                              UUID expectedHearingId,
-                                                                              UUID expectedDocId) {
+    public Map<String, Object> removeHearingFurtherEvidenceDocuments(CaseData caseData,
+                                                                     String migrationId,
+                                                                     UUID expectedHearingId,
+                                                                     UUID expectedDocId) {
         Long caseId = caseData.getId();
 
         Element<HearingFurtherEvidenceBundle> elementToBeUpdated = caseData.getHearingFurtherEvidenceDocuments()

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseService.java
@@ -11,12 +11,14 @@ import uk.gov.hmcts.reform.fpl.model.CaseSummary;
 import uk.gov.hmcts.reform.fpl.model.Child;
 import uk.gov.hmcts.reform.fpl.model.Court;
 import uk.gov.hmcts.reform.fpl.model.HearingBooking;
+import uk.gov.hmcts.reform.fpl.model.HearingFurtherEvidenceBundle;
 import uk.gov.hmcts.reform.fpl.model.IncorrectCourtCodeConfig;
 import uk.gov.hmcts.reform.fpl.model.Placement;
 import uk.gov.hmcts.reform.fpl.model.PositionStatementChild;
 import uk.gov.hmcts.reform.fpl.model.PositionStatementRespondent;
 import uk.gov.hmcts.reform.fpl.model.SentDocuments;
 import uk.gov.hmcts.reform.fpl.model.SkeletonArgument;
+import uk.gov.hmcts.reform.fpl.model.SupportingEvidenceBundle;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
 import uk.gov.hmcts.reform.fpl.model.judicialmessage.JudicialMessage;
 import uk.gov.hmcts.reform.fpl.model.order.HearingOrder;
@@ -535,5 +537,69 @@ public class MigrateCaseService {
         }
         return str.replace("<", "")
             .replace(">", "");
+    }
+
+    public Map<String, Object> removeHearingFurtherEvidenceSolicitorDocuments(CaseData caseData,
+                                                                              String migrationId,
+                                                                              UUID expectedHearingId,
+                                                                              UUID expectedDocId) {
+        Long caseId = caseData.getId();
+
+        Element<HearingFurtherEvidenceBundle> elementToBeUpdated = caseData.getHearingFurtherEvidenceDocuments()
+            .stream()
+            .filter(hfed -> expectedHearingId.equals(hfed.getId()))
+            .findFirst().orElseThrow(() -> new AssertionError(format(
+                "Migration {id = %s, case reference = %s}, hearing not found",
+                migrationId, caseId)));
+        List<Element<SupportingEvidenceBundle>> newSupportingEvidenceBundle =
+            elementToBeUpdated.getValue().getSupportingEvidenceBundle().stream()
+                .filter(el -> !expectedDocId.equals(el.getId()))
+                .collect(toList());
+        if (newSupportingEvidenceBundle.size() != elementToBeUpdated.getValue().getSupportingEvidenceBundle()
+            .size() - 1) {
+            throw new AssertionError(format(
+                "Migration {id = %s, case reference = %s}, hearing further evidence documents not found",
+                migrationId, caseId));
+        }
+        elementToBeUpdated.getValue().setSupportingEvidenceBundle(newSupportingEvidenceBundle);
+
+        List<Element<HearingFurtherEvidenceBundle>> listOfHearingFurtherEvidenceBundle =
+            caseData.getHearingFurtherEvidenceDocuments().stream()
+                .filter(el -> !expectedHearingId.equals(el.getId()))
+                .collect(toList());
+        if (!newSupportingEvidenceBundle.isEmpty()) {
+            listOfHearingFurtherEvidenceBundle.add(elementToBeUpdated);
+        }
+        if (listOfHearingFurtherEvidenceBundle.isEmpty()) {
+            Map<String, Object> ret = new HashMap<>();
+            ret.put("hearingFurtherEvidenceDocuments", null);
+            return ret;
+        } else {
+            return Map.of("hearingFurtherEvidenceDocuments", listOfHearingFurtherEvidenceBundle);
+        }
+    }
+
+    public Map<String, Object> removeFurtherEvidenceSolicitorDocuments(CaseData caseData,
+                                                                       String migrationId,
+                                                                       UUID expectedDocId) {
+        Long caseId = caseData.getId();
+        List<Element<SupportingEvidenceBundle>> furtherEvidenceDocumentsSolicitor =
+            caseData.getFurtherEvidenceDocumentsSolicitor().stream()
+                .filter(el -> !expectedDocId.equals(el.getId()))
+                .collect(toList());
+
+        if (furtherEvidenceDocumentsSolicitor.size() != caseData.getFurtherEvidenceDocumentsSolicitor().size() - 1) {
+            throw new AssertionError(format(
+                "Migration {id = %s, case reference = %s}, further evidence documents solicitor not found",
+                migrationId, caseId));
+        }
+
+        if (furtherEvidenceDocumentsSolicitor.isEmpty()) {
+            Map<String, Object> ret = new HashMap<>();
+            ret.put("furtherEvidenceDocumentsSolicitor", null);
+            return ret;
+        } else {
+            return Map.of("furtherEvidenceDocumentsSolicitor", furtherEvidenceDocumentsSolicitor);
+        }
     }
 }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseServiceTest.java
@@ -23,12 +23,14 @@ import uk.gov.hmcts.reform.fpl.model.ChildParty;
 import uk.gov.hmcts.reform.fpl.model.Court;
 import uk.gov.hmcts.reform.fpl.model.HearingBooking;
 import uk.gov.hmcts.reform.fpl.model.HearingDocuments;
+import uk.gov.hmcts.reform.fpl.model.HearingFurtherEvidenceBundle;
 import uk.gov.hmcts.reform.fpl.model.Placement;
 import uk.gov.hmcts.reform.fpl.model.PositionStatementChild;
 import uk.gov.hmcts.reform.fpl.model.PositionStatementRespondent;
 import uk.gov.hmcts.reform.fpl.model.SentDocument;
 import uk.gov.hmcts.reform.fpl.model.SentDocuments;
 import uk.gov.hmcts.reform.fpl.model.SkeletonArgument;
+import uk.gov.hmcts.reform.fpl.model.SupportingEvidenceBundle;
 import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
 import uk.gov.hmcts.reform.fpl.model.event.PlacementEventData;
@@ -1355,4 +1357,91 @@ class MigrateCaseServiceTest {
         }
     }
 
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @Nested
+    class RemoveHearingFurtherEvidenceDocuments {
+        private final Element<SupportingEvidenceBundle> seb1 = element(SupportingEvidenceBundle.builder()
+            .build());
+        private final Element<SupportingEvidenceBundle> seb2 = element(SupportingEvidenceBundle.builder()
+            .build());
+        private final Element<SupportingEvidenceBundle> sebToBeRemoved =
+            element(SupportingEvidenceBundle.builder().build());
+
+        private UUID hearingFurtherEvidenceBundleId = UUID.randomUUID();
+
+        @Test
+        void shouldRemoveTargetSupportingEvidenceBundle() {
+            CaseData caseData = CaseData.builder()
+                .id(1L)
+                .hearingFurtherEvidenceDocuments(List.of(
+                    element(hearingFurtherEvidenceBundleId, HearingFurtherEvidenceBundle.builder()
+                        .supportingEvidenceBundle(List.of(seb1, seb2, sebToBeRemoved))
+                        .build())
+                ))
+                .build();
+
+            Map<String, Object> updatedFields = underTest.removeHearingFurtherEvidenceDocuments(caseData, MIGRATION_ID,
+                hearingFurtherEvidenceBundleId, sebToBeRemoved.getId());
+
+            assertThat(updatedFields).extracting("hearingFurtherEvidenceDocuments").asList()
+                .containsExactly(
+                    element(hearingFurtherEvidenceBundleId, HearingFurtherEvidenceBundle.builder()
+                        .supportingEvidenceBundle(List.of(seb1, seb2))
+                        .build()
+                ));
+        }
+
+        @Test
+        void shouldReturnNullWhenLastSupportingEvidenceBundleIsRemoved() {
+            CaseData caseData = CaseData.builder()
+                .id(1L)
+                .hearingFurtherEvidenceDocuments(List.of(
+                    element(hearingFurtherEvidenceBundleId, HearingFurtherEvidenceBundle.builder()
+                        .supportingEvidenceBundle(List.of(sebToBeRemoved))
+                        .build())
+                ))
+                .build();
+
+            Map<String, Object> updatedFields = underTest.removeHearingFurtherEvidenceDocuments(caseData, MIGRATION_ID,
+                hearingFurtherEvidenceBundleId, sebToBeRemoved.getId());
+
+            assertThat(updatedFields).extracting("hearingFurtherEvidenceDocuments").isNull();
+        }
+
+        @Test
+        void shouldThrowExceptionIfTargetSupportingEvidenceBundleNotExist() {
+            CaseData caseData = CaseData.builder()
+                .id(1L)
+                .hearingFurtherEvidenceDocuments(List.of(
+                    element(hearingFurtherEvidenceBundleId, HearingFurtherEvidenceBundle.builder()
+                        .supportingEvidenceBundle(List.of(seb1, seb2))
+                        .build())
+                ))
+                .build();
+
+            assertThatThrownBy(() -> underTest.removeHearingFurtherEvidenceDocuments(caseData, MIGRATION_ID,
+                    hearingFurtherEvidenceBundleId, sebToBeRemoved.getId()))
+                .isInstanceOf(AssertionError.class)
+                .hasMessage(format(
+                    "Migration {id = %s, case reference = %s}, hearing further evidence documents not found",
+                    MIGRATION_ID, 1, sebToBeRemoved.getId().toString()));
+        }
+
+        @Test
+        void shouldThrowExceptionIfHearingIdNotExist() {
+            CaseData caseData = CaseData.builder()
+                .id(1L)
+                .hearingFurtherEvidenceDocuments(List.of(
+                    element(hearingFurtherEvidenceBundleId, HearingFurtherEvidenceBundle.builder()
+                        .supportingEvidenceBundle(List.of(seb1, seb2, sebToBeRemoved))
+                        .build())
+                ))
+                .build();
+
+            assertThatThrownBy(() -> underTest.removeHearingFurtherEvidenceDocuments(caseData, MIGRATION_ID,
+                UUID.randomUUID(), sebToBeRemoved.getId()))
+                .isInstanceOf(AssertionError.class)
+                .hasMessage(format("Migration {id = %s, case reference = %s}, hearing not found", MIGRATION_ID, 1));
+        }
+    }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-1437


### Change description ###
Migration script for removing `furtherEvidenceDocumentsSolicitor` and `hearingFurtherEvidenceDocuments`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
