### PR TITLE
DFPL-1681: Remove CorrespondenceDocument list from case

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -196,10 +196,8 @@ public class MigrateCaseController extends CallbackController {
     private void run1681(CaseDetails caseDetails) {
         var migrationId = "DFPL-1681";
         var possibleCaseIds = List.of(1669737648667050L);
-        UUID expectedDocument = UUID.fromString("438c74f9-9519-4d8f-80fb-d65780a55a8e");
         migrateCaseService.doCaseIdCheckList(caseDetails.getId(), possibleCaseIds, migrationId);
 
-        caseDetails.getData().putAll(migrateCaseService.removeCorrespondenceDocument(getCaseData(caseDetails),
-            migrationId, expectedDocument));
+        caseDetails.getData().remove("correspondenceDocumentsNC");
     }
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DFPL-1681

Clear CorrespondenceDocumentNC from case after issue with migration

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
