### PR TITLE
Remove e2e tests from PR pipeline for FPL

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -9,8 +9,6 @@ def type = "java"
 def product = "fpl"
 def component = "case-service"
 
-// def yarnBuilder = new uk.gov.hmcts.contino.YarnBuilder(this)
-
 AppPipelineConfig pipelineConf;
 
 def serviceSecrets = [
@@ -192,17 +190,11 @@ withPipeline(type, product, component) {
   }
 
   before('smoketest:saat') {
-//    yarnBuilder.yarn('yarn-update')
-//    yarnBuilder.yarn('install-dependencies')
-//    yarnBuilder.yarn('lint-ui-tests')
     env.URL = "https://ccd-case-management-web-saat.service.core-compute-saat.internal"
     archiveCoreCaseDataDefinitions('saat')
   }
 
   before('smoketest:preview') {
-//    yarnBuilder.yarn('yarn-update')
-//    yarnBuilder.yarn('install-dependencies')
-//    yarnBuilder.yarn('lint-ui-tests')
     sh """
       eval \$(./bin/variables/load-preview-environment-variables.sh ${CHANGE_ID})
       ./fpla-docker/bin/add-roles.sh
@@ -285,9 +277,6 @@ withPipeline(type, product, component) {
   }
 
   before('smoketest:aat') {
-    yarnBuilder.yarn('yarn-update')
-    yarnBuilder.yarn('install-dependencies')
-    yarnBuilder.yarn('lint-ui-tests')
     env.URL = "https://manage-case.aat.platform.hmcts.net"
     env.TEST_CONF_FPL_URL = "https://fpl-case-service-staging.aat.platform.hmcts.net"
   }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -9,7 +9,7 @@ def type = "java"
 def product = "fpl"
 def component = "case-service"
 
-def yarnBuilder = new uk.gov.hmcts.contino.YarnBuilder(this)
+// def yarnBuilder = new uk.gov.hmcts.contino.YarnBuilder(this)
 
 AppPipelineConfig pipelineConf;
 
@@ -192,17 +192,17 @@ withPipeline(type, product, component) {
   }
 
   before('smoketest:saat') {
-    yarnBuilder.yarn('yarn-update')
-    yarnBuilder.yarn('install-dependencies')
-    yarnBuilder.yarn('lint-ui-tests')
+//    yarnBuilder.yarn('yarn-update')
+//    yarnBuilder.yarn('install-dependencies')
+//    yarnBuilder.yarn('lint-ui-tests')
     env.URL = "https://ccd-case-management-web-saat.service.core-compute-saat.internal"
     archiveCoreCaseDataDefinitions('saat')
   }
 
   before('smoketest:preview') {
-    yarnBuilder.yarn('yarn-update')
-    yarnBuilder.yarn('install-dependencies')
-    yarnBuilder.yarn('lint-ui-tests')
+//    yarnBuilder.yarn('yarn-update')
+//    yarnBuilder.yarn('install-dependencies')
+//    yarnBuilder.yarn('lint-ui-tests')
     sh """
       eval \$(./bin/variables/load-preview-environment-variables.sh ${CHANGE_ID})
       ./fpla-docker/bin/add-roles.sh

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -268,20 +268,20 @@ withPipeline(type, product, component) {
     // all the AAT tasks in the master pipeline finished, so we update the env variable to promote to prod tasks
   }
 
-  before('functionalTest:preview') {
-    yarnBuilder.yarn('yarn-update')
-    yarnBuilder.yarn('install-dependencies')
-    yarnBuilder.yarn('lint-ui-tests')
-  }
-
-  afterSuccess('functionalTest:preview') {
-    env.PARALLEL_CHUNKS = 12
-    yarnBuilder.yarn('test:functional')
-    steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'output/**/*'
-    steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'build/reports/tests/**/*'
-    steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'build/reports/serenity/**/*'
-    steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'test-results/functional/**/*'
-  }
+//  before('functionalTest:preview') {
+//    yarnBuilder.yarn('yarn-update')
+//    yarnBuilder.yarn('install-dependencies')
+//    yarnBuilder.yarn('lint-ui-tests')
+//  }
+//
+//  afterSuccess('functionalTest:preview') {
+//    env.PARALLEL_CHUNKS = 12
+//    yarnBuilder.yarn('test:functional')
+//    steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'output/**/*'
+//    steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'build/reports/tests/**/*'
+//    steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'build/reports/serenity/**/*'
+//    steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'test-results/functional/**/*'
+//  }
 
   afterAlways('highleveldatasetup') {
     if (env.ENV != 'preview') {

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -268,21 +268,6 @@ withPipeline(type, product, component) {
     // all the AAT tasks in the master pipeline finished, so we update the env variable to promote to prod tasks
   }
 
-//  before('functionalTest:preview') {
-//    yarnBuilder.yarn('yarn-update')
-//    yarnBuilder.yarn('install-dependencies')
-//    yarnBuilder.yarn('lint-ui-tests')
-//  }
-//
-//  afterSuccess('functionalTest:preview') {
-//    env.PARALLEL_CHUNKS = 12
-//    yarnBuilder.yarn('test:functional')
-//    steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'output/**/*'
-//    steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'build/reports/tests/**/*'
-//    steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'build/reports/serenity/**/*'
-//    steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'test-results/functional/**/*'
-//  }
-
   afterAlways('highleveldatasetup') {
     if (env.ENV != 'preview') {
       // For Preview the setup is performed before the smoke test since the environment could be not bootstrapped yet (if the first build or removed the PR helm release)


### PR DESCRIPTION
### Change description ###
The end to end tests are overkill. They only assert UI behaviour which is owned by XUI. Running it against every PR is too much. These should be running in the nightly pipeline only.

### JIRA link (if applicable) ###
N/A


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
