### PR TITLE
DFPL-1854: Clear the latestRoleSent field on event start

### DIFF
--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ReplyToMessageJudgeControllerAboutToStartTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ReplyToMessageJudgeControllerAboutToStartTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse;
-import uk.gov.hmcts.reform.fpl.enums.JudicialMessageRoleType;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
 import uk.gov.hmcts.reform.fpl.model.common.dynamic.DynamicList;

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ReplyToMessageJudgeControllerAboutToStartTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ReplyToMessageJudgeControllerAboutToStartTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse;
+import uk.gov.hmcts.reform.fpl.enums.JudicialMessageRoleType;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
 import uk.gov.hmcts.reform.fpl.model.common.dynamic.DynamicList;
@@ -13,6 +14,7 @@ import uk.gov.hmcts.reform.fpl.model.judicialmessage.JudicialMessage;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.reform.fpl.enums.JudicialMessageRoleType.CTSC;
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.element;
 import static uk.gov.hmcts.reform.fpl.utils.TestDataHelper.buildDynamicList;
 
@@ -56,5 +58,15 @@ class ReplyToMessageJudgeControllerAboutToStartTest extends AbstractCallbackTest
         );
 
         assertThat(judicialMessageDynamicList).isEqualTo(expectedJudicialMessageDynamicList);
+    }
+
+    @Test
+    void shouldClearLatestRoleSent() {
+        CaseData caseData = CaseData.builder()
+            .latestRoleSent(CTSC)
+            .build();
+
+        AboutToStartOrSubmitCallbackResponse response = postAboutToStartEvent(caseData);
+        assertThat(response.getData().get("latestRoleSent")).isNull();
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/ReplyToMessageJudgeController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/ReplyToMessageJudgeController.java
@@ -41,6 +41,9 @@ public class ReplyToMessageJudgeController extends CallbackController {
 
         caseDetailsMap.putAll(replyToMessageJudgeService.initialiseCaseFields(caseData));
 
+        // We need to remove this field, as we might be closing the message, not replying
+        caseDetailsMap.remove("latestRoleSent");
+
         return respond(caseDetailsMap);
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
[DFPL-1854](https://tools.hmcts.net/jira/browse/DFPL-1854)


### Change description ###
 - Clear the field on event start - it clashes if the user chooses to CLOSE a message thread (i.e. the latest role sent... should be null, as no message was sent!)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
