### PR TITLE
Add environment parameterisation for demo/perftest/etc 

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn lint
+#yarn lint

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -30,7 +30,8 @@ def integrationTestSecrets = [
   'fpl-aat': [
     secret('integration-test-notify-service-key', 'INTEGRATION_TEST_NOTIFY_SERVICE_KEY'),
     secret('docmosis-api-key', 'INTEGRATION_TEST_DOCMOSIS_TORNADO_KEY'),
-    secret('e2e-test-password', 'E2E_TEST_PASSWORD')
+    secret('e2e-test-password', 'E2E_TEST_PASSWORD'),
+    secret('e2e-test-judge-password', 'E2E_TEST_JUDGE_PASSWORD')
   ]
 ]
 

--- a/playwright-e2e/README.md
+++ b/playwright-e2e/README.md
@@ -41,6 +41,7 @@ AAT_SERVICE_URL=https://example.com
 
 # Passwords
 E2E_TEST_PASSWORD=passwordhere
+E2E_TEST_JUDGE_PASSWORD=passwordhere
 
 # Ports
 SERVER_PORT=

--- a/playwright-e2e/pages/sign-in.ts
+++ b/playwright-e2e/pages/sign-in.ts
@@ -1,5 +1,5 @@
 import { type Page, type Locator, expect } from "@playwright/test";
-import UrlConfig from "../settings/urls";
+import { urlConfig } from "../settings/urls";
 
 export class SignInPage {
   readonly page: Page;
@@ -12,7 +12,7 @@ export class SignInPage {
 
   public constructor(page: Page) {
     this.page = page;
-    this.url = UrlConfig.frontEndBaseURL;
+    this.url = urlConfig.frontEndBaseURL;
     this.emailInputLocator = page.getByLabel("Email address");
     this.passwordInputLocator = page.getByLabel("Password");
     this.signinButtonLocator = page.getByRole("button", { name: "Sign in" });

--- a/playwright-e2e/settings/urls.ts
+++ b/playwright-e2e/settings/urls.ts
@@ -1,16 +1,13 @@
+// aat, demo, perftest, ithc
+const env = process.env.ENVIRONMENT || "aat";
+
 interface UrlConfig {
-  [key: string]: URL | string;
+  [key: string]: string;
 }
 
-const urlConfig: UrlConfig = {
-  aatIdamUrl: process.env.AAT_IDAM_URL || "https://idam-api.aat.platform.hmcts.net/",
-  aatServiceUrl: process.env.AAT_SERVICE_URL || "http://fpl-case-service-aat.service.core-compute-aat.internal/",
-  frontEndBaseURL: process.env.FE_BASE_URL || "https://manage-case.aat.platform.hmcts.net/",
+export const urlConfig: UrlConfig = {
+  idamUrl: process.env.AAT_IDAM_URL || `https://idam-api.${env}.platform.hmcts.net/`,
+  serviceUrl: process.env.AAT_SERVICE_URL || `http://fpl-case-service-${env}.service.core-compute-${env}.internal/`,
+  frontEndBaseURL: process.env.FE_BASE_URL || `https://manage-case.${env}.platform.hmcts.net/`,
   // You can add other URLs as needed
-};
-
-export default urlConfig as {
-  aatIdamUrl: string;
-  aatServiceUrl: string;
-  frontEndBaseURL: string;
 };

--- a/playwright-e2e/settings/userCredentials.ts
+++ b/playwright-e2e/settings/userCredentials.ts
@@ -1,7 +1,8 @@
-import dotenv from "dotenv";
+import * as dotenv from "dotenv";
 dotenv.config();
 
 const e2ePw = process.env.E2E_TEST_PASSWORD || "";
+const e2eJudgePw = process.env.E2E_TEST_JUDGE_PASSWORD || "";
 
 export const newSwanseaLocalAuthorityUserOne = {
   email: "local-authority-swansea-0001@maildrop.cc",
@@ -11,3 +12,7 @@ export const systemUpdateUser = {
   email: "fpl-system-update@mailnesia.com",
   password: e2ePw,
 };
+export const judgeWalesUser = {
+  email: "judge-wales@ejudiciary.net",
+  password: e2eJudgePw,
+}

--- a/playwright-e2e/utils/apiFixture.ts
+++ b/playwright-e2e/utils/apiFixture.ts
@@ -1,10 +1,10 @@
-import {systemUpdateUser,newSwanseaLocalAuthorityUserOne, swanseaUser} from '../settings/userCredentials';
-import {UrlConfig} from '../settings/urls';
+import { systemUpdateUser, newSwanseaLocalAuthorityUserOne } from '../settings/userCredentials';
+import { urlConfig } from '../settings/urls';
 
 
 import axios from 'axios';
-import qs from 'qs';
-import lodash from 'lodash'
+import * as qs from 'qs';
+import * as lodash from 'lodash'
 
 export class Apihelp {
 
@@ -15,7 +15,7 @@ export class Apihelp {
           'Content-Type': 'application/x-www-form-urlencoded',
         },
       };
-      let  url = `${UrlConfig.idamUrl}/loginUser?username=${user.email}&password=${user.password}`;
+      let  url = `${urlConfig.idamUrl}/loginUser?username=${user.email}&password=${user.password}`;
       return await axios.post(url,qs.stringify(axiosConfig));
     } catch (error) {
       if (axios.isAxiosError(error)) {
@@ -31,11 +31,11 @@ export class Apihelp {
   async createCase(caseName='e2e UI Test'){
 
     let res : object;
-    const url = `${UrlConfig.serviceUrl}/testing-support/case/create`;
+    const url = `${urlConfig.serviceUrl}/testing-support/case/create`;
     const data = {
             caseName : caseName,
          };
-      res= await this.apiRequest(url,swanseaUser,'post',data);
+      res= await this.apiRequest(url, newSwanseaLocalAuthorityUserOne,'post',data);
      // @ts-ignore
     return res.id;
   }
@@ -43,7 +43,7 @@ export class Apihelp {
   async updateCase(caseName = 'e2e Test',caseID: string,caseData: {} | undefined){
     //This can be moved to before test hook to as same document URL will be used for all test data
     //replace the documents placeholder with docuemnt url
-    let  docDetail =await this.apiRequest(UrlConfig.serviceUrl + '/testing-support/test-document',systemUpdateUser);
+    let  docDetail =await this.apiRequest(urlConfig.serviceUrl + '/testing-support/test-document',systemUpdateUser);
           let docParameter= {
       TEST_DOCUMENT_URL : docDetail.document_url,
       TEST_DOCUMENT_BINARY_URL : docDetail.document_binary_url
@@ -57,7 +57,7 @@ export class Apihelp {
     // @ts-ignore
     caseData.caseData.dateAndTimeSubmitted = dateTime.slice(0, -1);
     let data =lodash.template(JSON.stringify(caseData))(docParameter);
-    let postURL = `${UrlConfig.serviceUrl}/testing-support/case/populate/${caseID}`;
+    let postURL = `${urlConfig.serviceUrl}/testing-support/case/populate/${caseID}`;
       try {
         console.log (' update request')
      let   res = await this.apiRequest(postURL,systemUpdateUser,'post',data);


### PR DESCRIPTION
### JIRA link (if applicable) ###
TBC


### Change description ###
 - Parameterise urls with environment so we can run against demo easier, defaulting to `aat`
 - Add Judge test user (recreated in AAT, the passwords are different (again... as were originally created by another team))
 - Fix some typescript import/export warnings
 - Disable OLD TEST LINTING, kept running in IntelliJ and was getting annoying, as was linting old tests


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
