### PR TITLE
DFPL-1561: Extract out code to load judges/legal-advisers + setup AM …

### DIFF
--- a/ccd-definition/AuthorisationCaseField/CareSupervision/ras-validation.json
+++ b/ccd-definition/AuthorisationCaseField/CareSupervision/ras-validation.json
@@ -1,0 +1,16 @@
+[
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseFieldID": "familyManCaseNumber",
+    "UserRole": "caseworker-ras-validation",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseFieldID": "caseManagementLocation",
+    "UserRole": "caseworker-ras-validation",
+    "CRUD": "R"
+  }
+]

--- a/ccd-definition/AuthorisationCaseState/CareSupervision/AuthorisationCaseState.json
+++ b/ccd-definition/AuthorisationCaseState/CareSupervision/AuthorisationCaseState.json
@@ -7,7 +7,8 @@
       "caseworker-publiclaw-solicitor",
       "caseworker-publiclaw-systemupdate",
       "caseworker-caa",
-      "caseworker-approver"
+      "caseworker-approver",
+      "caseworker-ras-validation"
     ],
     "CRUD": "CRU"
   },
@@ -26,7 +27,8 @@
       "caseworker-publiclaw-bulkscan",
       "caseworker-publiclaw-bulkscansystemupdate",
       "caseworker-caa",
-      "caseworker-approver"
+      "caseworker-approver",
+      "caseworker-ras-validation"
     ],
     "CRUD": "CRU"
   },
@@ -45,7 +47,8 @@
       "caseworker-publiclaw-bulkscan",
       "caseworker-publiclaw-bulkscansystemupdate",
       "caseworker-caa",
-      "caseworker-approver"
+      "caseworker-approver",
+      "caseworker-ras-validation"
     ],
     "CRUD": "CRU"
   },
@@ -64,7 +67,8 @@
       "caseworker-publiclaw-bulkscan",
       "caseworker-publiclaw-bulkscansystemupdate",
       "caseworker-caa",
-      "caseworker-approver"
+      "caseworker-approver",
+      "caseworker-ras-validation"
     ],
     "CRUD": "CRU"
   },
@@ -83,7 +87,8 @@
       "caseworker-publiclaw-magistrate",
       "caseworker-caa",
       "caseworker-approver",
-      "caseworker-publiclaw-cafcass"
+      "caseworker-publiclaw-cafcass",
+      "caseworker-ras-validation"
     ],
     "CRUD": "CRU"
   },
@@ -97,7 +102,8 @@
       "caseworker-publiclaw-systemupdate",
       "caseworker-caa",
       "caseworker-approver",
-      "caseworker-publiclaw-cafcass"
+      "caseworker-publiclaw-cafcass",
+      "caseworker-ras-validation"
     ],
     "CRUD": "CRU"
   },
@@ -116,7 +122,8 @@
       "caseworker-publiclaw-bulkscan",
       "caseworker-publiclaw-bulkscansystemupdate",
       "caseworker-caa",
-      "caseworker-approver"
+      "caseworker-approver",
+      "caseworker-ras-validation"
     ],
     "CRUD": "CRU"
   },
@@ -135,7 +142,8 @@
       "caseworker-publiclaw-bulkscan",
       "caseworker-publiclaw-bulkscansystemupdate",
       "caseworker-caa",
-      "caseworker-approver"
+      "caseworker-approver",
+      "caseworker-ras-validation"
     ],
     "CRUD": "CRU"
   }

--- a/ccd-definition/AuthorisationCaseType/AuthorisationCaseType-nonshuttered.json
+++ b/ccd-definition/AuthorisationCaseType/AuthorisationCaseType-nonshuttered.json
@@ -13,7 +13,8 @@
       "caseworker-publiclaw-bulkscan",
       "caseworker-publiclaw-bulkscansystemupdate",
       "caseworker-caa",
-      "caseworker-approver"
+      "caseworker-approver",
+      "caseworker-ras-validation"
     ],
     "CRUD": "CRU"
   },

--- a/ccd-definition/AuthorisationCaseType/AuthorisationCaseType-shuttered.json
+++ b/ccd-definition/AuthorisationCaseType/AuthorisationCaseType-shuttered.json
@@ -12,7 +12,8 @@
       "caseworker-publiclaw-bulkscan",
       "caseworker-publiclaw-bulkscansystemupdate",
       "caseworker-caa",
-      "caseworker-approver"
+      "caseworker-approver",
+      "caseworker-ras-validation"
     ],
     "CRUD": "D"
   },

--- a/charts/fpl-case-service/values.preview.template.yaml
+++ b/charts/fpl-case-service/values.preview.template.yaml
@@ -28,6 +28,8 @@ java:
     PARENTAL_RESPONSIBILITY_FATHER_KEYWORD: ParentalResponsibChg
     PARENTAL_RESPONSIBILITY_FEMALE_KEYWORD: ParentalResponsibility
     DECLARATION_OF_PARENTAGE: Private
+    RD_STAFF_API_ENABLED: true
+    RD_JUDICIAL_API_ENABLED: true
   keyVaults:
     fpl:
       secrets:

--- a/charts/fpl-case-service/values.yaml
+++ b/charts/fpl-case-service/values.yaml
@@ -26,6 +26,9 @@ java:
     IDAM_API_URL: https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net
     IDAM_S2S_AUTH_URL: http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
     RD_PROFESSIONAL_API_URL: http://rd-professional-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
+    RD_JUDICIAL_API_URL: http://rd-judicial-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
+    RD_STAFF_API_URL: http://rd-caseworker-ref-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
+    AM_ROLE_ASSIGNMENT_API_URL: http://am-role-assignment-service-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
     CORE_CASE_DATA_API_URL: http://ccd-data-store-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
     CASE_ASSIGNMENT_API_URL: http://aac-manage-case-assignment-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
     SEND_LETTER_URL: http://rpe-send-letter-service-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal

--- a/service/src/cftlib/java/uk/gov/hmcts/reform/fpl/CftlibConfig.java
+++ b/service/src/cftlib/java/uk/gov/hmcts/reform/fpl/CftlibConfig.java
@@ -25,7 +25,8 @@ public class CftlibConfig implements CFTLibConfigurer {
             "caseworker-publiclaw-gatekeeper",
             "caseworker-publiclaw-localAuthority",
             "caseworker-publiclaw-courtadmin",
-            "caseworker-caa"
+            "caseworker-caa",
+            "caseworker-ras-validation"
         };
         lib.createRoles(roles);
 

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/TestingSupportControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/TestingSupportControllerTest.java
@@ -30,6 +30,7 @@ import uk.gov.hmcts.reform.document.domain.UploadResponse;
 import uk.gov.hmcts.reform.document.utils.InMemoryMultipartFile;
 import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
 import uk.gov.hmcts.reform.fpl.request.RequestData;
+import uk.gov.hmcts.reform.fpl.service.RoleAssignmentService;
 import uk.gov.hmcts.reform.fpl.service.ccd.CoreCaseDataService;
 import uk.gov.hmcts.reform.fpl.testingsupport.controllers.TestingSupportController;
 import uk.gov.hmcts.reform.fpl.utils.ResourceReader;
@@ -89,6 +90,9 @@ class TestingSupportControllerTest {
 
     @MockBean
     private CaseDocumentClientApi caseDocumentClientApi;
+
+    @MockBean
+    private RoleAssignmentService roleAssignmentService;
 
     @MockBean
     private DocumentUploadClientApi uploadClient;

--- a/service/src/main/java/uk/gov/hmcts/reform/am/client/AmApi.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/am/client/AmApi.java
@@ -1,0 +1,58 @@
+package uk.gov.hmcts.reform.am.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import uk.gov.hmcts.reform.am.model.AssignmentRequest;
+import uk.gov.hmcts.reform.am.model.QueryRequest;
+import uk.gov.hmcts.reform.am.model.QueryResponse;
+import uk.gov.hmcts.reform.am.model.RoleAssignmentRequestResource;
+import uk.gov.hmcts.reform.fpl.config.feign.FeignClientConfiguration;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi.SERVICE_AUTHORIZATION;
+
+@FeignClient(
+    name = "am-role-assignment-api",
+    url = "${am_role_assignment.api.url}",
+    configuration = FeignClientConfiguration.class
+)
+public interface AmApi {
+
+    @PostMapping(
+        value = "/am/role-assignments",
+        consumes = APPLICATION_JSON_VALUE,
+        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
+    )
+    RoleAssignmentRequestResource createRoleAssignment(
+        @RequestHeader(AUTHORIZATION) String authorisation,
+        @RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorization,
+        @RequestBody AssignmentRequest request
+    );
+
+    @PostMapping(
+        value = "/am/role-assignments/query",
+        consumes = APPLICATION_JSON_VALUE,
+        headers = {CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE, "size=50"}
+    )
+    QueryResponse queryRoleAssignments(
+        @RequestHeader(AUTHORIZATION) String authorisation,
+        @RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorization,
+        @RequestBody QueryRequest request
+    );
+
+    @DeleteMapping(
+        value = "/am/role-assignments/{assignmentId}",
+        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
+    )
+    void deleteRoleAssignment(
+        @RequestHeader(AUTHORIZATION) String authorisation,
+        @RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorization,
+        @PathVariable("assignmentId") String assignmentId
+    );
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/am/model/AssignmentRequest.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/am/model/AssignmentRequest.java
@@ -1,0 +1,21 @@
+package uk.gov.hmcts.reform.am.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.jackson.Jacksonized;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@Jacksonized
+@AllArgsConstructor
+public class AssignmentRequest {
+
+    private List<RoleAssignment> requestedRoles;
+    private RoleRequest roleRequest;
+
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/am/model/GrantType.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/am/model/GrantType.java
@@ -1,0 +1,9 @@
+package uk.gov.hmcts.reform.am.model;
+
+public enum GrantType {
+    BASIC,
+    SPECIFIC,
+    STANDARD,
+    CHALLENGED,
+    EXCLUDED
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/am/model/QueryRequest.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/am/model/QueryRequest.java
@@ -1,0 +1,25 @@
+package uk.gov.hmcts.reform.am.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+
+@Data
+@Builder
+public class QueryRequest {
+
+    private List<String> actorId;
+    private Map<String, List<String>> attributes;
+    private List<String> authorisations;
+    private List<String> classification;
+    private List<String> grantType;
+    private List<String> hasAttributes;
+    private boolean readOnly;
+    private List<String> roleCategory;
+    private List<String> roleName;
+    private List<String> roleType;
+    private ZonedDateTime validAt;
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/am/model/QueryResponse.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/am/model/QueryResponse.java
@@ -1,0 +1,18 @@
+package uk.gov.hmcts.reform.am.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class QueryResponse {
+
+    private List<RoleAssignment> roleAssignmentResponse;
+
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/am/model/RoleAssignment.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/am/model/RoleAssignment.java
@@ -1,0 +1,50 @@
+package uk.gov.hmcts.reform.am.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+
+@Data
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@AllArgsConstructor
+public class RoleAssignment {
+
+    private String id;
+
+    @Builder.Default
+    private String actorIdType = "IDAM";
+
+    private Map<String, Object> attributes;
+
+    private List<String> authorisations;
+
+    private List<String> notes;
+
+    private ZonedDateTime beginTime;
+
+    private ZonedDateTime endTime;
+
+    private ZonedDateTime created;
+
+    @Builder.Default
+    private String status = "CREATE_REQUESTED";
+
+    @Builder.Default
+    private String classification = "PUBLIC";
+
+    private String actorId;
+    private GrantType grantType;
+    private RoleCategory roleCategory;
+    private String roleName;
+    private RoleType roleType;
+    private boolean readOnly;
+
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/am/model/RoleAssignmentRequestResource.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/am/model/RoleAssignmentRequestResource.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.reform.am.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RoleAssignmentRequestResource {
+
+    private AssignmentRequest roleAssignmentResponse;
+
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/am/model/RoleCategory.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/am/model/RoleCategory.java
@@ -1,0 +1,12 @@
+package uk.gov.hmcts.reform.am.model;
+
+public enum RoleCategory {
+    JUDICIAL,
+    LEGAL_OPERATIONS,
+    ADMIN,
+    PROFESSIONAL,
+    CITIZEN,
+    SYSTEM,
+    OTHER_GOV_DEPT,
+    CTSC
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/am/model/RoleRequest.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/am/model/RoleRequest.java
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.reform.am.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class RoleRequest {
+
+    private String assignerId;
+
+    @Builder.Default
+    private String process = "fpl-case-service";
+    private String reference;
+
+    @Builder.Default
+    private boolean replaceExisting = false;
+
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/am/model/RoleType.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/am/model/RoleType.java
@@ -1,0 +1,6 @@
+package uk.gov.hmcts.reform.am.model;
+
+public enum RoleType {
+    CASE,
+    ORGANISATION
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/Application.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/Application.java
@@ -14,7 +14,8 @@ import org.springframework.scheduling.annotation.EnableAsync;
     "uk.gov.hmcts.reform.rd.client",
     "uk.gov.hmcts.reform.fnp.client",
     "uk.gov.hmcts.reform.calendar.client",
-    "uk.gov.hmcts.reform.aac.client"
+    "uk.gov.hmcts.reform.aac.client",
+    "uk.gov.hmcts.reform.am.client"
 })
 @ComponentScan
 @EnableRetry

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/config/SystemUserRoleAssignment.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/config/SystemUserRoleAssignment.java
@@ -1,0 +1,30 @@
+package uk.gov.hmcts.reform.fpl.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.fpl.service.RoleAssignmentService;
+
+import javax.annotation.PostConstruct;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+@ConditionalOnProperty(value = "create-system-user-role.enabled", havingValue = "true")
+public class SystemUserRoleAssignment {
+
+    private final RoleAssignmentService roleAssignmentService;
+
+    @PostConstruct
+    public void init() {
+        try {
+            log.info("Attempting to assign system-update user role");
+            roleAssignmentService.assignSystemUserRole();
+            log.info("Assigned role successfully");
+        } catch (Exception e) {
+            log.error("Could not automatically create system user role assignment", e);
+        }
+    }
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/config/rd/JudicialUsersConfiguration.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/config/rd/JudicialUsersConfiguration.java
@@ -32,7 +32,7 @@ public class JudicialUsersConfiguration {
     private final AuthTokenGenerator authTokenGenerator;
     private final JudicialApi judicialApi;
 
-    private final int JUDICIAL_PAGE_SIZE = 3000;
+    private final int judicialPageSize = 3000;
 
 
     public JudicialUsersConfiguration(@Autowired JudicialApi judicialApi,
@@ -60,7 +60,7 @@ public class JudicialUsersConfiguration {
         String systemUserToken = systemUserService.getSysUserToken();
 
         List<JudicialUserProfile> users = judicialApi.findUsers(systemUserToken, authTokenGenerator.generate(),
-            JUDICIAL_PAGE_SIZE,
+            judicialPageSize,
             JudicialUserRequest.builder()
                 .ccdServiceName("PUBLICLAW")
                 .build());

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/config/rd/JudicialUsersConfiguration.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/config/rd/JudicialUsersConfiguration.java
@@ -1,0 +1,78 @@
+package uk.gov.hmcts.reform.fpl.config.rd;
+
+import feign.FeignException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.fpl.service.SystemUserService;
+import uk.gov.hmcts.reform.rd.client.JudicialApi;
+import uk.gov.hmcts.reform.rd.model.JudicialUserProfile;
+import uk.gov.hmcts.reform.rd.model.JudicialUserRequest;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.apache.commons.lang3.ObjectUtils.isEmpty;
+import static uk.gov.hmcts.reform.fpl.service.JudicialService.JUDICIAL_PAGE_SIZE;
+
+@Slf4j
+@Component
+@Configuration
+public class JudicialUsersConfiguration {
+
+    private Map<String, String> mapping;
+
+    private final SystemUserService systemUserService;
+    private final AuthTokenGenerator authTokenGenerator;
+    private final JudicialApi judicialApi;
+
+
+    public JudicialUsersConfiguration(@Autowired JudicialApi judicialApi,
+                                      @Autowired SystemUserService systemUserService,
+                                      @Autowired AuthTokenGenerator authTokenGenerator,
+                                      @Value("${rd_judicial.api.enabled:false}") boolean jrdEnabled) {
+        this.judicialApi = judicialApi;
+        this.systemUserService = systemUserService;
+        this.authTokenGenerator = authTokenGenerator;
+        log.info("Attempting to gather all judges.");
+        if (jrdEnabled) {
+            mapping = this.getAllJudges();
+        } else {
+            mapping = Map.of();
+        }
+        log.info("Loaded {} judges", mapping.size());
+    }
+
+    public Optional<String> getJudgeUUID(String email) {
+        return Optional.ofNullable(mapping.getOrDefault(email.toLowerCase(), null));
+    }
+
+    @Retryable(value = FeignException.class, recover = "recoverFailedJudgeCall", maxAttempts = 5)
+    public Map<String, String> getAllJudges() {
+        String systemUserToken = systemUserService.getSysUserToken();
+
+        List<JudicialUserProfile> users = judicialApi.findUsers(systemUserToken, authTokenGenerator.generate(),
+            JUDICIAL_PAGE_SIZE,
+            JudicialUserRequest.builder()
+                .ccdServiceName("PUBLICLAW")
+                .build());
+
+        return users.stream()
+            .filter(jup -> !isEmpty(jup.getSidamId()))
+            .collect(Collectors.toMap(profile -> profile.getEmailId().toLowerCase(), JudicialUserProfile::getSidamId));
+    }
+
+    @Recover
+    public Map<String, String> recoverFailedJudgeCall(FeignException e) {
+        log.error("Could not download list of publiclaw judiciary from JRD", e);
+        return Map.of();
+    }
+
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/config/rd/JudicialUsersConfiguration.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/config/rd/JudicialUsersConfiguration.java
@@ -44,7 +44,12 @@ public class JudicialUsersConfiguration {
         this.authTokenGenerator = authTokenGenerator;
         log.info("Attempting to gather all judges.");
         if (jrdEnabled) {
-            mapping = this.getAllJudges();
+            try {
+                mapping = this.getAllJudges();
+            } catch (Exception e) {
+                mapping = Map.of();
+                log.error("Could not download list of publiclaw judiciary from JRD", e);
+            }
         } else {
             mapping = Map.of();
         }
@@ -72,7 +77,7 @@ public class JudicialUsersConfiguration {
 
     @Recover
     public Map<String, String> recoverFailedJudgeCall(FeignException e) {
-        log.error("Could not download list of publiclaw judiciary from JRD", e);
+        log.error("Recover - Could not download list of publiclaw judiciary from JRD", e);
         return Map.of();
     }
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/config/rd/JudicialUsersConfiguration.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/config/rd/JudicialUsersConfiguration.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.ObjectUtils.isEmpty;
-import static uk.gov.hmcts.reform.fpl.service.JudicialService.JUDICIAL_PAGE_SIZE;
 
 @Slf4j
 @Component
@@ -32,6 +31,8 @@ public class JudicialUsersConfiguration {
     private final SystemUserService systemUserService;
     private final AuthTokenGenerator authTokenGenerator;
     private final JudicialApi judicialApi;
+
+    private final int JUDICIAL_PAGE_SIZE = 3000;
 
 
     public JudicialUsersConfiguration(@Autowired JudicialApi judicialApi,

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/config/rd/LegalAdviserUsersConfiguration.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/config/rd/LegalAdviserUsersConfiguration.java
@@ -42,7 +42,12 @@ public class LegalAdviserUsersConfiguration {
         this.staffApi = staffApi;
         log.info("Attempting to gather all legal advisers");
         if (staffEnabled) {
-            mapping = this.getAllLegalAdvisers();
+            try {
+                mapping = this.getAllLegalAdvisers();
+            } catch (Exception e) {
+                mapping = Map.of();
+                log.error("Could not download list of publiclaw legal advisers from SRD", e);
+            }
         } else {
             mapping = Map.of();
         }
@@ -66,7 +71,7 @@ public class LegalAdviserUsersConfiguration {
 
     @Recover
     public Map<String, String> recoverFailedLegalAdviserCall(FeignException e) {
-        log.error("Could not download list of publiclaw legal advisers from SRD", e);
+        log.error("Recover - Could not download list of publiclaw legal advisers from SRD", e);
         return Map.of();
     }
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/config/rd/LegalAdviserUsersConfiguration.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/config/rd/LegalAdviserUsersConfiguration.java
@@ -1,0 +1,73 @@
+package uk.gov.hmcts.reform.fpl.config.rd;
+
+import feign.FeignException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.fpl.service.SystemUserService;
+import uk.gov.hmcts.reform.rd.client.StaffApi;
+import uk.gov.hmcts.reform.rd.model.StaffProfile;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+@Configuration
+public class LegalAdviserUsersConfiguration {
+
+    public static final String SERVICE_CODE = "ABA3";
+    private static final String LEGAL_ADVISER_JOB_CODE = "3";
+    private static final int STAFF_PAGE_SIZE = 1000;
+
+    private Map<String, String> mapping;
+
+    private final SystemUserService systemUserService;
+    private final AuthTokenGenerator authTokenGenerator;
+    private final StaffApi staffApi;
+
+    public LegalAdviserUsersConfiguration(@Autowired SystemUserService systemUserService,
+                                          @Autowired AuthTokenGenerator authTokenGenerator,
+                                          @Autowired StaffApi staffApi,
+                                          @Value("${rd_staff.api.enabled:false}") boolean staffEnabled) {
+        this.systemUserService = systemUserService;
+        this.authTokenGenerator = authTokenGenerator;
+        this.staffApi = staffApi;
+        log.info("Attempting to gather all legal advisers");
+        if (staffEnabled) {
+            mapping = this.getAllLegalAdvisers();
+        } else {
+            mapping = Map.of();
+        }
+        log.info("Loaded {} legal advisers", mapping.size());
+    }
+
+    public Optional<String> getLegalAdviserUUID(String email) {
+        return Optional.ofNullable(mapping.getOrDefault(email.toLowerCase(), null));
+    }
+
+    @Retryable(value = FeignException.class, recover = "recoverFailedLegalAdviserCall", maxAttempts = 5)
+    public Map<String, String> getAllLegalAdvisers() {
+        String systemUserToken = systemUserService.getSysUserToken();
+
+        List<StaffProfile> staff = staffApi.getAllStaffResponseDetails(systemUserToken, authTokenGenerator.generate(),
+            STAFF_PAGE_SIZE, SERVICE_CODE, LEGAL_ADVISER_JOB_CODE);
+
+        return staff.stream()
+            .collect(Collectors.toMap(profile -> profile.getEmailId().toLowerCase(), StaffProfile::getCaseWorkerId));
+    }
+
+    @Recover
+    public Map<String, String> recoverFailedLegalAdviserCall(FeignException e) {
+        log.error("Could not download list of publiclaw legal advisers from SRD", e);
+        return Map.of();
+    }
+
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/RoleAssignmentService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/RoleAssignmentService.java
@@ -1,0 +1,62 @@
+package uk.gov.hmcts.reform.fpl.service;
+
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.am.client.AmApi;
+import uk.gov.hmcts.reform.am.model.AssignmentRequest;
+import uk.gov.hmcts.reform.am.model.GrantType;
+import uk.gov.hmcts.reform.am.model.RoleAssignment;
+import uk.gov.hmcts.reform.am.model.RoleCategory;
+import uk.gov.hmcts.reform.am.model.RoleRequest;
+import uk.gov.hmcts.reform.am.model.RoleType;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+
+import java.util.List;
+import java.util.Map;
+
+import static uk.gov.hmcts.reform.fpl.CaseDefinitionConstants.JURISDICTION;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+public class RoleAssignmentService {
+
+    private final AmApi amApi;
+    private final SystemUserService systemUserService;
+    private final AuthTokenGenerator authTokenGenerator;
+
+    /**
+     * Create the role assignment for our system-update user.
+     * This role can be recreated, but is likely to not be necessary. This call should be executed on startup based on
+     * an environment variable.
+     * This matches a pre-defined specification with AM, and if changes are needed, the drool rule on their side will
+     * need updating too for the request to be successful.
+     */
+    @Retryable(value = {FeignException.class}, label = "Create system-user role assignment")
+    public void assignSystemUserRole() {
+        String systemUserToken = systemUserService.getSysUserToken();
+        amApi.createRoleAssignment(systemUserToken, authTokenGenerator.generate(), AssignmentRequest.builder()
+            .requestedRoles(List.of(RoleAssignment.builder()
+                .actorId(systemUserService.getUserId(systemUserToken))
+                .roleType(RoleType.ORGANISATION)
+                .classification("PUBLIC")
+                .grantType(GrantType.STANDARD)
+                .roleCategory(RoleCategory.SYSTEM)
+                .roleName("case-allocator")
+                .attributes(Map.of("jurisdiction", JURISDICTION, "primaryLocation", "UK"))
+                .readOnly(false)
+                .build()))
+            .roleRequest(RoleRequest.builder()
+                .assignerId(systemUserService.getUserId(systemUserToken))
+                .reference("public-law-case-allocator-system-user")
+                .process("public-law-system-users")
+                .replaceExisting(true)
+                .build())
+            .build());
+    }
+
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/testingsupport/controllers/TestingSupportController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/testingsupport/controllers/TestingSupportController.java
@@ -33,6 +33,7 @@ import uk.gov.hmcts.reform.fpl.enums.docmosis.RenderFormat;
 import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
 import uk.gov.hmcts.reform.fpl.request.RequestData;
 import uk.gov.hmcts.reform.fpl.service.DocumentDownloadService;
+import uk.gov.hmcts.reform.fpl.service.RoleAssignmentService;
 import uk.gov.hmcts.reform.fpl.service.UploadDocumentService;
 import uk.gov.hmcts.reform.fpl.service.ccd.CoreCaseDataService;
 import uk.gov.hmcts.reform.fpl.utils.ResourceReader;
@@ -64,6 +65,7 @@ public class TestingSupportController {
     private static final String POPULATE_EVENT_ID_TEMPLATE = "populateCase-%s";
 
     private final IdamClient idamClient;
+    private final RoleAssignmentService roleAssignmentService;
     private final RequestData requestData;
     private final AuthTokenGenerator authToken;
 
@@ -205,4 +207,10 @@ public class TestingSupportController {
 
         return reference;
     }
+
+    @GetMapping("/testing-support/assign-system-role")
+    public void assignSystemUserRole() {
+        roleAssignmentService.assignSystemUserRole();
+    }
+
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/utils/RoleAssignmentUtils.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/utils/RoleAssignmentUtils.java
@@ -1,0 +1,49 @@
+package uk.gov.hmcts.reform.fpl.utils;
+
+import uk.gov.hmcts.reform.am.model.GrantType;
+import uk.gov.hmcts.reform.am.model.RoleAssignment;
+import uk.gov.hmcts.reform.am.model.RoleCategory;
+import uk.gov.hmcts.reform.am.model.RoleType;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static uk.gov.hmcts.reform.fpl.CaseDefinitionConstants.CASE_TYPE;
+import static uk.gov.hmcts.reform.fpl.CaseDefinitionConstants.JURISDICTION;
+
+public class RoleAssignmentUtils {
+
+    private RoleAssignmentUtils() {
+
+    }
+
+    public static RoleAssignment buildRoleAssignment(Long caseId, String userId, String role,
+                                              RoleCategory roleCategory, ZonedDateTime beginTime,
+                                              ZonedDateTime endTime) {
+        return RoleAssignment.builder()
+            .actorId(userId)
+            .attributes(Map.of("caseId", caseId.toString(),
+                "caseType", CASE_TYPE,
+                "jurisdiction", JURISDICTION,
+                "substantive", "Y"))
+            .grantType(GrantType.SPECIFIC)
+            .roleCategory(roleCategory)
+            .roleType(RoleType.CASE)
+            .beginTime(beginTime)
+            .endTime(endTime)
+            .roleName(role)
+            .readOnly(false)
+            .build();
+    }
+
+    public static List<RoleAssignment> buildRoleAssignments(Long caseId, List<String> userIds, String role,
+                                                     RoleCategory roleCategory, ZonedDateTime beginTime,
+                                                     ZonedDateTime endTime) {
+        return userIds.stream()
+            .map(user -> buildRoleAssignment(caseId, user, role, roleCategory, beginTime, endTime))
+            .collect(Collectors.toList());
+    }
+
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/rd/client/JudicialApi.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/rd/client/JudicialApi.java
@@ -1,0 +1,31 @@
+package uk.gov.hmcts.reform.rd.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import uk.gov.hmcts.reform.fpl.config.feign.FeignClientConfiguration;
+import uk.gov.hmcts.reform.rd.model.JudicialUserProfile;
+import uk.gov.hmcts.reform.rd.model.JudicialUserRequest;
+
+import java.util.List;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi.SERVICE_AUTHORIZATION;
+
+@FeignClient(
+    name = "rd-judicial-api",
+    url = "${rd_judicial.api.url}",
+    configuration = FeignClientConfiguration.class
+)
+public interface JudicialApi {
+
+    @PostMapping("/refdata/judicial/users")
+    List<JudicialUserProfile> findUsers(
+        @RequestHeader(AUTHORIZATION) String authorisation,
+        @RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorization,
+        @RequestHeader("page_size") int pageSize,
+        @RequestBody JudicialUserRequest request
+    );
+
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/rd/client/StaffApi.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/rd/client/StaffApi.java
@@ -1,0 +1,29 @@
+package uk.gov.hmcts.reform.rd.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import uk.gov.hmcts.reform.fpl.config.feign.FeignClientConfiguration;
+import uk.gov.hmcts.reform.rd.model.StaffProfile;
+
+import java.util.List;
+
+@FeignClient(
+    name = "rd-staff-api",
+    url = "${rd_staff.api.url}",
+    configuration = FeignClientConfiguration.class
+)
+public interface StaffApi {
+
+    @GetMapping(value = "refdata/case-worker/profile/search", consumes = "application/json")
+    List<StaffProfile> getAllStaffResponseDetails(
+        @RequestHeader("Authorization") String authorization,
+        @RequestHeader("ServiceAuthorization") String serviceAuthorization,
+        @RequestHeader("page_size") int pageSize,
+        @RequestParam("serviceCode") String serviceCode,
+        @RequestParam("userType") String jobTitle
+    );
+
+
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/rd/model/JudicialUserProfile.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/rd/model/JudicialUserProfile.java
@@ -1,0 +1,36 @@
+package uk.gov.hmcts.reform.rd.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.jackson.Jacksonized;
+
+@Data
+@Builder
+@NoArgsConstructor
+@Jacksonized
+@AllArgsConstructor
+public class JudicialUserProfile {
+
+    @JsonProperty("sidam_id")
+    private String sidamId;
+
+    @JsonProperty("known_as")
+    private String knownAs;
+
+    private String surname;
+
+    @JsonProperty("full_name")
+    private String fullName;
+
+    @JsonProperty("post_nominals")
+    private String postNominals;
+
+    @JsonProperty("email_id")
+    private String emailId;
+
+    private String personalCode;
+
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/rd/model/JudicialUserRequest.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/rd/model/JudicialUserRequest.java
@@ -1,0 +1,31 @@
+package uk.gov.hmcts.reform.rd.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.jackson.Jacksonized;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@Jacksonized
+@AllArgsConstructor
+public class JudicialUserRequest {
+
+    @JsonProperty("personal_code")
+    private List<String> personalCode;
+
+    @JsonProperty("ccdServiceName")
+    private String ccdServiceName;
+
+    public static JudicialUserRequest fromPersonalCode(String personalCode) {
+        return JudicialUserRequest.builder()
+            .personalCode(List.of(personalCode))
+            .build();
+    }
+
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/rd/model/StaffProfile.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/rd/model/StaffProfile.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.reform.rd.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class StaffProfile {
+
+    @JsonProperty("first_name")
+    private String firstName;
+
+    @JsonProperty("last_name")
+    private String lastName;
+
+    @JsonProperty("user_type")
+    private String userType;
+
+    @JsonProperty("email_id")
+    private String emailId;
+
+    @JsonProperty("case_worker_id")
+    private String caseWorkerId;
+
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/rd/model/StaffResponse.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/rd/model/StaffResponse.java
@@ -1,0 +1,21 @@
+package uk.gov.hmcts.reform.rd.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class StaffResponse {
+
+    @JsonProperty("ccd_service_name")
+    private String ccdServiceName;
+
+    @JsonProperty(value = "staff_profile")
+    private StaffProfile staffProfile;
+
+}

--- a/service/src/main/resources/application-local.yaml
+++ b/service/src/main/resources/application-local.yaml
@@ -68,16 +68,30 @@ rd_professional:
   api:
     url: ${RD_PROFESSIONAL_API_URL:http://localhost:8765}
 
+rd_judicial:
+  api:
+    enabled: false
+    url: ${RD_JUDICIAL_API_URL:http://localhost:8765}
+
+rd_staff:
+  api:
+    enabled: false
+    url: ${RD_STAFF_API_URL:http://localhost:8765}
+
+am_role_assignment:
+  api:
+    url: ${AM_API_URL:http://localhost:4096}
+
 fees-register:
   api:
-    url: http://localhost:8765
+    url: ${FEES_REGISTER_API_URL:http://localhost:8765}
 
 send-letter:
   url: http://localhost:8765
 
 payment:
   api:
-    url: http://localhost:8765
+    url: ${PAYMENT_API_URL:http://localhost:8765}
 
 manage-case:
   ui:

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -332,3 +332,14 @@ contacts:
   passport_office:
     address: 'Glasgow CPST, HMPO Glasgow, 96 Milton Street, Glasgow, G4 0BT'
     email: 'Glasgowcaveats@hmpo.gov.uk'
+
+create-system-user-role:
+  enabled: ${CREATE_SYSTEM_USER_ROLE:false}
+
+rd_staff:
+  api:
+    enabled: ${RD_STAFF_API_ENABLED:false}
+
+rd_judicial:
+  api:
+    enabled: ${RD_JUDICIAL_API_ENABLED:false}

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/config/SystemUserRoleAssignmentTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/config/SystemUserRoleAssignmentTest.java
@@ -1,0 +1,26 @@
+package uk.gov.hmcts.reform.fpl.config;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.reform.fpl.service.RoleAssignmentService;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(SpringExtension.class)
+class SystemUserRoleAssignmentTest {
+
+    @Mock
+    private RoleAssignmentService roleAssignmentService;
+
+    @Test
+    void shouldAttemptToCreateSystemUpdateRole() {
+        SystemUserRoleAssignment underTest = new SystemUserRoleAssignment(roleAssignmentService);
+
+        underTest.init();
+
+        verify(roleAssignmentService).assignSystemUserRole();
+    }
+
+}

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/config/rd/JudicialUsersConfigurationTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/config/rd/JudicialUsersConfigurationTest.java
@@ -1,0 +1,69 @@
+package uk.gov.hmcts.reform.fpl.config.rd;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.fpl.service.SystemUserService;
+import uk.gov.hmcts.reform.rd.client.JudicialApi;
+import uk.gov.hmcts.reform.rd.model.JudicialUserProfile;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class JudicialUsersConfigurationTest {
+
+    private static final JudicialUserProfile JUDGE = JudicialUserProfile.builder()
+        .emailId("email@test.com")
+        .sidamId("12345")
+        .build();
+
+    private static final List<JudicialUserProfile> JUPS = List.of(JUDGE);
+
+    @Mock
+    private JudicialApi jrdApi;
+
+    @Mock
+    private SystemUserService systemUserService;
+
+    @Mock
+    private AuthTokenGenerator authTokenGenerator;
+
+    @BeforeEach
+    void beforeEach() {
+        when(systemUserService.getSysUserToken()).thenReturn("token");
+        when(jrdApi.findUsers(any(), any(), anyInt(), any())).thenReturn(JUPS);
+    }
+
+    @Test
+    void shouldGetJudgeUUIDIfInMapping() {
+        JudicialUsersConfiguration config = new JudicialUsersConfiguration(jrdApi, systemUserService,
+            authTokenGenerator, true);
+
+        Optional<String> uuid = config.getJudgeUUID("email@test.com");
+        assertThat(uuid.isPresent()).isTrue();
+        assertThat(uuid.get()).isEqualTo("12345");
+    }
+
+    @Test
+    void shouldGetAllJudges() {
+        JudicialUsersConfiguration config = new JudicialUsersConfiguration(jrdApi, systemUserService,
+            authTokenGenerator, true);
+
+        Map<String, String> judges = config.getAllJudges();
+        assertThat(judges).isEqualTo(Map.of("email@test.com", "12345"));
+
+    }
+}

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/config/rd/LegalAdviserUsersConfigurationTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/config/rd/LegalAdviserUsersConfigurationTest.java
@@ -1,0 +1,69 @@
+package uk.gov.hmcts.reform.fpl.config.rd;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.fpl.service.SystemUserService;
+import uk.gov.hmcts.reform.rd.client.StaffApi;
+import uk.gov.hmcts.reform.rd.model.StaffProfile;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class LegalAdviserUsersConfigurationTest {
+
+    private static final StaffProfile ADVISER = StaffProfile.builder()
+        .emailId("email@test.com")
+        .caseWorkerId("12345")
+        .build();
+
+    private static final List<StaffProfile> STAFF = List.of(ADVISER);
+
+    @Mock
+    private StaffApi staffApi;
+
+    @Mock
+    private SystemUserService systemUserService;
+
+    @Mock
+    private AuthTokenGenerator authTokenGenerator;
+
+    @BeforeEach
+    void beforeEach() {
+        when(systemUserService.getSysUserToken()).thenReturn("token");
+        when(staffApi.getAllStaffResponseDetails(any(), any(), anyInt(), any(), any())).thenReturn(STAFF);
+    }
+
+    @Test
+    void shouldGetJudgeUUIDIfInMapping() {
+        LegalAdviserUsersConfiguration config = new LegalAdviserUsersConfiguration(systemUserService,
+            authTokenGenerator, staffApi, true);
+
+        Optional<String> uuid = config.getLegalAdviserUUID("email@test.com");
+        assertThat(uuid.isPresent()).isTrue();
+        assertThat(uuid.get()).isEqualTo("12345");
+    }
+
+    @Test
+    void shouldGetAllJudges() {
+        LegalAdviserUsersConfiguration config = new LegalAdviserUsersConfiguration(systemUserService,
+            authTokenGenerator, staffApi, true);
+
+        Map<String, String> judges = config.getAllLegalAdvisers();
+        assertThat(judges).isEqualTo(Map.of("email@test.com", "12345"));
+
+    }
+}

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/RoleAssignmentServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/RoleAssignmentServiceTest.java
@@ -1,0 +1,75 @@
+package uk.gov.hmcts.reform.fpl.service;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import uk.gov.hmcts.reform.am.client.AmApi;
+import uk.gov.hmcts.reform.am.model.AssignmentRequest;
+import uk.gov.hmcts.reform.am.model.GrantType;
+import uk.gov.hmcts.reform.am.model.RoleCategory;
+import uk.gov.hmcts.reform.am.model.RoleType;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.quality.Strictness.LENIENT;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = LENIENT)
+class RoleAssignmentServiceTest {
+
+    @Mock
+    private AmApi amApi;
+    @Mock
+    private SystemUserService systemUserService;
+    @Mock
+    private AuthTokenGenerator authTokenGenerator;
+
+    @InjectMocks
+    private RoleAssignmentService underTest;
+
+    @Captor
+    private ArgumentCaptor<AssignmentRequest> assignmentRequestCaptor;
+
+    @Nested
+    class SystemUser {
+
+        @Test
+        void shouldCreateValidSystemUserRoleAssignment() {
+            when(systemUserService.getSysUserToken()).thenReturn("token");
+            when(systemUserService.getUserId("token")).thenReturn("systemUserId");
+
+            underTest.assignSystemUserRole();
+
+            verify(amApi).createRoleAssignment(any(), any(), assignmentRequestCaptor.capture());
+
+            verifyRoleAssignmentRequest(assignmentRequestCaptor.getValue());
+        }
+
+        private void verifyRoleAssignmentRequest(AssignmentRequest req) {
+            assertThat(req.getRequestedRoles()).hasSize(1);
+            assertThat(req.getRequestedRoles().get(0))
+                .extracting("actorId", "roleType", "roleCategory", "attributes", "roleName",
+                    "grantType", "status")
+                .containsExactly("systemUserId", RoleType.ORGANISATION, RoleCategory.SYSTEM,
+                    Map.of("jurisdiction", "PUBLICLAW", "primaryLocation", "UK"),
+                    "case-allocator", GrantType.STANDARD, "CREATE_REQUESTED");
+
+            assertThat(req.getRoleRequest()).extracting("assignerId", "reference", "replaceExisting",
+                    "process")
+                .containsExactly("systemUserId", "public-law-case-allocator-system-user", true,
+                    "public-law-system-users");
+        }
+    }
+
+}

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/utils/RoleAssignmentUtilsTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/utils/RoleAssignmentUtilsTest.java
@@ -1,0 +1,52 @@
+package uk.gov.hmcts.reform.fpl.utils;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.am.model.GrantType;
+import uk.gov.hmcts.reform.am.model.RoleAssignment;
+import uk.gov.hmcts.reform.am.model.RoleCategory;
+import uk.gov.hmcts.reform.am.model.RoleType;
+
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RoleAssignmentUtilsTest {
+
+    @Nested
+    class BuildAssignments {
+
+        private final ZonedDateTime now = ZonedDateTime.now();
+
+        @Test
+        void shouldBuildRoleAssignmentWithGivenProperties() {
+            RoleAssignment role = RoleAssignmentUtils.buildRoleAssignment(12345L, "userId", "role",
+                RoleCategory.JUDICIAL, now, now);
+
+            role.setCreated(now); // override the default behaviour, as now() is hard to test, millisecond delays!
+
+            RoleAssignment expected = RoleAssignment.builder()
+                .actorId("userId")
+                .attributes(Map.of("caseId", "12345", "caseType", "CARE_SUPERVISION_EPO",
+                    "jurisdiction", "PUBLICLAW", "substantive", "Y"))
+                .grantType(GrantType.SPECIFIC)
+                .roleCategory(RoleCategory.JUDICIAL)
+                .roleType(RoleType.CASE)
+                .beginTime(now)
+                .endTime(now)
+                .roleName("role")
+                .readOnly(false)
+                .actorIdType("IDAM")
+                .created(now)
+                .status("CREATE_REQUESTED")
+                .classification("PUBLIC")
+                .build();
+
+            assertThat(role).isEqualTo(expected);
+
+        }
+
+    }
+
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4887,8 +4887,8 @@ __metadata:
   linkType: hard
 
 "node-fetch@npm:^2.6.12, node-fetch@npm:^2.6.9":
-  version: 2.6.13
-  resolution: "node-fetch@npm:2.6.13"
+  version: 2.7.0
+  resolution: "node-fetch@npm:2.7.0"
   dependencies:
     whatwg-url: ^5.0.0
   peerDependencies:
@@ -4896,7 +4896,7 @@ __metadata:
   peerDependenciesMeta:
     encoding:
       optional: true
-  checksum: 055845ae5b4796c78c7053564745345025cf959563b3568b43c385f67d311779e6b00e5fef6ed1b79f86ba4048e4b4b722e1aa948305521b9353eb7e788912c9
+  checksum: d76d2f5edb451a3f05b15115ec89fc6be39de37c6089f1b6368df03b91e1633fd379a7e01b7ab05089a25034b2023d959b47e59759cb38d88341b2459e89d6e5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-1561

### Change description ###
 - Adds AM, JRD, CRD API integrations
 - Adds (conditional) startup script to download and cache the list of all legal advisers + judges in PUBLICLAW
 - Adds (conditional) startup script to grant our system-update user a `case-allocator` organisational role


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
