### PR TITLE
DFPL-1529 SDO created but venue didn't pull though to the order

### DIFF
--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ManageHearingsControllerSubmittedTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ManageHearingsControllerSubmittedTest.java
@@ -241,7 +241,7 @@ class ManageHearingsControllerSubmittedTest extends ManageHearingsControllerTest
             eq(CASE_ID),
             eq("populateSDO"));
 
-        verify(concurrencyHelper, times(2)).submitEvent(
+        verify(concurrencyHelper, timeout(ASYNC_METHOD_CALL_TIMEOUT).times(2)).submitEvent(
             any(),
             eq(CASE_ID),
             anyMap());
@@ -252,7 +252,7 @@ class ManageHearingsControllerSubmittedTest extends ManageHearingsControllerTest
             eq(CASE_ID),
             eq("internal-update-case-summary"));
 
-        verify(concurrencyHelper).submitEvent(
+        verify(concurrencyHelper, timeout(ASYNC_METHOD_CALL_TIMEOUT)).submitEvent(
             any(),
             eq(CASE_ID),
             eq(caseSummary("Yes", "Case management", LocalDate.of(2050, 5, 20))));

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/CaseDataExtractionService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/CaseDataExtractionService.java
@@ -41,6 +41,7 @@ import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.trim;
 import static uk.gov.hmcts.reform.fpl.enums.HearingDuration.DAYS;
+import static uk.gov.hmcts.reform.fpl.enums.YesNo.YES;
 import static uk.gov.hmcts.reform.fpl.model.configuration.Display.Due.BY;
 import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.DATE_TIME;
 import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.TIME_DATE;
@@ -213,6 +214,11 @@ public class CaseDataExtractionService {
     }
 
     private String buildHearingVenue(HearingBooking hearing) {
+        if (hearing != null && hearing.getPreviousHearingVenue() != null
+            && YES.getValue().equals(hearing.getPreviousHearingVenue().getUsePreviousVenue())){
+            String venueAddress = hearing.getPreviousHearingVenue().getPreviousVenue();
+            return (hearing.isRemote()) ? String.format(REMOTE_HEARING_VENUE, venueAddress) : venueAddress;
+        }
         HearingVenue venue = hearingVenueLookUpService.getHearingVenue(hearing);
         if (venue.getAddress() != null) {
             String venueAddress = hearingVenueLookUpService.buildHearingVenue(venue);

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/CaseDataExtractionService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/CaseDataExtractionService.java
@@ -109,7 +109,9 @@ public class CaseDataExtractionService {
         if (ObjectUtils.isNotEmpty(caseData.getLocalAuthorities())) {
             return ofNullable(caseData.getDesignatedLocalAuthority())
                 .map(LocalAuthority::getName)
-                .orElse("");
+                .orElse(ofNullable(caseData.getLocalAuthorities().get(0))
+                    .map(Element::getValue)
+                    .map(LocalAuthority::getName).orElse(""));
         }
 
         return ofNullable(caseData.getAllApplicants().get(0).getValue().getParty())

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/CaseDataExtractionService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/CaseDataExtractionService.java
@@ -217,7 +217,7 @@ public class CaseDataExtractionService {
         if (hearing.getPreviousHearingVenue() != null
             && YES.getValue().equals(hearing.getPreviousHearingVenue().getUsePreviousVenue())) {
             String venueAddress = hearing.getPreviousHearingVenue().getPreviousVenue();
-            return (hearing.isRemote()) ? String.format(REMOTE_HEARING_VENUE, venueAddress) : venueAddress;
+            return hearing.isRemote() ? format(REMOTE_HEARING_VENUE, venueAddress) : venueAddress;
         }
         HearingVenue venue = hearingVenueLookUpService.getHearingVenue(hearing);
         if (venue.getAddress() != null) {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/CaseDataExtractionService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/CaseDataExtractionService.java
@@ -215,7 +215,7 @@ public class CaseDataExtractionService {
 
     private String buildHearingVenue(HearingBooking hearing) {
         if (hearing != null && hearing.getPreviousHearingVenue() != null
-            && YES.getValue().equals(hearing.getPreviousHearingVenue().getUsePreviousVenue())){
+            && YES.getValue().equals(hearing.getPreviousHearingVenue().getUsePreviousVenue())) {
             String venueAddress = hearing.getPreviousHearingVenue().getPreviousVenue();
             return (hearing.isRemote()) ? String.format(REMOTE_HEARING_VENUE, venueAddress) : venueAddress;
         }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/CaseDataExtractionService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/CaseDataExtractionService.java
@@ -214,7 +214,7 @@ public class CaseDataExtractionService {
     }
 
     private String buildHearingVenue(HearingBooking hearing) {
-        if (hearing != null && hearing.getPreviousHearingVenue() != null
+        if (hearing.getPreviousHearingVenue() != null
             && YES.getValue().equals(hearing.getPreviousHearingVenue().getUsePreviousVenue())) {
             String venueAddress = hearing.getPreviousHearingVenue().getPreviousVenue();
             return (hearing.isRemote()) ? String.format(REMOTE_HEARING_VENUE, venueAddress) : venueAddress;

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/CaseDataExtractionServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/CaseDataExtractionServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.fpl.enums.DirectionAssignee;
+import uk.gov.hmcts.reform.fpl.enums.OrderType;
 import uk.gov.hmcts.reform.fpl.enums.hearing.HearingAttendance;
 import uk.gov.hmcts.reform.fpl.model.Address;
 import uk.gov.hmcts.reform.fpl.model.Applicant;
@@ -23,6 +24,7 @@ import uk.gov.hmcts.reform.fpl.model.ChildParty;
 import uk.gov.hmcts.reform.fpl.model.Direction;
 import uk.gov.hmcts.reform.fpl.model.HearingBooking;
 import uk.gov.hmcts.reform.fpl.model.LocalAuthority;
+import uk.gov.hmcts.reform.fpl.model.Orders;
 import uk.gov.hmcts.reform.fpl.model.PreviousHearingVenue;
 import uk.gov.hmcts.reform.fpl.model.Respondent;
 import uk.gov.hmcts.reform.fpl.model.RespondentParty;
@@ -224,6 +226,30 @@ class CaseDataExtractionServiceTest {
                 .build();
 
             assertThat(service.getApplicantName(caseData)).isEqualTo(StringUtils.EMPTY);
+        }
+
+        @Test
+        void shouldGetApplicantNameIfC1ApplicationAndApplicantIsNotLA() {
+
+            final LocalAuthority solicitorApplicant = LocalAuthority.builder()
+                .designated("No")
+                .name("Private Solicitor")
+                .build();
+
+            final LocalAuthority localAuthority = LocalAuthority.builder()
+                .designated("NO")
+                .name("Local authority organisation")
+                .build();
+
+            final CaseData caseData = CaseData.builder()
+                .orders(Orders.builder().orderType(List.of(OrderType.CONTACT_WITH_CHILD_IN_CARE)).build())
+                .localAuthorities(wrapElements(solicitorApplicant, localAuthority))
+                .applicants(wrapElements(Applicant.builder()
+                    .party(ApplicantParty.builder().organisationName("Applicant organisation").build())
+                    .build()))
+                .build();
+
+            assertThat(service.getApplicantName(caseData)).isEqualTo("Private Solicitor");
         }
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-1529


### Change description ###
Step to reproduce:

1. Goto "Judicial Gatekeeping" event and create a gatekeeping order
2. Goto "Manage Hearing" event and add a new hearing (any court except Other)
3. Goto "List gatekeeping hearing" event
4. "Use this court for this hearing?", select "Yes"
5.  Input hearing date earlier than any hearing in the case ([DFPL-1531](https://tools.hmcts.net/jira/browse/DFPL-1531))
6. submit, then goto "Order" tab
7. the hearing venue of the SDO is empty


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
