### PR TITLE
DFPL-1379: Add AppInsights connection string to terraform

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -38,6 +38,12 @@ resource "azurerm_key_vault_secret" "AZURE_APPINSGHTS_KEY" {
   key_vault_id = module.key-vault.key_vault_id
 }
 
+resource "azurerm_key_vault_secret" "AZURE_KEY_VAULT_SECRET" {
+  name         = "app-insights-connection-string"
+  value        = azurerm_application_insights.appinsights.connection_string
+  key_vault_id = module.key-vault.key_vault_id
+}
+
 module "key-vault" {
   source                  = "git@github.com:hmcts/cnp-module-key-vault?ref=master"
   name                    = "fpl-${var.env}"


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DFPL-1379

PR to only stage the connection string key in the vault before the actual upgrade

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
