### PR TITLE
Versions of owasp dependency check below v9 are deprecated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 
 plugins {
   id 'java'
-  id 'org.owasp.dependencycheck' version '8.4.2' apply true
+  id 'org.owasp.dependencycheck' version '9.0.4' apply true
 }
 
 java {


### PR DESCRIPTION
### Change description ###

We are getting this warning:

Versions of owasp dependency check below v9 are deprecated, please upgrade to latest release. This configuration will stop working by 15/12/2023 ( in 7 days )

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
