### PR TITLE
DFPL-1895: Add elinks feature toggle

### DIFF
--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/AllocatedJudgeControllerMidEventTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/AllocatedJudgeControllerMidEventTest.java
@@ -41,7 +41,7 @@ class AllocatedJudgeControllerMidEventTest extends AbstractCallbackTest {
 
     @Test
     void shouldNotReturnAValidationErrorWhenJudgePersonalCodeAdded() {
-        given(jrdApi.findUsers(any(), any(), anyInt(), any())).willReturn(List.of(JudicialUserProfile.builder()
+        given(jrdApi.findUsers(any(), any(), anyInt(), any(), any())).willReturn(List.of(JudicialUserProfile.builder()
             .build()));
         CaseData caseData = CaseData.builder()
             .enterManually(YesNo.NO)

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ManageHearingsControllerValidateJudgeEmailMidEventTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ManageHearingsControllerValidateJudgeEmailMidEventTest.java
@@ -59,7 +59,7 @@ class ManageHearingsControllerValidateJudgeEmailMidEventTest extends ManageHeari
 
     @Test
     void shouldNotReturnAValidationErrorWhenJudgePersonalCodeAdded() {
-        given(jrdApi.findUsers(any(), any(), anyInt(), any())).willReturn(List.of(JudicialUserProfile.builder()
+        given(jrdApi.findUsers(any(), any(), anyInt(), any(), any())).willReturn(List.of(JudicialUserProfile.builder()
                 .fullName("His Honour Judge John Smith")
             .build()));
         CaseData caseData = CaseData.builder()

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/listgatekeepinghearing/ListGatekeepingHearingControllerAllocatedJudgeMidEventTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/listgatekeepinghearing/ListGatekeepingHearingControllerAllocatedJudgeMidEventTest.java
@@ -45,7 +45,7 @@ class ListGatekeepingHearingControllerAllocatedJudgeMidEventTest extends Abstrac
 
     @Test
     void shouldNotReturnAValidationErrorWhenJudgePersonalCodeAdded() {
-        given(jrdApi.findUsers(any(), any(), anyInt(), any())).willReturn(List.of(JudicialUserProfile.builder()
+        given(jrdApi.findUsers(any(), any(), anyInt(), any(), any())).willReturn(List.of(JudicialUserProfile.builder()
             .fullName("His Honour Judge John Smith")
             .build()));
         CaseData caseData = CaseData.builder()

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/listgatekeepinghearing/ListGatekeepingHearingControllerValidateJudgeEmailMidEventTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/listgatekeepinghearing/ListGatekeepingHearingControllerValidateJudgeEmailMidEventTest.java
@@ -61,7 +61,7 @@ class ListGatekeepingHearingControllerValidateJudgeEmailMidEventTest extends Abs
 
     @Test
     void shouldNotReturnAValidationErrorWhenJudgePersonalCodeAdded() {
-        given(jrdApi.findUsers(any(), any(), anyInt(), any())).willReturn(List.of(JudicialUserProfile.builder()
+        given(jrdApi.findUsers(any(), any(), anyInt(), any(), any())).willReturn(List.of(JudicialUserProfile.builder()
             .fullName("His Honour Judge John Smith")
             .build()));
         CaseData caseData = CaseData.builder()

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/config/rd/JudicialUsersConfiguration.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/config/rd/JudicialUsersConfiguration.java
@@ -9,6 +9,7 @@ import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.fpl.service.ElinksService;
 import uk.gov.hmcts.reform.fpl.service.SystemUserService;
 import uk.gov.hmcts.reform.rd.client.JudicialApi;
 import uk.gov.hmcts.reform.rd.model.JudicialUserProfile;
@@ -31,6 +32,7 @@ public class JudicialUsersConfiguration {
     private final SystemUserService systemUserService;
     private final AuthTokenGenerator authTokenGenerator;
     private final JudicialApi judicialApi;
+    private final ElinksService elinksService;
 
     private final int judicialPageSize = 10000;
 
@@ -38,10 +40,12 @@ public class JudicialUsersConfiguration {
     public JudicialUsersConfiguration(@Autowired JudicialApi judicialApi,
                                       @Autowired SystemUserService systemUserService,
                                       @Autowired AuthTokenGenerator authTokenGenerator,
+                                      @Autowired ElinksService elinksService,
                                       @Value("${rd_judicial.api.enabled:false}") boolean jrdEnabled) {
         this.judicialApi = judicialApi;
         this.systemUserService = systemUserService;
         this.authTokenGenerator = authTokenGenerator;
+        this.elinksService = elinksService;
         log.info("Attempting to gather all judges.");
         if (jrdEnabled) {
             try {
@@ -66,6 +70,7 @@ public class JudicialUsersConfiguration {
 
         List<JudicialUserProfile> users = judicialApi.findUsers(systemUserToken, authTokenGenerator.generate(),
             judicialPageSize,
+            elinksService.getElinksAcceptHeader(),
             JudicialUserRequest.builder()
                 .ccdServiceName("PUBLICLAW")
                 .build());

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -60,7 +60,7 @@ public class MigrateCaseController extends CallbackController {
         "DFPL-1802", this::run1802,
         "DFPL-1810", this::run1810,
         "DFPL-1837", this::run1837,
-        "DFPL-1842", this::run1842,
+        "DFPL-1883", this::run1883,
         "DFPL-1850", this::run1850
     );
 
@@ -255,10 +255,10 @@ public class MigrateCaseController extends CallbackController {
             migrationId, expectedHearingId, expectedDocId));
     }
 
-    private void run1842(CaseDetails caseDetails) {
-        var migrationId = "DFPL-1842";
-        var possibleCaseIds = List.of(1643109401093000L);
-        var expectedPositionStatementId = UUID.fromString("ae94c8a7-25f1-4ca3-b381-4ce847f9ec36");
+    private void run1883(CaseDetails caseDetails) {
+        var migrationId = "DFPL-1883";
+        var possibleCaseIds = List.of(1686737004191900L);
+        var expectedPositionStatementId = UUID.fromString("b96b56e4-0bdd-41a4-b272-8bf2d9c349af");
         migrateCaseService.doCaseIdCheckList(caseDetails.getId(), possibleCaseIds, migrationId);
 
         CaseData caseData = getCaseData(caseDetails);

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/ElinksService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/ElinksService.java
@@ -13,6 +13,6 @@ public class ElinksService {
     public String getElinksAcceptHeader() {
         return featureToggleService.isElinksEnabled()
             ? "application/vnd.jrd.api+json;Version=2.0"
-            : "application/vnd.jrd.api+json";
+            : null;
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/ElinksService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/ElinksService.java
@@ -1,0 +1,18 @@
+package uk.gov.hmcts.reform.fpl.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+public class ElinksService {
+
+    private final FeatureToggleService featureToggleService;
+
+    public String getElinksAcceptHeader() {
+        return featureToggleService.isElinksEnabled()
+            ? "application/vnd.jrd.api+json;Version=2.0"
+            : "application/vnd.jrd.api+json";
+    }
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/FeatureToggleService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/FeatureToggleService.java
@@ -85,6 +85,10 @@ public class FeatureToggleService {
         return ldClient.boolVariation("secure-docstore-enabled", createLDUser(), false);
     }
 
+    public boolean isElinksEnabled() {
+        return ldClient.boolVariation("elinks-enabled", createLDUser(), false);
+    }
+
     private LDUser createLDUser() {
         return createLDUser(Map.of());
     }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/JudicialService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/JudicialService.java
@@ -62,6 +62,7 @@ public class JudicialService {
     private final ValidateEmailService validateEmailService;
     private final JudicialUsersConfiguration judicialUsersConfiguration;
     private final LegalAdviserUsersConfiguration legalAdviserUsersConfiguration;
+    private final ElinksService elinksService;
 
     /**
      * Delete a set of allocated-[users] on a specific case.
@@ -169,6 +170,7 @@ public class JudicialService {
         List<JudicialUserProfile> judges = judicialApi.findUsers(systemUserToken,
             authTokenGenerator.generate(),
             JUDICIAL_PAGE_SIZE,
+            elinksService.getElinksAcceptHeader(),
             JudicialUserRequest.fromPersonalCode(personalCode));
 
         return !judges.isEmpty();
@@ -207,6 +209,7 @@ public class JudicialService {
         List<JudicialUserProfile> judges = judicialApi.findUsers(systemUserToken,
             authTokenGenerator.generate(),
             JUDICIAL_PAGE_SIZE,
+            elinksService.getElinksAcceptHeader(),
             JudicialUserRequest.fromPersonalCode(personalCode));
 
         if (judges.isEmpty()) {

--- a/service/src/main/java/uk/gov/hmcts/reform/rd/client/JudicialApi.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/rd/client/JudicialApi.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.reform.rd.model.JudicialUserRequest;
 
 import java.util.List;
 
+import static org.springframework.http.HttpHeaders.ACCEPT;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi.SERVICE_AUTHORIZATION;
 
@@ -25,6 +26,7 @@ public interface JudicialApi {
         @RequestHeader(AUTHORIZATION) String authorisation,
         @RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorization,
         @RequestHeader("page_size") int pageSize,
+        @RequestHeader(ACCEPT) String accept,
         @RequestBody JudicialUserRequest request
     );
 

--- a/service/src/main/java/uk/gov/hmcts/reform/rd/client/JudicialApi.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/rd/client/JudicialApi.java
@@ -26,7 +26,7 @@ public interface JudicialApi {
         @RequestHeader(AUTHORIZATION) String authorisation,
         @RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorization,
         @RequestHeader("page_size") int pageSize,
-        @RequestHeader(ACCEPT) String accept,
+        @RequestHeader(value = ACCEPT, required = false) String accept,
         @RequestBody JudicialUserRequest request
     );
 

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/config/rd/JudicialUsersConfigurationTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/config/rd/JudicialUsersConfigurationTest.java
@@ -8,6 +8,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.fpl.service.ElinksService;
 import uk.gov.hmcts.reform.fpl.service.SystemUserService;
 import uk.gov.hmcts.reform.rd.client.JudicialApi;
 import uk.gov.hmcts.reform.rd.model.JudicialUserProfile;
@@ -41,16 +42,19 @@ class JudicialUsersConfigurationTest {
     @Mock
     private AuthTokenGenerator authTokenGenerator;
 
+    @Mock
+    private ElinksService elinksService;
+
     @BeforeEach
     void beforeEach() {
         when(systemUserService.getSysUserToken()).thenReturn("token");
-        when(jrdApi.findUsers(any(), any(), anyInt(), any())).thenReturn(JUPS);
+        when(jrdApi.findUsers(any(), any(), anyInt(), any(), any())).thenReturn(JUPS);
     }
 
     @Test
     void shouldGetJudgeUUIDIfInMapping() {
         JudicialUsersConfiguration config = new JudicialUsersConfiguration(jrdApi, systemUserService,
-            authTokenGenerator, true);
+            authTokenGenerator, elinksService, true);
 
         Optional<String> uuid = config.getJudgeUUID("email@test.com");
         assertThat(uuid.isPresent()).isTrue();
@@ -60,7 +64,7 @@ class JudicialUsersConfigurationTest {
     @Test
     void shouldGetAllJudges() {
         JudicialUsersConfiguration config = new JudicialUsersConfiguration(jrdApi, systemUserService,
-            authTokenGenerator, true);
+            authTokenGenerator, elinksService, true);
 
         Map<String, String> judges = config.getAllJudges();
         assertThat(judges).isEqualTo(Map.of("email@test.com", "12345"));

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ElinksServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ElinksServiceTest.java
@@ -6,6 +6,7 @@ import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
@@ -27,7 +28,7 @@ class ElinksServiceTest {
         when(featureToggleService.isElinksEnabled()).thenReturn(false);
         ElinksService elinksService = new ElinksService(featureToggleService);
 
-        assertEquals("application/vnd.jrd.api+json", elinksService.getElinksAcceptHeader());
+        assertNull(elinksService.getElinksAcceptHeader());
     }
 
 }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ElinksServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ElinksServiceTest.java
@@ -1,0 +1,33 @@
+package uk.gov.hmcts.reform.fpl.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SpringExtension.class)
+class ElinksServiceTest {
+
+    @Mock
+    private FeatureToggleService featureToggleService;
+
+    @Test
+    void shouldGetElinksAcceptHeaderWhenEnabled() {
+        when(featureToggleService.isElinksEnabled()).thenReturn(true);
+        ElinksService elinksService = new ElinksService(featureToggleService);
+
+        assertEquals("application/vnd.jrd.api+json;Version=2.0", elinksService.getElinksAcceptHeader());
+    }
+
+    @Test
+    void shouldGetNonElinksAcceptHeaderWhenDisabled() {
+        when(featureToggleService.isElinksEnabled()).thenReturn(false);
+        ElinksService elinksService = new ElinksService(featureToggleService);
+
+        assertEquals("application/vnd.jrd.api+json", elinksService.getElinksAcceptHeader());
+    }
+
+}

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ElinksServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ElinksServiceTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/JudicialServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/JudicialServiceTest.java
@@ -275,7 +275,7 @@ class JudicialServiceTest {
 
     @Test
     void shouldCheckJudgeExistsWhenPresentInJrd() {
-        when(judicialApi.findUsers(any(), any(), anyInt(), any()))
+        when(judicialApi.findUsers(any(), any(), anyInt(), any(), any()))
             .thenReturn(List.of(JudicialUserProfile.builder().build()));
         boolean exists = underTest.checkJudgeExists("1234");
 
@@ -284,7 +284,7 @@ class JudicialServiceTest {
 
     @Test
     void shouldCheckJudgeDoesntExistWhenNotPresentInJrd() {
-        when(judicialApi.findUsers(any(), any(), anyInt(), any()))
+        when(judicialApi.findUsers(any(), any(), anyInt(), any(), any()))
             .thenReturn(List.of());
         boolean exists = underTest.checkJudgeExists("1234");
 

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/JudicialServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/JudicialServiceTest.java
@@ -71,6 +71,9 @@ class JudicialServiceTest {
     @Mock
     private JudicialUsersConfiguration judicialUsersConfiguration;
 
+    @Mock
+    private ElinksService elinksService;
+
     @Captor
     private ArgumentCaptor<List<RoleAssignment>> rolesCaptor;
 
@@ -144,6 +147,8 @@ class JudicialServiceTest {
                 .thenReturn(Optional.empty());
             when(legalAdviserUsersConfiguration.getLegalAdviserUUID(JUDGE_3.getJudgeEmailAddress()))
                 .thenReturn(Optional.of(JUDGE_3_ID));
+
+            when(elinksService.getElinksAcceptHeader()).thenReturn("application/json");
         }
 
         @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
[DFPL-1895](https://tools.hmcts.net/jira/browse/DFPL-1895)


### Change description ###
 - Change the JRD api headers based on a feature toggle `elinks-enabled` to make sure we can seamlessly rollover to using elinks API


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
