### PR TITLE
DFPL-1894-for-demo: Changes to .tf files to remove v11 database

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -12,11 +12,19 @@ terraform {
 }
 
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
   skip_provider_registration = true
   alias                      = "postgres_network"
   subscription_id            = var.aks_subscription_id
@@ -102,28 +110,8 @@ module "fpl-scheduler-postgres-v15-flexible-server" {
 
 }
 
-module "fpl-scheduler-db" {
-  source             = "git@github.com:hmcts/cnp-module-postgres?ref=master"
-  product            = "${var.product}-${var.component}"
-  location           = var.location_db
-  env                = var.env
-  database_name      = "fpl_scheduler"
-  postgresql_user    = "fpl_scheduler"
-  postgresql_version = "11"
-  sku_name           = "GP_Gen5_2"
-  sku_tier           = "GeneralPurpose"
-  common_tags        = var.common_tags
-  subscription       = var.subscription
-}
-
 data "azurerm_key_vault_secret" "fpl_support_email_secret" {
   name      = "${var.product}-support-email"
-  key_vault_id = module.key-vault.key_vault_id
-}
-
-resource "azurerm_key_vault_secret" "scheduler-db-password" {
-  name      = "scheduler-db-password"
-  value     = module.fpl-scheduler-db.postgresql_password
   key_vault_id = module.key-vault.key_vault_id
 }
 

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -1,5 +1,3 @@
-variable "subscription" {}
-
 variable "product" {
   type = string
 }
@@ -9,11 +7,6 @@ variable "component" {
 }
 
 variable "location" {
-  type    = string
-  default = "UK South"
-}
-
-variable "location_db" {
   type    = string
   default = "UK South"
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DFPL-1894

### Change description ###

For demo testing.
Now the fpl-scheduler is using postgres v15 flexiserver, pg v11 can be removed.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
