### PR TITLE
DFPL-2120 Allow C1 with Supplement Supporting Documents to be Removed in Manage Documents

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/common/SubmittedC1WithSupplementBundle.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/common/SubmittedC1WithSupplementBundle.java
@@ -11,7 +11,7 @@ import uk.gov.hmcts.reform.fpl.model.SupportingEvidenceBundle;
 import java.util.List;
 
 @Data
-@Builder
+@Builder(toBuilder = true)
 @AllArgsConstructor
 public class SubmittedC1WithSupplementBundle  {
     private final DocumentReference document;

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ManageDocumentServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ManageDocumentServiceTest.java
@@ -5297,7 +5297,7 @@ class ManageDocumentServiceTest {
 
         @Test
         void adminShouldBeAbleToRemoveSupportingDocumentFromC1WithSupplement() {
-            int loginType = HMCTS_LOGIN_TYPE;x
+            int loginType = HMCTS_LOGIN_TYPE;
             initialiseUserService(loginType);
 
             SupportingEvidenceBundle seb = buildSupportingEvidenceBundle(filename1,

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ManageDocumentServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ManageDocumentServiceTest.java
@@ -5297,9 +5297,7 @@ class ManageDocumentServiceTest {
 
         @Test
         void adminShouldBeAbleToRemoveSupportingDocumentFromC1WithSupplement() {
-            int loginType = HMCTS_LOGIN_TYPE;
-            UUID additionalApplicationUUID = UUID.randomUUID();
-
+            int loginType = HMCTS_LOGIN_TYPE;x
             initialiseUserService(loginType);
 
             SupportingEvidenceBundle seb = buildSupportingEvidenceBundle(filename1,

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ManageDocumentServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ManageDocumentServiceTest.java
@@ -60,6 +60,7 @@ import uk.gov.hmcts.reform.fpl.model.common.C2DocumentBundle;
 import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
 import uk.gov.hmcts.reform.fpl.model.common.OtherApplicationsBundle;
+import uk.gov.hmcts.reform.fpl.model.common.SubmittedC1WithSupplementBundle;
 import uk.gov.hmcts.reform.fpl.model.common.dynamic.DynamicList;
 import uk.gov.hmcts.reform.fpl.model.common.dynamic.DynamicListElement;
 import uk.gov.hmcts.reform.fpl.model.event.ManageDocumentEventData;
@@ -3914,6 +3915,29 @@ class ManageDocumentServiceTest {
         }
 
         @Test
+        void shouldShowC1SupportingDocumentsInDocumentTypesForSubmittedC1WithSupplementByLA() {
+            initialiseUserService(HMCTS_LOGIN_TYPE);
+            DocumentUploaderType uploaderType = getUploaderType(LA_LOGIN_TYPE);
+
+            when(caseConverter.toMap(any())).thenReturn(Map.of());
+            when(dynamicListService.asDynamicList(List.of(
+                Pair.of(AA_PARENT_APPLICATIONS.name(), AA_PARENT_APPLICATIONS.getDescription()),
+                Pair.of(C1_APPLICATION_DOCUMENTS.name(), C1_APPLICATION_DOCUMENTS.getDescription())
+            ))).thenReturn(expectedDynamicList1);
+
+            DynamicList dynamicList = underTest.buildDocumentTypeDynamicListForRemoval(CaseData.builder()
+                .submittedC1WithSupplement(SubmittedC1WithSupplementBundle.builder()
+                    .supportingEvidenceBundle(List.of(element(SupportingEvidenceBundle.builder()
+                        .document(testDocumentReference())
+                        .uploaderType(uploaderType)
+                        .uploaderCaseRoles(getUploaderCaseRoles(LA_LOGIN_TYPE))
+                        .build())))
+                    .build())
+                .build());
+            assertThat(dynamicList).isEqualTo(expectedDynamicList1);
+        }
+
+        @Test
         void shouldShowC2SupportingDocumentsInDocumentTypes() {
             initialiseUserService(HMCTS_LOGIN_TYPE);
             DocumentUploaderType uploaderType = getUploaderType(HMCTS_LOGIN_TYPE);
@@ -4307,6 +4331,29 @@ class ManageDocumentServiceTest {
                         .build())
                     .build())
             ));
+
+            when(dynamicListService.asDynamicList(List.of(
+                Pair.of(format("%s###%s", C1_APPLICATION_DOCUMENTS.name(), elementId1), filename1)
+            ))).thenReturn(expectedDynamicList1);
+
+            DynamicList dynamicList = underTest.buildAvailableDocumentsToBeRemoved(builder.build());
+            assertThat(dynamicList).isEqualTo(expectedDynamicList1);
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {LA_LOGIN_TYPE, HMCTS_LOGIN_TYPE})
+        void shouldReturnDynamicListWhenC1WithSupplementSupportingDocumentUploadedByLA(
+            int loginType) {
+            initialiseUserService(loginType);
+            CaseData.CaseDataBuilder builder = createCaseDataBuilderForRemovalDocumentJourney();
+            builder.submittedC1WithSupplement(
+                SubmittedC1WithSupplementBundle.builder()
+                    .supportingEvidenceBundle(List.of(element(elementId1, SupportingEvidenceBundle.builder()
+                        .document(testDocumentReference(filename1))
+                        .uploaderType(getUploaderType(LA_LOGIN_TYPE))
+                        .uploaderCaseRoles(getUploaderCaseRoles(LA_LOGIN_TYPE))
+                        .build())))
+                    .build());
 
             when(dynamicListService.asDynamicList(List.of(
                 Pair.of(format("%s###%s", C1_APPLICATION_DOCUMENTS.name(), elementId1), filename1)


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-2120


### Change description ###
Allow C1 with Supplement Supporting Documents to be Removed in Manage Documents


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
