### PR TITLE
DFPL-1310: Re-add change from 150 -> 554

### DIFF
--- a/ccd-definition/FixedLists/CareSupervision/Court.json
+++ b/ccd-definition/FixedLists/CareSupervision/Court.json
@@ -65,7 +65,7 @@
   {
     "LiveFrom": "01/01/2017",
     "ID": "Court",
-    "ListElementCode": "150",
+    "ListElementCode": "554",
     "ListElement": "Brighton",
     "DisplayOrder": 100
   },

--- a/ccd-definition/FixedLists/CareSupervision/dfj/BrightonDFJCourts.json
+++ b/ccd-definition/FixedLists/CareSupervision/dfj/BrightonDFJCourts.json
@@ -2,7 +2,7 @@
   {
     "LiveFrom": "01/01/2017",
     "ID": "BrightonDFJCourts",
-    "ListElementCode": "150",
+    "ListElementCode": "554",
     "ListElement": "Brighton",
     "DisplayOrder": 1
   }


### PR DESCRIPTION
This reverts commit 32ddeca4ddb3bb8977a3bea5da2d926f0f8ad5ef.

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-1310


### Change description ###
 - Changes Brighton's court code from 150 -> 554
 - Migration is still present in MigrateCaseController


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
