### PR TITLE
fortify release id change

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -85,7 +85,7 @@ withNightlyPipeline(type, product, component) {
   enableFullFunctionalTest(240)
   // 'microsoft' and 'safari' to be returned to crossbrowser tests once FPLA-3172 improvements are complete
   enableCrossBrowserTest(['chrome', 'firefox'])
-  enableFortifyScan()
+  enableFortifyScan('fpl-aat')
 
 
   //before('mutationTest') {

--- a/service/config/fortify-client.properties
+++ b/service/config/fortify-client.properties
@@ -1,1 +1,1 @@
-fortify.client.releaseId=65536
+fortify.client.releaseId=91417


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DFPL-553

### Change description ###

Changed fortify release id, updated username and password in azure aat vault and pointing nightly build to aat. The default key vault might be aat, so we can think of removing specifying aat once we have fortify scan working. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
