### PR TITLE
DFPL-1839 add DirtiesContext annotation to fix flaky unit tets

### DIFF
--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/placement/PlacementSubmittedControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/placement/PlacementSubmittedControllerTest.java
@@ -8,6 +8,7 @@ import org.mockito.Captor;
 import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 import uk.gov.hmcts.reform.ccd.document.am.model.Document;
 import uk.gov.hmcts.reform.fnp.client.FeesRegisterApi;
@@ -44,6 +45,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -76,6 +78,7 @@ import static uk.gov.hmcts.reform.fpl.utils.TestDataHelper.testDocumentReference
 
 @WebMvcTest(PlacementController.class)
 @OverrideAutoConfiguration(enabled = true)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 class PlacementSubmittedControllerTest extends AbstractPlacementControllerTest {
 
     private static final Long CASE_ID = 12345L;


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-1839


### Change description ###
Mark the test as DirtyContext, so Spring clear cache after each test



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
