### PR TITLE
DFPL-1572: Remove blocker on Cafcass notifications for newly submitted standalones

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/SubmittedCaseEventHandler.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/SubmittedCaseEventHandler.java
@@ -83,14 +83,9 @@ public class SubmittedCaseEventHandler {
     public void notifyCafcass(final SubmittedCaseEvent event) {
         CaseData caseData = event.getCaseData();
 
-        if (!caseData.getRepresentativeType().equals(RepresentativeType.LOCAL_AUTHORITY)) {
-            log.info("Application has been made as a non-LA, skipping Cafcass notification.");
-            return;
-        }
-
         if (CafcassHelper.isNotifyingCafcassWelsh(caseData, cafcassLookupConfiguration)) {
             Optional<String> recipientIsWelsh = cafcassLookupConfiguration.getCafcassWelsh(caseData
-                .getCaseLocalAuthority()).map(CafcassLookupConfiguration.Cafcass::getEmail);
+                .getCaseLaOrRelatingLa()).map(CafcassLookupConfiguration.Cafcass::getEmail);
             if (recipientIsWelsh.isPresent()) {
                 NotifyData notifyData = cafcassEmailContentProvider.buildCafcassSubmissionNotification(caseData);
                 notificationService.sendEmail(CAFCASS_SUBMISSION_TEMPLATE, recipientIsWelsh.get(),
@@ -103,11 +98,6 @@ public class SubmittedCaseEventHandler {
     @EventListener
     public void notifyCafcassSendGrid(final SubmittedCaseEvent event) {
         CaseData caseData = event.getCaseData();
-
-        if (!caseData.getRepresentativeType().equals(RepresentativeType.LOCAL_AUTHORITY)) {
-            log.info("Application has been made as a non-LA, skipping Cafcass notification.");
-            return;
-        }
 
         if (CafcassHelper.isNotifyingCafcassEngland(caseData, cafcassLookupConfiguration)) {
             Set<DocumentReference> documentReferences = Optional.ofNullable(caseData.getC110A().getSubmittedForm())

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/SubmittedCaseEventHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/SubmittedCaseEventHandlerTest.java
@@ -12,7 +12,6 @@ import uk.gov.hmcts.reform.fnp.exception.RetryablePaymentException;
 import uk.gov.hmcts.reform.fpl.config.CafcassLookupConfiguration;
 import uk.gov.hmcts.reform.fpl.config.CafcassLookupConfiguration.Cafcass;
 import uk.gov.hmcts.reform.fpl.enums.LanguageTranslationRequirement;
-import uk.gov.hmcts.reform.fpl.enums.RepresentativeType;
 import uk.gov.hmcts.reform.fpl.events.FailedPBAPaymentEvent;
 import uk.gov.hmcts.reform.fpl.events.SubmittedCaseEvent;
 import uk.gov.hmcts.reform.fpl.model.CaseData;

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/SubmittedCaseEventHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/SubmittedCaseEventHandlerTest.java
@@ -117,8 +117,6 @@ class SubmittedCaseEventHandlerTest {
         final SubmitCaseCafcassTemplate parameters = mock(SubmitCaseCafcassTemplate.class);
 
         when(caseData.getCaseLaOrRelatingLa()).thenReturn(LOCAL_AUTHORITY_CODE);
-        when(caseData.getCaseLocalAuthority()).thenReturn(LOCAL_AUTHORITY_CODE);
-        when(caseData.getRepresentativeType()).thenReturn(RepresentativeType.LOCAL_AUTHORITY);
         when(caseData.getId()).thenReturn(CASE_ID);
         when(cafcassLookupConfiguration.getCafcassWelsh(LOCAL_AUTHORITY_CODE))
             .thenReturn(Optional.of(new Cafcass(LOCAL_AUTHORITY_CODE, EMAIL)));
@@ -147,7 +145,6 @@ class SubmittedCaseEventHandlerTest {
         when(caseData.getC110A()).thenReturn(c110A);
         when(cafcassLookupConfiguration.getCafcassEngland(LOCAL_AUTHORITY_CODE))
                 .thenReturn(Optional.of(new Cafcass(LOCAL_AUTHORITY_CODE, EMAIL)));
-        when(caseData.getRepresentativeType()).thenReturn(RepresentativeType.LOCAL_AUTHORITY);
 
         submittedCaseEventHandler.notifyCafcassSendGrid(new SubmittedCaseEvent(caseData, caseDataBefore));
 
@@ -165,8 +162,6 @@ class SubmittedCaseEventHandlerTest {
                 .build();
 
         final NewApplicationCafcassData parameters = mock(NewApplicationCafcassData.class);
-
-        when(caseData.getRepresentativeType()).thenReturn(RepresentativeType.CHILD_SOLICITOR);
 
         submittedCaseEventHandler.notifyCafcassSendGrid(new SubmittedCaseEvent(caseData, caseDataBefore));
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-1572


### Change description ###
 - Seems to be a block on sending notifications to Cafcass for standalone apps leftover from before we added the `relatingLA` field, which can (is) used to distinguish which regional office to send notifications to.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
