### PR TITLE
DFPL-1899-2: Fix Migration + Add builder for grounds

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/Grounds.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/Grounds.java
@@ -11,7 +11,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 @Data
-@Builder
+@Builder(toBuilder = true)
 @AllArgsConstructor
 public class Grounds {
     @NotNull(message = "Select at least one option for how this case meets the threshold criteria")

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseService.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.reform.fpl.model.CaseSummary;
 import uk.gov.hmcts.reform.fpl.model.Child;
 import uk.gov.hmcts.reform.fpl.model.Court;
 import uk.gov.hmcts.reform.fpl.model.CourtBundle;
+import uk.gov.hmcts.reform.fpl.model.Grounds;
 import uk.gov.hmcts.reform.fpl.model.HearingBooking;
 import uk.gov.hmcts.reform.fpl.model.HearingCourtBundle;
 import uk.gov.hmcts.reform.fpl.model.HearingFurtherEvidenceBundle;
@@ -838,10 +839,11 @@ public class MigrateCaseService {
         }
 
         thresholdDetails = thresholdDetails.replace(textToRemove, "");
+        Grounds updatedGrounds = caseData.getGrounds().toBuilder().thresholdDetails(thresholdDetails).build();
 
-        return Map.of("thresholdDetails", thresholdDetails);
+        return Map.of("grounds", updatedGrounds);
     }
-  
+
     public Map<String, OrganisationPolicy> changeThirdPartyStandaloneApplicant(CaseData caseData, String orgId) {
         String orgName = organisationService.findOrganisation(orgId)
             .map(uk.gov.hmcts.reform.rd.model.Organisation::getName)

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseServiceTest.java
@@ -2129,8 +2129,14 @@ class MigrateCaseServiceTest {
             var thresholdDetailsStartIndex = 167;
             var thresholdDetailsEndIndex = 259;
 
+            final Grounds expectedGrounds = Grounds.builder()
+                .thresholdDetails(expectedThresholdDetails)
+                .thresholdReason(List.of("noCare"))
+                .build();
+
             final Grounds grounds = Grounds.builder()
                 .thresholdDetails(testThresholdDetails)
+                .thresholdReason(List.of("noCare"))
                 .build();
 
             CaseData caseData = CaseData.builder()
@@ -2141,7 +2147,7 @@ class MigrateCaseServiceTest {
             Map<String, Object> updatedGrounds = underTest.removeCharactersFromThresholdDetails(caseData, MIGRATION_ID,
                 thresholdDetailsStartIndex, thresholdDetailsEndIndex);
 
-            assertThat(updatedGrounds).extracting("thresholdDetails").isEqualTo(expectedThresholdDetails);
+            assertThat(updatedGrounds).extracting("grounds").isEqualTo(expectedGrounds);
         }
 
         @Test


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DFPL-1899

Update migration for grounds to correctly update subfield rather than try to add a new field to the case as per the last PR

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
