### PR TITLE
DFPL-2172 - No HTML Test Report Generated for Failing Playwright Tests

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -106,17 +106,24 @@ withNightlyPipeline(type, product, component) {
   }
 
   afterAlways('fullFunctionalTest') {
-    yarnBuilder.yarn('test:functional-nightly')
-    env.TESTS_FOR_ACCESSIBILITY = false
-    publishHTML([
-      allowMissing         : true,
-      alwaysLinkToLastBuild: true,
-      keepAll              : true,
-      reportDir            : "playwright-report",
-      reportFiles          : 'index.html',
-      reportName           : 'UI Functional Test Report'
-    ])
-    steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'build/reports/tests/functionalTest/**/*'
+    stage('Functional Tests Nightly') {
+      try {
+        yarnBuilder.yarn('test:functional-nightly')
+        env.TESTS_FOR_ACCESSIBILITY = false
+      } catch (Error) {
+        unstable(message: "${STAGE_NAME} is unstable: " + Error.toString())
+      } finally {
+        publishHTML([
+          allowMissing         : true,
+          alwaysLinkToLastBuild: true,
+          keepAll              : true,
+          reportDir            : "playwright-report",
+          reportFiles          : 'index.html',
+          reportName           : 'UI Functional Test Report'
+        ])
+        steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'build/reports/tests/functionalTest/**/*'
+      }
+    }
   }
 
   afterAlways('fortify-scan') {

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -109,7 +109,6 @@ withNightlyPipeline(type, product, component) {
     stage('Functional Tests Nightly') {
       try {
         yarnBuilder.yarn('test:functional-nightly')
-        env.TESTS_FOR_ACCESSIBILITY = false
       } catch (Error) {
         unstable(message: "${STAGE_NAME} is unstable: " + Error.toString())
       } finally {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DFPL-2172

### Change description ###
Reports should be generated even when the tests fail. New stage is added with try/catch block to catch the error and finally generate html reports. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
