### PR TITLE
DFPL-1913: Add old style hearing label checking for the event

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/jobs/CreateWAOrderChasingTasks.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/jobs/CreateWAOrderChasingTasks.java
@@ -134,7 +134,7 @@ public class CreateWAOrderChasingTasks implements Job {
 
         // ES cannot index nulls (automatically), also sometimes the cmo field is not present at all => manual check
         return hearingsWithinRange.stream().anyMatch(booking -> !booking.getValue().hasCMOAssociation()
-            && !sendOrderReminderService.checkSealedCMOExistsForHearing(caseData, booking.getId()));
+            && !sendOrderReminderService.checkSealedCMOExistsForHearing(caseData, booking));
     }
 
     private MustNot getInvalidStates() {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/cmo/SendOrderReminderService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/cmo/SendOrderReminderService.java
@@ -6,12 +6,9 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.HearingBooking;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
-import uk.gov.hmcts.reform.fpl.utils.ElementUtils;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static java.time.LocalDateTime.now;

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/cmo/SendOrderReminderService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/cmo/SendOrderReminderService.java
@@ -25,20 +25,17 @@ public class SendOrderReminderService {
         return caseData.getAllNonCancelledHearings().stream()
             .filter(booking -> booking.getValue().getEndDate().isBefore(now())
                 && !booking.getValue().hasCMOAssociation()
-                && !checkSealedCMOExistsForHearing(caseData, booking.getId()))
+                && !checkSealedCMOExistsForHearing(caseData, booking))
             .map(Element::getValue)
             .sorted(Comparator.comparing(HearingBooking::getStartDate))
             .collect(Collectors.toList());
     }
 
-    public boolean checkSealedCMOExistsForHearing(CaseData caseData, UUID hearingId) {
-        Optional<Element<HearingBooking>> booking = ElementUtils
-            .findElement(hearingId, caseData.getAllNonCancelledHearings());
-
+    public boolean checkSealedCMOExistsForHearing(CaseData caseData, Element<HearingBooking> booking) {
         // either it have a new style UUID hearing ID or an old style string hearing label (fallback)
         return caseData.getSealedCMOs().stream()
-            .anyMatch(el -> hearingId.equals(el.getValue().getHearingId())
-                || (booking.isPresent() && isNotEmpty(el.getValue().getHearing())
-                    && el.getValue().getHearing().equals(booking.get().getValue().toLabel())));
+            .anyMatch(el -> booking.getId().equals(el.getValue().getHearingId())
+                || (isNotEmpty(el.getValue().getHearing())
+                    && el.getValue().getHearing().equals(booking.getValue().toLabel())));
     }
 }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/cmo/SendOrderReminderServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/cmo/SendOrderReminderServiceTest.java
@@ -115,4 +115,28 @@ class SendOrderReminderServiceTest {
         assertThat(actual).isEqualTo(List.of());
     }
 
+    @Test
+    void shouldNotFindOrderWithNoHearingLabelOrUuid() {
+        LocalDateTime startDate = now().minusDays(5);
+        Element<HearingBooking> hearingBooking = element(HearingBooking.builder()
+            .type(HearingType.CASE_MANAGEMENT)
+            .startDate(startDate)
+            .endDate(startDate.plusHours(1))
+            .build());
+
+        CaseData caseData = CaseData.builder()
+            .id(12345L)
+            .hearingDetails(List.of(hearingBooking))
+            .sealedCMOs(List.of(
+                element(HearingOrder.builder()
+                    .order(testDocumentReference())
+                    .build())
+            ))
+            .build();
+
+        List<HearingBooking> actual = underTest.getPastHearingBookingsWithoutCMOs(caseData);
+
+        assertThat(actual).isEqualTo(List.of(hearingBooking.getValue()));
+    }
+
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
[DFPL-1913](https://tools.hmcts.net/jira/browse/DFPL-1913)


### Change description ###
 - Adds checking for the toLabel clause, as this was stored prior to work allocation rather than a uuid, therefore need to have this as a fallback so we don't show old hearings in the 'send order reminder' flow (that have labels not uuids)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
