### PR TITLE
Allow renovate to automerge PRs with these files in them

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,3 +11,6 @@ infrastructure/state.tf
 .github/workflows/*.yaml
 package.json
 yarn.lock
+.nvmrc
+gradlew
+gradlew.bat


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
PRs were remaining open even though approved and ready to merge. I believe it's because they were missing from the CODEOWNERS file.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
