### PR TITLE
DFPL-1838 Cafcass Sendgrid - Keep Pipe Delimiter when no FamilyMan No is added to the case yet

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/cafcass/CafcassNotificationService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/cafcass/CafcassNotificationService.java
@@ -231,7 +231,7 @@ public class CafcassNotificationService {
 
             String subject = String.join(SUBJECT_DELIMITER,
                     oldestChildsLastName,
-                    caseData.getFamilyManCaseNumber(),
+                    Optional.ofNullable(caseData.getFamilyManCaseNumber()).orElse(""),
                     String.valueOf(caseData.getId()),
                     cafcassDocumentMappingType,
                     additionalInfo);

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/cafcass/CafcassNotificationServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/cafcass/CafcassNotificationServiceTest.java
@@ -762,6 +762,43 @@ class CafcassNotificationServiceTest {
                                 largeDocMessage));
     }
 
+    @Test
+    void shouldKeepExtraDelimiterWhenFamilyManNumberIsNotPressented() {
+        when(featureToggleService.isCafcassSubjectCategorised()).thenReturn(true);
+        when(configuration.getRecipientForNewDocument()).thenReturn(RECIPIENT_EMAIL);
+        when(documentDownloadService.downloadDocument(DOCUMENT_BINARY_URL)).thenReturn(
+            DOCUMENT_CONTENT);
+
+        CaseData caseWithoutFamilyManNumber = caseData.toBuilder().familyManCaseNumber(null).build();
+
+        underTest.sendEmail(caseWithoutFamilyManNumber,
+            of(getDocumentReference().toBuilder()
+                .type("Child's Guardian Reports")
+                .build()
+            ),
+            NEW_DOCUMENT,
+            NewDocumentData.builder()
+                .documentTypes("• Application statement")
+                .emailSubjectInfo("Further documents for main application")
+                .build()
+        );
+
+        verify(documentDownloadService).downloadDocument(DOCUMENT_BINARY_URL);
+
+        verify(emailService).sendEmail(eq(SENDER_EMAIL), emailDataArgumentCaptor.capture());
+        EmailData data = emailDataArgumentCaptor.getValue();
+        assertThat(data.getRecipient()).isEqualTo(RECIPIENT_EMAIL);
+        assertThat(data.getSubject()).isEqualTo("William||12345|REPORTING TO COURT");
+        assertThat(data.getAttachments()).containsExactly(
+            document("application/pdf",  DOCUMENT_CONTENT, DOCUMENT_FILENAME)
+        );
+        assertThat(data.getMessage()).isEqualTo(
+            String.join(" ",
+                "Types of documents attached:\n\n"
+                + "• Application statement")
+        );
+    }
+
     private DocumentReference getDocumentReference() {
         return DocumentReference.builder().binaryUrl(DOCUMENT_BINARY_URL)
                 .url(DOCUMENT_URL)


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-1838


### Change description ###
if no familyMan number is presented, the format of subject line should be
'Jones||1697024954824971|APPLICATION' instead of 'Jones|1697024954824971|APPLICATION'
ie. || instead of |

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
