### PR TITLE
Re-enable PACT consumer deploy check

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -159,15 +159,13 @@ withPipeline(type, product, component) {
   onMaster() {
     env.ENV = 'aat'
     enablePactAs([AppPipelineDsl.PactRoles.CONSUMER,
-                  // todo re-enable after rd-professional-api publish a new master build
-                  // AppPipelineDsl.PactRoles.CONSUMER_DEPLOY_CHECK
+                   AppPipelineDsl.PactRoles.CONSUMER_DEPLOY_CHECK
     ])
   }
   onPR() {
     env.ENV = 'preview'
     enablePactAs([AppPipelineDsl.PactRoles.CONSUMER,
-                  // todo re-enable after rd-professional-api publish a new master build
-                  // AppPipelineDsl.PactRoles.CONSUMER_DEPLOY_CHECK
+                   AppPipelineDsl.PactRoles.CONSUMER_DEPLOY_CHECK
     ])
   }
   onDemo {


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
 - Re-enables PACT Can I Deploy stage in the pipeline after rd-professional-api have published and verified a new latest pact


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
