### PR TITLE
DFPL-1474: Migrate the orders.court specifically left out from earlier migration

### DIFF
--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseControllerTest.java
@@ -58,7 +58,7 @@ class MigrateCaseControllerTest extends AbstractCallbackTest {
     void shouldMigrateOrdersCourt() {
         CaseData caseData = CaseData.builder()
             .court(Court.builder()
-                .code("150")
+                .code("554")
                 .build())
             .orders(Orders.builder()
                 .court("150")
@@ -69,27 +69,5 @@ class MigrateCaseControllerTest extends AbstractCallbackTest {
             buildCaseDetails(caseData, "DFPL-1310"));
 
         assertThat(resp.getData().get("orders")).extracting("court").isEqualTo("554");
-    }
-
-    @Test
-    void shouldMigrateOrdersSolicitorCourt() {
-        CaseData caseData = CaseData.builder()
-            .court(Court.builder()
-                .code("150")
-                .build())
-            .orders(Orders.builder()
-                .court("150")
-                .build())
-            .ordersSolicitor(Orders.builder()
-                .court("150")
-                .build())
-            .build();
-
-        AboutToStartOrSubmitCallbackResponse resp = postAboutToSubmitEvent(
-            buildCaseDetails(caseData, "DFPL-1310"));
-
-        assertThat(resp.getData().get("court")).extracting("code").isEqualTo("554");
-        assertThat(resp.getData().get("orders")).extracting("court").isEqualTo("554");
-        assertThat(resp.getData().get("ordersSolicitor")).extracting("court").isEqualTo("554");
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-1474


### Change description ###
 - Add migration to migrate those that had a correct court.code but not a correct orders.court


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
