### PR TITLE
DFPL-1533: Remove generic solicitor IDAM role from accessing non-LA event

### DIFF
--- a/ccd-definition/AuthorisationCaseEvent/CareSupervision/AuthorisationCaseEvent.json
+++ b/ccd-definition/AuthorisationCaseEvent/CareSupervision/AuthorisationCaseEvent.json
@@ -1411,14 +1411,14 @@
           "[CHILDSOLICITORA]", "[CHILDSOLICITORB]", "[CHILDSOLICITORC]", "[CHILDSOLICITORD]",
           "[CHILDSOLICITORE]", "[CHILDSOLICITORF]", "[CHILDSOLICITORG]", "[CHILDSOLICITORH]",
           "[CHILDSOLICITORI]", "[CHILDSOLICITORJ]", "[CHILDSOLICITORK]", "[CHILDSOLICITORL]",
-          "[CHILDSOLICITORM]", "[CHILDSOLICITORN]", "[CHILDSOLICITORO]", "caseworker-publiclaw-solicitor"
+          "[CHILDSOLICITORM]", "[CHILDSOLICITORN]", "[CHILDSOLICITORO]"
         ],
         "CRUD": "CR"
       },
       {
         "UserRoles": [
           "caseworker-publiclaw-courtadmin", "caseworker-publiclaw-gatekeeper",
-          "caseworker-publiclaw-judiciary", "caseworker-publiclaw-magistrate"
+          "caseworker-publiclaw-judiciary", "caseworker-publiclaw-magistrate", "caseworker-publiclaw-solicitor"
         ],
         "CRUD": "R"
       }

--- a/ccd-definition/AuthorisationCaseEvent/CareSupervision/AuthorisationCaseEvent.json
+++ b/ccd-definition/AuthorisationCaseEvent/CareSupervision/AuthorisationCaseEvent.json
@@ -54,10 +54,15 @@
           "[LAMANAGING]",
           "[LASHARED]",
           "[SOLICITORA]",
-          "[CHILDSOLICITORA]",
-          "caseworker-publiclaw-solicitor"
+          "[CHILDSOLICITORA]"
         ],
         "CRUD": "CR"
+      },
+      {
+        "UserRoles": [
+          "caseworker-publiclaw-solicitor"
+        ],
+        "CRUD": "R"
       }
     ]
   },
@@ -227,10 +232,15 @@
           "[LAMANAGING]",
           "[LASHARED]",
           "[SOLICITORA]",
-          "[CHILDSOLICITORA]",
-          "caseworker-publiclaw-solicitor"
+          "[CHILDSOLICITORA]"
         ],
         "CRUD": "CR"
+      },
+      {
+        "UserRoles": [
+          "caseworker-publiclaw-solicitor"
+        ],
+        "CRUD": "R"
       }
     ]
   },
@@ -1709,7 +1719,7 @@
           "[CHILDSOLICITORA]", "[CHILDSOLICITORB]", "[CHILDSOLICITORC]", "[CHILDSOLICITORD]",
           "[CHILDSOLICITORE]", "[CHILDSOLICITORF]", "[CHILDSOLICITORG]", "[CHILDSOLICITORH]",
           "[CHILDSOLICITORI]", "[CHILDSOLICITORJ]", "[CHILDSOLICITORK]", "[CHILDSOLICITORL]",
-          "[CHILDSOLICITORM]", "[CHILDSOLICITORN]", "[CHILDSOLICITORO]", "caseworker-publiclaw-solicitor"
+          "[CHILDSOLICITORM]", "[CHILDSOLICITORN]", "[CHILDSOLICITORO]"
         ],
         "CRUD": "CR"
       }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-1533


### Change description ###
 - Removing incorrectly added IDAM permission from a respondent/child solicitor only event, so that the LAs stop seeing it and confusing it with their version of the flow.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
