### PR TITLE
DFPL-1750: Removed NTH from AuthorityFixedList.json as no longer valid

### DIFF
--- a/ccd-definition/FixedLists/CareSupervision/AuthorityFixedList.json
+++ b/ccd-definition/FixedLists/CareSupervision/AuthorityFixedList.json
@@ -772,13 +772,6 @@
   {
     "LiveFrom": "01/01/2017",
     "ID": "AuthorityFixedList",
-    "ListElementCode": "NTH",
-    "ListElement": "Northamptonshire County Council",
-    "DisplayOrder": 265
-  },
-  {
-    "LiveFrom": "01/01/2017",
-    "ID": "AuthorityFixedList",
     "ListElementCode": "NHB",
     "ListElement": "Northumberland County Council",
     "DisplayOrder": 267


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DFPL-1750

### Change description ###

Removed NTH from AuthorityFixedList.json as no longer valid.  Northamptonshire Council has been superceded.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
