### PR TITLE
DFPL-1956: Add migration to clear the old temp hearingOption field

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -44,7 +44,8 @@ public class MigrateCaseController extends CallbackController {
         "DFPL-1940", this::run1940,
         "DFPL-1934", this::run1934,
         "DFPL-log", this::runLogMigration,
-        "DFPL-1855", this::run1855
+        "DFPL-1855", this::run1855,
+        "DFPL-1956", this::run1956
     );
 
     private static void pushChangesToCaseDetails(CaseDetails caseDetails, Map<String, Object> changes) {
@@ -182,7 +183,7 @@ public class MigrateCaseController extends CallbackController {
         var migrationId = "DFPL-1855";
         caseDetails.getData().putAll(migrateCaseService.fixIncorrectCaseManagementLocation(caseDetails, migrationId));
     }
-  
+
     private void run1940(CaseDetails caseDetails) {
         var migrationId = "DFPL-1940";
         var possibleCaseIds = List.of(1697791879605293L);
@@ -196,6 +197,10 @@ public class MigrateCaseController extends CallbackController {
 
     private void run1934(CaseDetails caseDetails) {
         migrateCaseService.clearChangeOrganisationRequest(caseDetails);
+    }
+
+    private void run1956(CaseDetails caseDetails) {
+        migrateCaseService.clearHearingOption(caseDetails);
     }
 
     private void runLogMigration(CaseDetails caseDetails) {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseService.java
@@ -806,6 +806,10 @@ public class MigrateCaseService {
         caseDetails.getData().remove("changeOrganisationRequestField");
     }
 
+    public void clearHearingOption(CaseDetails caseDetails) {
+        caseDetails.getData().remove("hearingOption");
+    }
+
     public Map<String, List<Element<LocalAuthority>>> removeElementFromLocalAuthorities(CaseData caseData,
                                                                  String migrationId,
                                                                  UUID expectedLocalAuthorityId) {

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseServiceTest.java
@@ -2266,4 +2266,26 @@ class MigrateCaseServiceTest {
                     MIGRATION_ID, 1));
         }
     }
+
+    @Nested
+    class ClearHearingOption {
+        @Test
+        void shouldClearHearingOption() {
+            HashMap<String, Object> data = new HashMap<>();
+            data.put("hearingOption", "EDIT_HEARING");
+            CaseDetails caseDetails = CaseDetails.builder().data(data).build();
+
+            underTest.clearHearingOption(caseDetails);
+
+            assertThat(caseDetails.getData()).extracting("hearingOption").isNull();
+        }
+
+        @Test
+        void shouldDoNothingIfNoHearingOption() {
+            HashMap<String, Object> data = new HashMap<>();
+            CaseDetails caseDetails = CaseDetails.builder().data(data).build();
+
+            assertThat(caseDetails.getData()).isEmpty();
+        }
+    }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
[DFPL-1956](https://tools.hmcts.net/jira/browse/DFPL-1956)


### Change description ###
 - Clear old temporary field - `hearingOption`, enum has changed but was not fully cleared off old cases


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
