### PR TITLE
Add a dummy DateTime whilst we don't have HMC

### DIFF
--- a/ccd-definition/AuthorisationCaseField/CareSupervision/caseSummary.json
+++ b/ccd-definition/AuthorisationCaseField/CareSupervision/caseSummary.json
@@ -480,6 +480,29 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseFieldID": "caseSummaryNextHearingDateTime",
+    "AccessControl": [
+      {
+        "UserRoles": [
+          "caseworker-publiclaw-courtadmin",
+          "caseworker-publiclaw-magistrate",
+          "caseworker-publiclaw-judiciary",
+          "caseworker-publiclaw-gatekeeper",
+          "caseworker-publiclaw-superuser"
+        ],
+        "CRUD": "R"
+      },
+      {
+        "UserRoles": [
+          "caseworker-publiclaw-systemupdate"
+        ],
+        "CRUD": "CRUD"
+      }
+    ]
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
     "CaseFieldID": "caseSummaryNextHearingJudge",
     "AccessControl": [
       {

--- a/ccd-definition/AuthorisationCaseField/CareSupervision/wa-task-configuration.json
+++ b/ccd-definition/AuthorisationCaseField/CareSupervision/wa-task-configuration.json
@@ -26,5 +26,12 @@
     "CaseFieldID": "caseSummaryNextHearingDate",
     "UserRole": "caseworker-wa-task-configuration",
     "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseFieldID": "caseSummaryNextHearingDateTime",
+    "UserRole": "caseworker-wa-task-configuration",
+    "CRUD": "R"
   }
 ]

--- a/ccd-definition/CaseField/CareSupervision/caseSummary.json
+++ b/ccd-definition/CaseField/CareSupervision/caseSummary.json
@@ -187,7 +187,7 @@
     "CaseTypeID": "CARE_SUPERVISION_EPO",
     "ID": "caseSummaryNextHearingDateTime",
     "Label": "Date",
-    "FieldType": "Date",
+    "FieldType": "DateTime",
     "SecurityClassification": "PUBLIC",
     "Searchable": "Y"
   },

--- a/ccd-definition/CaseField/CareSupervision/caseSummary.json
+++ b/ccd-definition/CaseField/CareSupervision/caseSummary.json
@@ -185,6 +185,15 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "ID": "caseSummaryNextHearingDateTime",
+    "Label": "Date",
+    "FieldType": "Date",
+    "SecurityClassification": "PUBLIC",
+    "Searchable": "Y"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
     "ID": "caseSummaryNextHearingJudge",
     "Label": "Judge",
     "FieldType": "Text",

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ListGatekeepingControllerSubmittedTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ListGatekeepingControllerSubmittedTest.java
@@ -43,6 +43,7 @@ import uk.gov.service.notify.NotificationClientException;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -751,6 +752,7 @@ class ListGatekeepingControllerSubmittedTest extends ManageHearingsControllerTes
             .caseSummaryHasNextHearing(hasNextHearing)
             .caseSummaryNextHearingType(hearingType)
             .caseSummaryNextHearingDate(hearingDate)
+            .caseSummaryNextHearingDateTime(LocalDateTime.of(hearingDate, LocalTime.of(13, 0, 0)))
             .caseSummaryCourtName(COURT_NAME)
             .caseSummaryLanguageRequirement("No")
             .caseSummaryLALanguageRequirement("No")

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ManageHearingsControllerSubmittedTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ManageHearingsControllerSubmittedTest.java
@@ -45,6 +45,7 @@ import uk.gov.service.notify.NotificationClientException;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -782,6 +783,7 @@ class ManageHearingsControllerSubmittedTest extends ManageHearingsControllerTest
             .caseSummaryHasNextHearing(hasNextHearing)
             .caseSummaryNextHearingType(hearingType)
             .caseSummaryNextHearingDate(hearingDate)
+            .caseSummaryNextHearingDateTime(LocalDateTime.of(hearingDate, LocalTime.of(13, 0, 0)))
             .caseSummaryCourtName(COURT_NAME)
             .caseSummaryLanguageRequirement("No")
             .caseSummaryLALanguageRequirement("No")

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/summary/SyntheticCaseSummary.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/summary/SyntheticCaseSummary.java
@@ -6,6 +6,7 @@ import lombok.extern.jackson.Jacksonized;
 import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Value
 @Builder
@@ -34,6 +35,7 @@ public class SyntheticCaseSummary {
     String caseSummaryHasNextHearing;
     String caseSummaryNextHearingType;
     LocalDate caseSummaryNextHearingDate;
+    LocalDateTime caseSummaryNextHearingDateTime;
     String caseSummaryNextHearingJudge;
     String caseSummaryNextHearingEmailAddress;
     DocumentReference caseSummaryNextHearingCMO;

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/summary/CaseSummaryNextHearingGenerator.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/summary/CaseSummaryNextHearingGenerator.java
@@ -38,6 +38,7 @@ public class CaseSummaryNextHearingGenerator implements CaseSummaryFieldsGenerat
                 .caseSummaryHasNextHearing("Yes")
                 .caseSummaryNextHearingType(nextHearing.getType().getLabel())
                 .caseSummaryNextHearingDate(nextHearing.getStartDate().toLocalDate())
+                .caseSummaryNextHearingDateTime(nextHearing.getStartDate())
                 .caseSummaryNextHearingJudge(generateSummaryNextHearingJudge(nextHearing,
                     caseData.getAllocatedJudge(),
                     HearingBooking::getHearingJudgeLabel))

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/summary/CaseSummaryNextHearingGeneratorTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/summary/CaseSummaryNextHearingGeneratorTest.java
@@ -74,6 +74,7 @@ class CaseSummaryNextHearingGeneratorTest {
         assertThat(actual).isEqualTo(SyntheticCaseSummary.builder()
             .caseSummaryHasNextHearing("Yes")
             .caseSummaryNextHearingDate(NOW.toLocalDate())
+            .caseSummaryNextHearingDateTime(NOW)
             .caseSummaryNextHearingType("Case management")
             .build());
     }
@@ -99,6 +100,7 @@ class CaseSummaryNextHearingGeneratorTest {
         assertThat(actual).isEqualTo(SyntheticCaseSummary.builder()
             .caseSummaryHasNextHearing("Yes")
             .caseSummaryNextHearingDate(NOW.toLocalDate())
+            .caseSummaryNextHearingDateTime(NOW)
             .caseSummaryNextHearingType("Case management")
             .build());
     }
@@ -118,6 +120,7 @@ class CaseSummaryNextHearingGeneratorTest {
         assertThat(actual).isEqualTo(SyntheticCaseSummary.builder()
             .caseSummaryHasNextHearing("Yes")
             .caseSummaryNextHearingDate(NOW.toLocalDate())
+            .caseSummaryNextHearingDateTime(NOW)
             .caseSummaryNextHearingType("Case management")
             .build());
     }
@@ -138,6 +141,7 @@ class CaseSummaryNextHearingGeneratorTest {
         assertThat(actual).isEqualTo(SyntheticCaseSummary.builder()
             .caseSummaryHasNextHearing("Yes")
             .caseSummaryNextHearingDate(NOW.toLocalDate())
+            .caseSummaryNextHearingDateTime(NOW)
             .caseSummaryNextHearingType("Case management")
             .build());
     }
@@ -163,6 +167,7 @@ class CaseSummaryNextHearingGeneratorTest {
         assertThat(actual).isEqualTo(SyntheticCaseSummary.builder()
             .caseSummaryHasNextHearing("Yes")
             .caseSummaryNextHearingDate(NOW.toLocalDate())
+            .caseSummaryNextHearingDateTime(NOW)
             .caseSummaryNextHearingType("Case management")
             .build());
     }
@@ -188,6 +193,7 @@ class CaseSummaryNextHearingGeneratorTest {
         assertThat(actual).isEqualTo(SyntheticCaseSummary.builder()
             .caseSummaryHasNextHearing("Yes")
             .caseSummaryNextHearingDate(NOW.toLocalDate())
+            .caseSummaryNextHearingDateTime(NOW)
             .caseSummaryNextHearingType("Case management")
             .caseSummaryNextHearingJudge(HEARING_JUDGE_LABEL)
             .caseSummaryNextHearingEmailAddress(HEARING_JUDGE_EMAIL_ADDRESS)
@@ -215,6 +221,7 @@ class CaseSummaryNextHearingGeneratorTest {
         assertThat(actual).isEqualTo(SyntheticCaseSummary.builder()
             .caseSummaryHasNextHearing("Yes")
             .caseSummaryNextHearingDate(NOW.toLocalDate())
+            .caseSummaryNextHearingDateTime(NOW)
             .caseSummaryNextHearingType("Case management")
             .caseSummaryNextHearingCMO(DOCUMENT_REFERENCE)
             .build());
@@ -245,6 +252,7 @@ class CaseSummaryNextHearingGeneratorTest {
         assertThat(actual).isEqualTo(SyntheticCaseSummary.builder()
             .caseSummaryHasNextHearing("Yes")
             .caseSummaryNextHearingDate(NOW.toLocalDate())
+            .caseSummaryNextHearingDateTime(NOW)
             .caseSummaryNextHearingType("Case management")
             .build());
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Similar to the caseSummaryNextHearingDate, add a DateTime version, which matches the format of the nextHearingDate provided by HMC/S+L, in the hope it'll get pulled through in the same way.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
