### PR TITLE
DFPL-1983 CFV notification is randomly dated back

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/email/content/FurtherEvidenceUploadedEmailContentProvider.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/email/content/FurtherEvidenceUploadedEmailContentProvider.java
@@ -32,7 +32,7 @@ public class FurtherEvidenceUploadedEmailContentProvider extends AbstractEmailCo
             .caseUrl(getCaseUrl(caseData.getId(), DOCUMENTS))
             .callout(buildSubjectLineWithHearingBookingDateSuffix(
                 caseData.getFamilyManCaseNumber(), caseData.getRespondents1(),
-                hearingBooking.orElse(caseData.getFirstHearing().orElse(null))
+                hearingBooking.orElse(null)
             ))
             .userName(sender)
             .lastName(helper.getEldestChildLastName(caseData.getAllChildren()))

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/email/content/FurtherEvidenceUploadedEmailContentProviderTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/email/content/FurtherEvidenceUploadedEmailContentProviderTest.java
@@ -13,6 +13,7 @@ import uk.gov.hmcts.reform.fpl.utils.EmailNotificationHelper;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -22,8 +23,10 @@ import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.wrapElements;
 @ContextConfiguration(classes = FurtherEvidenceUploadedEmailContentProvider.class)
 class FurtherEvidenceUploadedEmailContentProviderTest extends AbstractEmailContentProviderTest {
     private static final LocalDateTime HEARING_DATE = LocalDateTime.of(2021, 12, 2, 0, 0, 0);
+     private static final HearingBooking HEARING_BOOKING = HearingBooking.builder().startDate((HEARING_DATE)).build();
     private static final String RESPONDENT_LAST_NAME = "Smith";
-    private static final String CALLOUT = RESPONDENT_LAST_NAME + ", 12345, hearing 2 Dec 2021";
+    private static final String CALLOUT_WITH_HEARING = RESPONDENT_LAST_NAME + ", 12345, hearing 2 Dec 2021";
+    private static final String CALLOUT_WITHOUT_HEARING = RESPONDENT_LAST_NAME ;
     private static final Long CASE_ID = 12345L;
     private static final String SENDER = "SENDER";
     private static final String SOME_NAME = "SOME NAME";
@@ -41,7 +44,7 @@ class FurtherEvidenceUploadedEmailContentProviderTest extends AbstractEmailConte
             .caseUrl(caseUrl(CASE_REFERENCE, DOCUMENTS))
             .lastName(SOME_NAME)
             .userName(SENDER)
-            .callout(CALLOUT)
+            .callout(CALLOUT_WITHOUT_HEARING)
             .documents(DOCUMENT_NAMES)
             .build();
 
@@ -54,6 +57,26 @@ class FurtherEvidenceUploadedEmailContentProviderTest extends AbstractEmailConte
         assertThat(actual).isEqualTo(expected);
     }
 
+    @Test
+    void shouldBuildExpectedParametersWithHearingFromCaseData() {
+        FurtherEvidenceDocumentUploadedData expected = FurtherEvidenceDocumentUploadedData.builder()
+            .caseUrl(caseUrl(CASE_REFERENCE, DOCUMENTS))
+            .lastName(SOME_NAME)
+            .userName(SENDER)
+            .callout(CALLOUT_WITH_HEARING)
+            .documents(DOCUMENT_NAMES)
+            .build();
+
+        CaseData caseData = buildCaseData();
+
+        when(helper.getEldestChildLastName(caseData.getAllChildren())).thenReturn(SOME_NAME);
+
+        FurtherEvidenceDocumentUploadedData actual = underTest.buildParametersWithHearing(caseData, SENDER,
+            DOCUMENT_NAMES, Optional.of(HEARING_BOOKING));
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
     private CaseData buildCaseData() {
         return CaseData.builder()
             .id(CASE_ID)
@@ -62,7 +85,7 @@ class FurtherEvidenceUploadedEmailContentProviderTest extends AbstractEmailConte
                 .firstName("John")
                 .lastName(RESPONDENT_LAST_NAME)
                 .build()).build()))
-            .hearingDetails(wrapElements(HearingBooking.builder().startDate((HEARING_DATE)).build()))
+            .hearingDetails(wrapElements(HEARING_BOOKING))
             .build();
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-1983


### Change description ###
**Analysis done:** 
Think this is a bug when a case has multiple hearings but no hearing is linked to the document uploaded, the old “Manage Hearing” event will query the first (oldest) hearing and include it in the notification.
In the new "Manage hearing" event, we don't have the drop down option to select hearing.

**Expected behaviour:**
CFC document uploaded notification should be sent without hearing details

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
