### PR TITLE
DFPL-1894: Removed chart/values reference to the removed v11 password

### DIFF
--- a/charts/fpl-case-service/values.yaml
+++ b/charts/fpl-case-service/values.yaml
@@ -83,7 +83,6 @@ java:
         - AppInsightsInstrumentationKey
         - name: app-insights-connection-string
           alias: app-insights-connection-string
-        - scheduler-db-password
         - scheduler-db-password-v15
         - rcj-family-high-court-inbox
         - court-to-court-admin-mapping


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DFPL-1894

### Change description ###

DFPL-1894: Removed chart/values reference to the removed v11 password


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
