### PR TITLE
DFPL-1754-v15-fs-step-2: Changes to point scheduler at Postrgres v15 …

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -283,7 +283,7 @@ withPipeline(type, product, component) {
     env.TEST_CONF_FPL_URL = "https://fpl-case-service-staging.aat.platform.hmcts.net"
   }
 
-  //def branchesToSync = ['demo', 'perftest', 'ithc'] TODO: uncomment this once testing in demo for WA completed
-  def branchesToSync = ['ithc']
+  //def branchesToSync = ['demo', 'perftest', 'ithc'] TODO: uncomment demo migration for DFPL-1855 completed
+  def branchesToSync = ['perftest','ithc']
   syncBranchesWithMaster(branchesToSync)
 }

--- a/charts/fpl-case-service/values.yaml
+++ b/charts/fpl-case-service/values.yaml
@@ -39,8 +39,8 @@ java:
     DOCMOSIS_TORNADO_URL: https://docmosis.{{ .Values.global.environment }}.platform.hmcts.net
     AUTH_IDAM_CLIENT_BASEURL: https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net
     AUTH_PROVIDER_SERVICE_CLIENT_BASEURL: http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
-    SCHEDULER_DB_USER: fpl_scheduler@fpl-case-service-{{ .Values.global.environment }}
-    SCHEDULER_DB_HOST: fpl-case-service-{{ .Values.global.environment }}.postgres.database.azure.com
+    SCHEDULER_DB_USER: fpl_scheduler_user
+    SCHEDULER_DB_HOST: fpl-case-service-postgresql-v15-flexible-server-{{ .Values.global.environment }}.postgres.database.azure.com
     SCHEDULER_DB_PORT: 5432
     SPRING_CLOUD_BOOTSTRAP_ENABLED: true
     CASE_DOCUMENT_AM_URL: http://ccd-case-document-am-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -332,7 +332,7 @@ dependencies {
   implementation group: 'io.github.openfeign', name: 'feign-core', version: '11.2'
   implementation group: 'org.yaml', name: 'snakeyaml', version: '2.2'
   implementation group: 'org.postgresql', name: 'postgresql', version: '42.6.0'
-  implementation group: 'org.flywaydb', name: 'flyway-core', version: '8.5.13'
+  implementation group: 'org.flywaydb', name: 'flyway-core', version: '9.15.2'
 
   implementation group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
   implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -250,9 +250,9 @@ scheduler:
   datasourceConf:
     name: schedulerDataSource
     driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://${SCHEDULER_DB_HOST:localhost}:${SCHEDULER_DB_PORT:6432}/${SCHEDULER_DB_NAME:postgres}?gssEncMode=disable
-    username: ${SCHEDULER_DB_USER:postgres}
-    password: ${SCHEDULER_DB_PASSWORD:postgres}
+    url: jdbc:postgresql://${SCHEDULER_DB_HOST:localhost}:${SCHEDULER_DB_PORT:6432}/${SCHEDULER_DB_NAME:fpl_scheduler}?gssEncMode=disable
+    username: ${SCHEDULER_DB_USER:fpl_scheduler_user}
+    password: ${SCHEDULER_DB_PASSWORD:fpl_scheduler}
   quartzConf:
     org.quartz:
       scheduler:

--- a/service/src/main/resources/bootstrap.yaml
+++ b/service/src/main/resources/bootstrap.yaml
@@ -41,5 +41,5 @@ spring:
         cafcass-notification-recipient-notice-of-hearing: cafcass.notification.noticeofhearing
         AppInsightsInstrumentationKey: azure.application-insights.instrumentation-key
         app-insights-connection-string: azure.application-insights.appinsights.connection_string
-        scheduler-db-password: SCHEDULER_DB_PASSWORD
+        scheduler-db-password-v15: SCHEDULER_DB_PASSWORD
         update-summary-tab-cron: UPDATE_SUMMARY_TAB_CRON


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DFPL-1754

### Change description ###

Changes to point the FPL scheduler at the new Postrgres v15 flexible server.

The v11 database will remain for a quick rollback in the event of issues.

Also enabling syncing of branches back to perftest.

Leaving as draft PR, until release properly scheduled.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
