### PR TITLE
DFPL-1483: Align caseData.court with caseData.caseManagementLocation

### DIFF
--- a/service/src/integrationTest/resources/fixtures/caseOtherOrderType.json
+++ b/service/src/integrationTest/resources/fixtures/caseOtherOrderType.json
@@ -53,7 +53,7 @@
         "orderType": [
           "OTHER"
         ],
-        "court": "22"
+        "court": "117"
       }
     }
   }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/OrdersNeededController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/OrdersNeededController.java
@@ -179,6 +179,11 @@ public class OrdersNeededController extends CallbackController {
     }
 
     private Court getCourtSelection(String courtID) {
-        return courtLookup.getCourtByCode(courtID).orElse(null);
+        // This needs to get the court out of the NEW list of courts, the old onboarding way might not have all courts
+        // especially in the lower environments, we should also match the 'Family Court sitting at XYZ' pattern.
+        Optional<Court> court = Optional.ofNullable(courtLookUpService.getCourtByCode(courtID).orElse(null));
+        return court.map(c -> c.toBuilder()
+            .name("Family Court sitting at " + c.getName())
+            .build()).orElse(null);
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-1483


### Change description ###
 - When updating court in the orders sought event, use the upto date JSON config rather than checking for courts in onboardings, as this may be outdated or not 'complete' in lower environments


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
