### PR TITLE
DFPL-1934: Add generic clearing noc field migration + dummy log migration

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -42,7 +42,9 @@ public class MigrateCaseController extends CallbackController {
         "DFPL-CFV-Failure", this::runCfvFailure,
         "DFPL-CFV-dry", this::dryRunCFV,
         "DFPL-1921", this::run1921,
-        "DFPL-1940", this::run1940
+        "DFPL-1940", this::run1940,
+        "DFPL-1934", this::run1934,
+        "DFPL-log", this::runLogMigration
     );
 
     private static void pushChangesToCaseDetails(CaseDetails caseDetails, Map<String, Object> changes) {
@@ -195,5 +197,13 @@ public class MigrateCaseController extends CallbackController {
         CaseData caseData = getCaseData(caseDetails);
         caseDetails.getData().putAll(migrateCaseService.removeJudicialMessage(caseData, migrationId,
             String.valueOf(expectedMessageId)));
+    }
+
+    private void run1934(CaseDetails caseDetails) {
+        migrateCaseService.clearChangeOrganisationRequest(caseDetails);
+    }
+
+    private void runLogMigration(CaseDetails caseDetails) {
+        log.info("Dummy migration for case {}", caseDetails.getId());
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-1934


### Change description ###
 - Re-add generic clearing migration to clear the notice of change field
 - Add a dummy logging migration if needed to reindex ES.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
