### PR TITLE
Make sure court name follows 'Family Court sitting at X' pattern on transfer

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/ManageLocalAuthoritiesService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/ManageLocalAuthoritiesService.java
@@ -351,9 +351,12 @@ public class ManageLocalAuthoritiesService {
             .map(DynamicList::getValueCode)
             .flatMap(courtLookUpService::getCourtByCode);
         if (chosenCourt.isPresent()) {
-            chosenCourt.get().setDateTransferred(time.now());
+            Court newCourt = chosenCourt.get().toBuilder()
+                .dateTransferred(time.now())
+                .name("Family Court sitting at " + chosenCourt.get().getName())
+                .build();
             caseData.setPastCourtList(buildPastCourtsList(caseData));
-            caseData.setCourt(chosenCourt.get());
+            caseData.setCourt(newCourt);
             return caseData.getCourt();
         }
         return null;

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ManageLocalAuthoritiesServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ManageLocalAuthoritiesServiceTest.java
@@ -970,7 +970,7 @@ class ManageLocalAuthoritiesServiceTest {
             final Court courtTransferred = underTest.transferCourtWithoutTransferLA(caseData);
 
             assertThat(courtTransferred.getCode()).isEqualTo(newCourt.getCode());
-            assertThat(courtTransferred.getName()).isEqualTo(newCourt.getName());
+            assertThat(courtTransferred.getName()).isEqualTo("Family Court sitting at " + newCourt.getName());
             assertThat(courtTransferred.getDateTransferred()).isEqualTo(
                 LocalDateTime.of(1997, Month.JULY, 1, 11, 00));
             assertThat(caseData.getPastCourtList()).hasSize(1);


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
 - Fix small bug noticed in WA demo testing - on transfer to court, the court name just becomes the name of the town/city/etc, rather than 'Family Court sitting at Barnet' for example
 - _Matches the court name during the ordersSought event_
 - Likely a temp fix until we can refactor the court logic completely!


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
