### PR TITLE
DFPL-1894: Terraform postgres deletion privs removed

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -12,19 +12,11 @@ terraform {
 }
 
 provider "azurerm" {
-  features {
-    resource_group {
-      prevent_deletion_if_contains_resources = false
-    }
-  }
+  features {}
 }
 
 provider "azurerm" {
-  features {
-    resource_group {
-      prevent_deletion_if_contains_resources = false
-    }
-  }
+  features {}
   skip_provider_registration = true
   alias                      = "postgres_network"
   subscription_id            = var.aks_subscription_id


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DFPL-1894

### Change description ###

Cleanup work now that pg v11 has been removed everywhere.

Terraform was permitted to teardown postgres databases without a lock.  This change reverts that permission, so accidental deletes are less likely via Terraform.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
