### PR TITLE
DFPL-1971: Avoid NPE as some fields are optional/can be null

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/summary/CaseSummaryCaseFlagGenerator.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/summary/CaseSummaryCaseFlagGenerator.java
@@ -5,8 +5,10 @@ import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.summary.SyntheticCaseSummary;
 import uk.gov.hmcts.reform.fpl.service.UserService;
 
+import java.util.HashMap;
 import java.util.Map;
 
+import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 import static uk.gov.hmcts.reform.fpl.enums.YesNo.YES;
 
 @Component
@@ -29,12 +31,12 @@ public class CaseSummaryCaseFlagGenerator implements CaseSummaryFieldsGenerator 
     }
 
     public Map<String, Object> generateFields(CaseData caseData) {
-        return Map.of(
-            "caseSummaryFlagAssessmentForm", caseData.getRedDotAssessmentForm(),
-            "caseSummaryCaseFlagNotes", caseData.getCaseFlagNotes(),
-            "caseSummaryFlagAddedByFullName", generateUploadedFullName(caseData),
-            "caseSummaryFlagAddedByEmail", generateUploadedByEmail(caseData)
-        );
+        HashMap<String, Object> map = new HashMap<>();
+        map.put("caseSummaryFlagAssessmentForm", caseData.getRedDotAssessmentForm());
+        map.put("caseSummaryCaseFlagNotes", caseData.getCaseFlagNotes());
+        map.put("caseSummaryFlagAddedByFullName", generateUploadedFullName(caseData));
+        map.put( "caseSummaryFlagAddedByEmail", generateUploadedByEmail(caseData));
+        return map;
     }
 
     private String generateUploadedByEmail(CaseData caseData) {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/summary/CaseSummaryCaseFlagGenerator.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/summary/CaseSummaryCaseFlagGenerator.java
@@ -8,7 +8,6 @@ import uk.gov.hmcts.reform.fpl.service.UserService;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 import static uk.gov.hmcts.reform.fpl.enums.YesNo.YES;
 
 @Component
@@ -35,7 +34,7 @@ public class CaseSummaryCaseFlagGenerator implements CaseSummaryFieldsGenerator 
         map.put("caseSummaryFlagAssessmentForm", caseData.getRedDotAssessmentForm());
         map.put("caseSummaryCaseFlagNotes", caseData.getCaseFlagNotes());
         map.put("caseSummaryFlagAddedByFullName", generateUploadedFullName(caseData));
-        map.put( "caseSummaryFlagAddedByEmail", generateUploadedByEmail(caseData));
+        map.put("caseSummaryFlagAddedByEmail", generateUploadedByEmail(caseData));
         return map;
     }
 

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/summary/CaseSummaryCaseFlagGeneratorTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/summary/CaseSummaryCaseFlagGeneratorTest.java
@@ -13,6 +13,9 @@ import uk.gov.hmcts.reform.fpl.service.UserService;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.fpl.enums.YesNo.NO;
@@ -94,6 +97,19 @@ class CaseSummaryCaseFlagGeneratorTest {
         );
 
         assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void shouldNoThrowNullPointerExceptionIfMissingOptionalFields() {
+        CaseData caseData = CaseData.builder()
+            .redDotAssessmentForm(RED_DOT_ASSESSMENT_FORM)
+            .caseFlagValueUpdated(YES)
+            .build();
+
+        when(userService.getUserName()).thenReturn(FULLNAME);
+        when(userService.getUserEmail()).thenReturn(USER_EMAIL);
+
+        assertDoesNotThrow(() -> (underTest.generateFields(caseData)));
     }
 
 }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/summary/CaseSummaryCaseFlagGeneratorTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/summary/CaseSummaryCaseFlagGeneratorTest.java
@@ -13,9 +13,7 @@ import uk.gov.hmcts.reform.fpl.service.UserService;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.fpl.enums.YesNo.NO;


### PR DESCRIPTION
### JIRA link (if applicable) ###
[DFPL-1971](https://tools.hmcts.net/jira/browse/DFPL-1971)


### Change description ###
 - Don't use a map which disallows nulls - some of the fields may be null as they are optional fields


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
