### PR TITLE
DFPl-1844: Gatekeeping not sending Order uploaded notification

### DIFF
--- a/ccd-definition/CaseEventToFields/CareSupervision/addGatekeepingOrder/listHearingOrSendToAdmin.json
+++ b/ccd-definition/CaseEventToFields/CareSupervision/addGatekeepingOrder/listHearingOrSendToAdmin.json
@@ -42,7 +42,7 @@
     "CaseEventID": "addGatekeepingOrder",
     "CaseFieldID": "gatekeepingOrderSealDecision",
     "PageFieldDisplayOrder": 4,
-    "DisplayContext": "COMPLEX",
+    "DisplayContext": "READONLY",
     "PageID": "ListHearingOrSendToAdmin",
     "PageDisplayOrder": 8,
     "PageColumnNumber": 1,

--- a/ccd-definition/CaseEventToFields/CareSupervision/addUrgentDirections/listHearingOrSendToAdmin.json
+++ b/ccd-definition/CaseEventToFields/CareSupervision/addUrgentDirections/listHearingOrSendToAdmin.json
@@ -42,7 +42,7 @@
     "CaseEventID": "addUrgentDirections",
     "CaseFieldID": "gatekeepingOrderSealDecision",
     "PageFieldDisplayOrder": 4,
-    "DisplayContext": "COMPLEX",
+    "DisplayContext": "READONLY",
     "PageID": "ListHearingOrSendToAdmin",
     "PageDisplayOrder": 6,
     "PageColumnNumber": 1,


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DFPL-1844

Gatekeeping wasn't attaching the uploaded/generated order to the decision due to ccd field being marked as complex and not readonly

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
