### PR TITLE
Demo: updated flyway to 9.15.2

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -332,7 +332,7 @@ dependencies {
   implementation group: 'io.github.openfeign', name: 'feign-core', version: '11.2'
   implementation group: 'org.yaml', name: 'snakeyaml', version: '2.2'
   implementation group: 'org.postgresql', name: 'postgresql', version: '42.6.0'
-  implementation group: 'org.flywaydb', name: 'flyway-core', version: '9.22.3'
+  implementation group: 'org.flywaydb', name: 'flyway-core', version: '9.15.2'
 
   implementation group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
   implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger


### PR DESCRIPTION
### Change description ###

Updated flyway to 9.15.2

Previous version still did not support v15 of pg.  jps-judicial-payment-service have used this version with v15.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
