### PR TITLE
DFPL-TBC: Remove temp field subpermission incase field has been accidentally persisted

### DIFF
--- a/ccd-definition/AuthorisationComplexType/caseDocuments/placement.json
+++ b/ccd-definition/AuthorisationComplexType/caseDocuments/placement.json
@@ -214,7 +214,7 @@
           "[SOLICITOR]", "[SOLICITORA]", "[SOLICITORB]", "[SOLICITORC]", "[SOLICITORD]",
           "[SOLICITORE]", "[SOLICITORF]", "[SOLICITORG]", "[SOLICITORH]", "[SOLICITORI]", "[SOLICITORJ]"
         ],
-        "CRUD": "CRU"
+        "CRUD": "CU"
       },
       {
         "UserRoles": [


### PR DESCRIPTION
### JIRA link (if applicable) ###
TBC

### Change description ###
 - Make sure that even the temp field sublevel permissions are hidden from respondent solicitors, like the collection complextype



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
