### PR TITLE
bump old Java chart to latest

### DIFF
--- a/charts/fpl-case-service/Chart.yaml
+++ b/charts/fpl-case-service/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
     email: fpl-developers@HMCTS.NET
 dependencies:
   - name: java
-    version: 4.2.0
+    version: 5.0.0
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
   - name: ccd
     version: 8.0.29

--- a/charts/fpl-case-service/Chart.yaml
+++ b/charts/fpl-case-service/Chart.yaml
@@ -1,7 +1,7 @@
 name: fpl-case-service
 apiVersion: v2
 home: https://github.com/hmcts/fpl-ccd-configuration
-version: 1.12.64
+version: 1.12.65
 description: FPL Case Service
 maintainers:
   - name: HMCTS Family Public Law team


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
4.2.0 is marked as deprecated. Moving to 5.0.0 as suggested by Platops.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
