### PR TITLE
DFPL-1937 remove line in base.js that causes sign in twice

### DIFF
--- a/e2e/actors/base.js
+++ b/e2e/actors/base.js
@@ -224,8 +224,6 @@ module.exports = {
 
   async navigateToCaseDetailsAs(user, caseId) {
     await I.goToPage(config.baseUrl);
-    await I.goToPage(config.baseUrl, config.hmctsUser);
-
     await this.signIn(user);
     I.wait(10);
     await this.navigateToCaseDetails(caseId);

--- a/e2e/actors/base.js
+++ b/e2e/actors/base.js
@@ -223,7 +223,7 @@ module.exports = {
   },
 
   async navigateToCaseDetailsAs(user, caseId) {
-    await I.goToPage(config.baseUrl);
+    await I.goToPage(config.baseUrl, user);
     await this.signIn(user);
     I.wait(10);
     await this.navigateToCaseDetails(caseId);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-1937


### Change description ###
removing the following line of code in base.js

line 227
await I.goToPage(config.baseUrl, config.hmctsUser);
It is causes the 'navigateToCaseDetailsAs' method to sign in twice which is not required.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
