### PR TITLE
DFPL-2006 CFV - Missing C1/C2 category in notification to Sendgrid

### DIFF
--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -348,6 +348,8 @@ cafcass:
       newApplication: APPLICATION
       placementApplication: APPLICATION
       policeDisclosure: POLICE INFORMATION
+      c1ApplicationDocuments: COURT PAPER
+      c2ApplicationDocuments: COURT PAPER
 
 case_document_am:
   url: ${CASE_DOCUMENT_AM_URL:http://localhost:4455}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-2006


### Change description ###
Notification should be sent to Cafcass England via Sendgrid and categorised as COURT PAPER.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
