### PR TITLE
removed renovate file for Christmas

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>hmcts/.github:renovate-config"
+  ]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "local>hmcts/.github:renovate-config",
-    "local>hmcts/.github//renovate/automerge-minor"
-  ]
-}


### PR DESCRIPTION
### Change description ###

Remove the renovate.json file for Christmas.

{
  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
  "extends": [
    "local>hmcts/.github:renovate-config",
    "local>hmcts/.github//renovate/automerge-minor"
  ]
}

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
