### PR TITLE
DFPL-1735: Fix issue with cached placement data

### DIFF
--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/placement/PlacementControllerPostSubmittedTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/placement/PlacementControllerPostSubmittedTest.java
@@ -1,0 +1,41 @@
+package uk.gov.hmcts.reform.fpl.controllers.placement;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.fpl.controllers.AbstractCallbackTest;
+import uk.gov.hmcts.reform.fpl.controllers.PlacementController;
+import uk.gov.hmcts.reform.fpl.model.Placement;
+import static java.util.Map.entry;
+import static java.util.Map.ofEntries;
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.reform.fpl.enums.State.CASE_MANAGEMENT;
+
+@WebMvcTest(PlacementController.class)
+@OverrideAutoConfiguration(enabled = true)
+public class PlacementControllerPostSubmittedTest extends AbstractCallbackTest {
+
+    PlacementControllerPostSubmittedTest()  {
+        super("placement/post-submit-callback");
+    }
+
+    @Test
+    void removeTemporaryFields() {
+
+        CaseDetails caseData = CaseDetails.builder()
+                .id(1234123412341234L)
+                .state(CASE_MANAGEMENT.getLabel())
+                .data(ofEntries(
+                        entry("placement", Placement.builder().childId(UUID.randomUUID()).build()),
+                        entry("placementIdToBeSealed", "")))
+                .build();
+
+        AboutToStartOrSubmitCallbackResponse response = postAboutToSubmitEvent(caseData);
+
+        assertThat(response.getData()).doesNotContainKeys("placement");
+        assertThat(response.getData()).doesNotContainKeys("placementIdToBeSealed");
+    }
+}

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/placementnotice/PlacementNoticeAboutToStartControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/placementnotice/PlacementNoticeAboutToStartControllerTest.java
@@ -62,6 +62,7 @@ class PlacementNoticeAboutToStartControllerTest extends AbstractPlacementNoticeC
 
         assertThat(actualPlacementData.getHasExistingPlacements()).isEqualTo(YES);
         assertThat(actualPlacementData.getPlacements()).isNotEmpty();
+        assertThat(actualPlacementData.getPlacement()).isNull();
     }
 
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/PlacementController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/PlacementController.java
@@ -45,6 +45,11 @@ public class PlacementController extends CallbackController {
     public AboutToStartOrSubmitCallbackResponse handleAboutToStart(@RequestBody CallbackRequest request) {
 
         final CaseDetails caseDetails = request.getCaseDetails();
+
+        /* DFPL-1735.  Working data for a placement is kept in the 'placement' json key.  On some cases
+        this was accidentally stored.  This line removes the key so that a new placement starts afresh. */
+        caseDetails.getData().remove("placement");
+
         final CaseData caseData = getCaseData(caseDetails);
         final CaseDetailsMap caseProperties = CaseDetailsMap.caseDetailsMap(caseDetails);
 
@@ -104,7 +109,9 @@ public class PlacementController extends CallbackController {
         final CaseData caseData = getCaseData(caseDetails);
 
         PlacementEventData eventData = placementService.preparePayment(caseData);
-        caseProperties.put("placement", eventData.getPlacement());
+        /*Todo, remove line if placement not needed for later mid events or submitting.  In testing
+        check that no 'placements' key remains on postgres data following submission.
+        caseProperties.put("placement", eventData.getPlacement());*/
         caseProperties.put("placementPaymentRequired", eventData.getPlacementPaymentRequired());
         caseProperties.put("placementFee", eventData.getPlacementFee());
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/PlacementController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/PlacementController.java
@@ -109,9 +109,7 @@ public class PlacementController extends CallbackController {
         final CaseData caseData = getCaseData(caseDetails);
 
         PlacementEventData eventData = placementService.preparePayment(caseData);
-        /*Todo, remove line if placement not needed for later mid events or submitting.  In testing
-        check that no 'placements' key remains on postgres data following submission.
-        caseProperties.put("placement", eventData.getPlacement());*/
+        caseProperties.put("placement", eventData.getPlacement());
         caseProperties.put("placementPaymentRequired", eventData.getPlacementPaymentRequired());
         caseProperties.put("placementFee", eventData.getPlacementFee());
 
@@ -192,6 +190,7 @@ public class PlacementController extends CallbackController {
         final CaseDetails caseDetails = request.getCaseDetails();
 
         caseDetails.getData().remove("placementIdToBeSealed");
+        caseDetails.getData().remove("placement");
 
         return respond(caseDetails);
     }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/PlacementNoticeController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/PlacementNoticeController.java
@@ -45,6 +45,11 @@ public class PlacementNoticeController extends CallbackController {
     @PostMapping("/about-to-start")
     public AboutToStartOrSubmitCallbackResponse handleAboutToStart(@RequestBody CallbackRequest request) {
         final CaseDetails caseDetails = request.getCaseDetails();
+
+        /* DFPL-1735.  Working data for a placement is kept in the 'placement' json key.  On some cases
+        this was accidentally stored.  This line removes the key so that a new placement starts afresh. */
+        caseDetails.getData().remove("placement");
+
         final CaseData caseData = getCaseData(caseDetails);
         final CaseDetailsMap caseProperties = CaseDetailsMap.caseDetailsMap(caseDetails);
 
@@ -88,7 +93,6 @@ public class PlacementNoticeController extends CallbackController {
 
         final PlacementEventData eventData = placementService.savePlacementNotice(caseData);
 
-        caseDetails.getData().put("placement", eventData.getPlacement());
         caseDetails.getData().put("placements", eventData.getPlacements());
         caseDetails.getData().put("placementsNonConfidential", eventData.getPlacementsNonConfidential(false));
         caseDetails.getData().put("placementsNonConfidentialNotices", eventData.getPlacementsNonConfidential(true));


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DFPL-1735

### Change description ###

Placement event caches data in CCD and when placement notice of hearing
or Placement event runs again, this data is populated for that particular
event and copies the notice event data and application from previously
submitted event into the current event. This PR fixes the issue to make sure
that when event runs, there is no data pre populated from previously submitted
placements.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
