### PR TITLE
DFPL-1446 Add retry and log for analysing secure doc store exception

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -36,6 +36,7 @@ public class MigrateCaseController extends CallbackController {
         "DFPL-1359", this::run1359,
         "DFPL-1401", this::run1401,
         "DFPL-1451", this::run1451,
+        "DFPL-1466", this::run1466,
         "DFPL-1501", this::run1501,
         "DFPL-1511", this::run1511
     );
@@ -82,6 +83,15 @@ public class MigrateCaseController extends CallbackController {
             migrationId, expectedOrderId));
         caseDetails.getData().putAll(migrateCaseService.removeHearingOrdersBundlesDrafts(getCaseData(caseDetails),
             migrationId, expectedHearingOrderBundleId));
+    }
+
+    private void run1466(CaseDetails caseDetails) {
+        var migrationId = "DFPL-1466";
+        var possibleCaseIds = List.of(1665396049325141L);
+        migrateCaseService.doCaseIdCheckList(caseDetails.getId(), possibleCaseIds, migrationId);
+
+        caseDetails.getData().putAll(migrateCaseService.removePositionStatementChild(getCaseData(caseDetails),
+            migrationId, UUID.fromString("b8da3a48-441f-4210-a21c-7008d256aa32")));
     }
 
     private void run1501(CaseDetails caseDetails) {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -36,6 +36,7 @@ public class MigrateCaseController extends CallbackController {
         "DFPL-1359", this::run1359,
         "DFPL-1401", this::run1401,
         "DFPL-1451", this::run1451,
+        "DFPL-1501", this::run1501,
         "DFPL-1511", this::run1511
     );
 
@@ -81,6 +82,15 @@ public class MigrateCaseController extends CallbackController {
             migrationId, expectedOrderId));
         caseDetails.getData().putAll(migrateCaseService.removeHearingOrdersBundlesDrafts(getCaseData(caseDetails),
             migrationId, expectedHearingOrderBundleId));
+    }
+
+    private void run1501(CaseDetails caseDetails) {
+        var migrationId = "DFPL-1501";
+        var possibleCaseIds = List.of(1659711594032934L);
+
+        migrateCaseService.doCaseIdCheckList(caseDetails.getId(), possibleCaseIds, migrationId);
+        caseDetails.getData().putAll(migrateCaseService.removeFurtherEvidenceSolicitorDocuments(
+            getCaseData(caseDetails), migrationId, UUID.fromString("43a9287c-f840-4104-958f-cbd98d28aea3")));
     }
 
     private void run1511(CaseDetails caseDetails) {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/DocumentDownloadService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/DocumentDownloadService.java
@@ -31,12 +31,11 @@ public class DocumentDownloadService {
     private final IdamClient idamClient;
     private final RequestData requestData;
 
-    private final SecureDocStoreService secureDocStoreService;
-    private final FeatureToggleService featureToggleService;
     private final SystemUserService systemUserService;
+    private final SecureDocStoreHelper secureDocStoreHelper;
 
     public byte[] downloadDocument(final String documentUrlString) {
-        return new SecureDocStoreHelper(secureDocStoreService, featureToggleService).download(documentUrlString, () -> {
+        return secureDocStoreHelper.download(documentUrlString, () -> {
             String userRoles = "caseworker-publiclaw-systemupdate";
             boolean useSystemUser = false;
             try {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/DocumentMetadataDownloadService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/DocumentMetadataDownloadService.java
@@ -24,9 +24,8 @@ public class DocumentMetadataDownloadService {
     private final DocumentMetadataDownloadClientApi documentMetadataDownloadClient;
     private final IdamClient idamClient;
     private final RequestData requestData;
-    private final FeatureToggleService featureToggleService;
-    private final SecureDocStoreService secureDocStoreService;
     private final SystemUserService systemUserService;
+    private final SecureDocStoreHelper secureDocStoreHelper;
 
     public DocumentReference getDocumentMetadata(final String documentUrlString) {
         boolean useSystemUser = false;
@@ -50,7 +49,7 @@ public class DocumentMetadataDownloadService {
 
         DocumentReference ret = null;
         try {
-            ret = new SecureDocStoreHelper(secureDocStoreService, featureToggleService)
+            ret = secureDocStoreHelper
                 .getDocumentMetadata(documentUrlString, () -> {
                     uk.gov.hmcts.reform.document.domain.Document document =
                         documentMetadataDownloadClient.getDocumentMetadata(

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/UploadDocumentService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/UploadDocumentService.java
@@ -21,20 +21,17 @@ public class UploadDocumentService {
     private final DocumentUploadClientApi documentUploadClient;
     private final RequestData requestData;
 
-    private final SecureDocStoreService secureDocStoreService;
-    private final FeatureToggleService featureToggleService;
+    private final SecureDocStoreHelper secureDocStoreHelper;
 
 
     public UploadDocumentService(AuthTokenGenerator authTokenGenerator,
                                  DocumentUploadClientApi documentUploadClient,
                                  RequestData requestData,
-                                 SecureDocStoreService secureDocStoreService,
-                                 FeatureToggleService featureToggleService) {
+                                 SecureDocStoreHelper secureDocStoreHelper) {
         this.authTokenGenerator = authTokenGenerator;
         this.documentUploadClient = documentUploadClient;
         this.requestData = requestData;
-        this.secureDocStoreService = secureDocStoreService;
-        this.featureToggleService = featureToggleService;
+        this.secureDocStoreHelper = secureDocStoreHelper;
     }
 
     // REFACTOR: 08/04/2021 Remove this method in subsequent PR
@@ -43,7 +40,7 @@ public class UploadDocumentService {
     }
 
     public Document uploadDocument(byte[] byteArray, String fileName, String contentType) {
-        return new SecureDocStoreHelper(secureDocStoreService, featureToggleService)
+        return secureDocStoreHelper
             .uploadDocument(byteArray, fileName, contentType, () -> {
                 MultipartFile file = new InMemoryMultipartFile("files", fileName, contentType, byteArray);
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/utils/SecureDocStoreHelper.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/utils/SecureDocStoreHelper.java
@@ -4,7 +4,6 @@ import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.properties.ConstructorBinding;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.ccd.document.am.model.Classification;
 import uk.gov.hmcts.reform.ccd.document.am.model.Document;

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/utils/SecureDocStoreHelper.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/utils/SecureDocStoreHelper.java
@@ -213,7 +213,7 @@ public class SecureDocStoreHelper implements DisposableBean {
     public void destroy() throws Exception {
         log.info("[SECURE DOC STORE TEST] Shutdown scheduler");
         retryScheduler.shutdownNow();
-        if(!retryScheduler.isShutdown()) {
+        if (!retryScheduler.isShutdown()) {
             log.error("[SECURE DOC STORE TEST] Fail to shutdown scheduler");
         }
     }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/utils/SecureDocStoreHelper.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/utils/SecureDocStoreHelper.java
@@ -3,6 +3,8 @@ package uk.gov.hmcts.reform.fpl.utils;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.ConstructorBinding;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.ccd.document.am.model.Classification;
 import uk.gov.hmcts.reform.ccd.document.am.model.Document;
@@ -28,11 +30,21 @@ public class SecureDocStoreHelper implements DisposableBean {
     private SecureDocStoreService secureDocStoreService;
     public final ScheduledExecutorService retryScheduler;
 
+    @Autowired
     public SecureDocStoreHelper(SecureDocStoreService secureDocStoreService,
                                 FeatureToggleService featureToggleService) {
         this.featureToggleService = featureToggleService;
         this.secureDocStoreService = secureDocStoreService;
         retryScheduler = Executors.newScheduledThreadPool(1);
+    }
+
+    // This constructor is used for unit test only.
+    public SecureDocStoreHelper(SecureDocStoreService secureDocStoreService,
+                                FeatureToggleService featureToggleService,
+                                ScheduledExecutorService retryScheduler) {
+        this.featureToggleService = featureToggleService;
+        this.secureDocStoreService = secureDocStoreService;
+        this.retryScheduler = retryScheduler;
     }
 
     public byte[] download(final String documentUrlString) {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/utils/SecureDocStoreHelper.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/utils/SecureDocStoreHelper.java
@@ -205,16 +205,16 @@ public class SecureDocStoreHelper implements DisposableBean {
     private void retrySecureDocStoreTest(final String documentUrlString, Callable<?> retrySecureDocStoreApi) {
         // assign ID to each retry for traceability
         String retryTestId = UUID.randomUUID().toString();
-        log.info("[SECURE DOC STORE TEST] {} Will retry API with 30s delay, document meta data: {}",
+        log.info("[SECURE DOC STORE TEST] {} Will retry API with 30s delay, documentUrlString: {}",
             retryTestId, documentUrlString);
 
         retryScheduler.schedule(() -> {
             try {
                 retrySecureDocStoreApi.call();
-                log.info("[SECURE DOC STORE TEST] {} Success, document meta data: {}",
+                log.info("[SECURE DOC STORE TEST] {} Success, documentUrlString: {}",
                     retryTestId, documentUrlString);
             } catch (Exception e) {
-                log.info("[SECURE DOC STORE TEST] {} Failed, document meta data: {}",
+                log.error("[SECURE DOC STORE TEST] {} Failed, documentUrlString: {}",
                     retryTestId, documentUrlString);
             }
         }, 30, TimeUnit.SECONDS);

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/DocumentDownloadServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/DocumentDownloadServiceTest.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.fpl.service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
@@ -13,6 +14,7 @@ import uk.gov.hmcts.reform.document.DocumentDownloadClientApi;
 import uk.gov.hmcts.reform.document.domain.Document;
 import uk.gov.hmcts.reform.fpl.exceptions.EmptyFileException;
 import uk.gov.hmcts.reform.fpl.request.RequestData;
+import uk.gov.hmcts.reform.fpl.utils.SecureDocStoreHelper;
 import uk.gov.hmcts.reform.idam.client.IdamClient;
 import uk.gov.hmcts.reform.idam.client.models.UserInfo;
 
@@ -63,6 +65,9 @@ class DocumentDownloadServiceTest {
     @Mock
     private ByteArrayResource byteArrayResource;
 
+    @InjectMocks
+    private SecureDocStoreHelper secureDocStoreHelper;
+
     private DocumentDownloadService documentDownloadService;
 
     private final Document document = document();
@@ -87,9 +92,8 @@ class DocumentDownloadServiceTest {
             documentDownloadClient,
             idamClient,
             requestData,
-            secureDocStoreService,
-            featureToggleService,
-            systemUserService);
+            systemUserService,
+            secureDocStoreHelper);
     }
 
     @Test

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/DocumentMetadataDownloadServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/DocumentMetadataDownloadServiceTest.java
@@ -4,6 +4,7 @@ import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
@@ -12,6 +13,7 @@ import uk.gov.hmcts.reform.document.DocumentMetadataDownloadClientApi;
 import uk.gov.hmcts.reform.document.domain.Document;
 import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
 import uk.gov.hmcts.reform.fpl.request.RequestData;
+import uk.gov.hmcts.reform.fpl.utils.SecureDocStoreHelper;
 import uk.gov.hmcts.reform.fpl.utils.extension.TestLogger;
 import uk.gov.hmcts.reform.fpl.utils.extension.TestLogs;
 import uk.gov.hmcts.reform.fpl.utils.extension.TestLogsExtension;
@@ -58,6 +60,8 @@ class DocumentMetadataDownloadServiceTest {
     private FeatureToggleService featureToggleService;
     @Mock
     private SystemUserService systemUserService;
+    @InjectMocks
+    private SecureDocStoreHelper secureDocStoreHelper;
 
     private DocumentMetadataDownloadService documentMetadataDownloadService;
 
@@ -80,9 +84,8 @@ class DocumentMetadataDownloadServiceTest {
                 documentMetadataDownloadClient,
                 idamClient,
                 requestData,
-                featureToggleService,
-                secureDocStoreService,
-                systemUserService);
+                systemUserService,
+                secureDocStoreHelper);
     }
 
     @Test

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/UploadDocumentServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/UploadDocumentServiceTest.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.reform.document.DocumentUploadClientApi;
 import uk.gov.hmcts.reform.document.domain.UploadResponse;
 import uk.gov.hmcts.reform.fpl.request.RequestData;
 import uk.gov.hmcts.reform.fpl.utils.DocumentManagementStoreLoader;
+import uk.gov.hmcts.reform.fpl.utils.SecureDocStoreHelper;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -42,6 +43,9 @@ class UploadDocumentServiceTest {
     @InjectMocks
     private SecureDocStoreService secureDocStoreService;
 
+    @InjectMocks
+    private SecureDocStoreHelper secureDocStoreHelper;
+
     private UploadDocumentService uploadDocumentService;
 
     @BeforeEach
@@ -51,7 +55,7 @@ class UploadDocumentServiceTest {
         given(requestData.userId()).willReturn(USER_ID);
 
         uploadDocumentService = new UploadDocumentService(
-            authTokenGenerator, documentUploadClient, requestData, secureDocStoreService, featureToggleService
+            authTokenGenerator, documentUploadClient, requestData, secureDocStoreHelper
         );
     }
 

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/utils/SecureDocStoreHelperTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/utils/SecureDocStoreHelperTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -20,9 +19,6 @@ import uk.gov.hmcts.reform.fpl.utils.extension.TestLogsExtension;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({SpringExtension.class, TestLogsExtension.class})

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/utils/SecureDocStoreHelperTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/utils/SecureDocStoreHelperTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -19,6 +20,9 @@ import uk.gov.hmcts.reform.fpl.utils.extension.TestLogsExtension;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({SpringExtension.class, TestLogsExtension.class})

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/utils/SecureDocStoreHelperTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/utils/SecureDocStoreHelperTest.java
@@ -16,7 +16,6 @@ import uk.gov.hmcts.reform.fpl.utils.extension.TestLogger;
 import uk.gov.hmcts.reform.fpl.utils.extension.TestLogs;
 import uk.gov.hmcts.reform.fpl.utils.extension.TestLogsExtension;
 
-import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-1446


### Change description ###
The changes in this PR is just for analysing secure doc store exception.
If failed, retry the secure doc store API with 30 seconds delay.
If retry success, that means those 404 exception are basically CCD / Sec-Doc-Store concurrent issue

Changes include:

1. convert the secure doc store helper to a Spring bean
Reason: 
i. allow Spring to manage the bean, instead of creating a new instance every time when we want to use the helper class
ii. allow us to use the Spring Bean lifecycle to release threads to avoid 
  a). memory leak and 
  b). SpringBoot cannot shutdown gracefully.

2. Use ScheduledExecutorService to fire the retry with 30 seconds delay
Reason:
i. Fire the retry in a separate thread, so that the main thread of the CCD event callback will not be blocked. 
ii. The use of ScheduledExecutorService avoid creating tons of thread. (in case tons of secure doc store API failing)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
