### PR TITLE
DFPL-1918: Bring back old setup judicial roles migration for rerun

### DIFF
--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseControllerTest.java
@@ -9,11 +9,22 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.fpl.config.rd.JudicialUsersConfiguration;
+import uk.gov.hmcts.reform.fpl.config.rd.LegalAdviserUsersConfiguration;
 import uk.gov.hmcts.reform.fpl.controllers.AbstractCallbackTest;
+import uk.gov.hmcts.reform.fpl.enums.JudgeOrMagistrateTitle;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
+import uk.gov.hmcts.reform.fpl.model.HearingBooking;
+import uk.gov.hmcts.reform.fpl.model.Judge;
+import uk.gov.hmcts.reform.fpl.model.JudicialUser;
+import uk.gov.hmcts.reform.fpl.model.common.JudgeAndLegalAdvisor;
+import uk.gov.hmcts.reform.fpl.service.JudicialService;
 import uk.gov.hmcts.reform.fpl.service.MigrateCFVService;
+import uk.gov.hmcts.reform.fpl.utils.ElementUtils;
 
+import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import static org.apache.commons.lang3.RandomUtils.nextLong;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -25,6 +36,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @WebMvcTest(MigrateCaseController.class)
 @OverrideAutoConfiguration(enabled = true)
@@ -38,6 +50,15 @@ class MigrateCaseControllerTest extends AbstractCallbackTest {
 
     @MockBean
     private MigrateCFVService migrateCFVService;
+
+    @MockBean
+    private JudicialUsersConfiguration judicialUsersConfiguration;
+
+    @MockBean
+    private JudicialService judicialService;
+
+    @MockBean
+    private LegalAdviserUsersConfiguration legalAdviserUsersConfiguration;
 
     @Test
     void shouldThrowExceptionWhenMigrationNotMappedForMigrationID() {
@@ -257,7 +278,7 @@ class MigrateCaseControllerTest extends AbstractCallbackTest {
 
             doThrow(AssertionError.class).when(migrateCFVService)
                 .doHasCFVMigratedCheck(anyLong(), any(), any(), eq(true));
-            
+
             assertThatThrownBy(() -> postAboutToSubmitEvent(caseDetails))
                 .getRootCause()
                 .isInstanceOf(AssertionError.class);
@@ -277,4 +298,222 @@ class MigrateCaseControllerTest extends AbstractCallbackTest {
             verify(migrateCFVService, times(0)).rollbackArchivedDocumentsList();
         }
     }
+
+    @Nested
+    class DfplAm {
+
+        private final String migrationId = "DFPL-AM";
+
+        @BeforeEach
+        void beforeEach() {
+            when(judicialService.getHearingJudgeRolesForMigration(any())).thenReturn(List.of());
+        }
+
+        @Test
+        void shouldUpdateAllocatedJudgeId() {
+            when(judicialUsersConfiguration.getJudgeUUID("test@test.com")).thenReturn(Optional.of("12345"));
+            when(judicialService.getJudgeUserIdFromEmail("test@test.com")).thenReturn(Optional.of("12345"));
+            when(legalAdviserUsersConfiguration.getLegalAdviserUUID("test@test.com")).thenReturn(Optional.empty());
+            CaseData caseData = CaseData.builder()
+                .id(12345L)
+                .allocatedJudge(Judge.builder()
+                    .judgeTitle(JudgeOrMagistrateTitle.HIS_HONOUR_JUDGE)
+                    .judgeLastName("Test")
+                    .judgeEmailAddress("test@test.com")
+                    .build())
+                .build();
+
+            AboutToStartOrSubmitCallbackResponse response = postAboutToSubmitEvent(
+                buildCaseDetails(caseData, migrationId));
+            CaseData responseData = extractCaseData(response);
+
+            assertThat(responseData.getAllocatedJudge()).extracting("judgeJudicialUser")
+                .isEqualTo(JudicialUser.builder()
+                    .idamId("12345")
+                    .build());
+        }
+
+        @Test
+        void shouldUpdateAllocatedJudgeIdIfLegalAdviser() {
+            when(judicialService.getJudgeUserIdFromEmail("test@test.com")).thenReturn(Optional.of("12345"));
+            when(legalAdviserUsersConfiguration.getLegalAdviserUUID("test@test.com")).thenReturn(Optional.of("12345"));
+            when(judicialUsersConfiguration.getJudgeUUID("test@test.com")).thenReturn(Optional.empty());
+            CaseData caseData = CaseData.builder()
+                .id(12345L)
+                .allocatedJudge(Judge.builder()
+                    .judgeTitle(JudgeOrMagistrateTitle.LEGAL_ADVISOR)
+                    .judgeLastName("Test")
+                    .judgeEmailAddress("test@test.com")
+                    .build())
+                .build();
+
+            AboutToStartOrSubmitCallbackResponse response = postAboutToSubmitEvent(
+                buildCaseDetails(caseData, migrationId));
+            CaseData responseData = extractCaseData(response);
+
+            assertThat(responseData.getAllocatedJudge()).extracting("judgeJudicialUser")
+                .isEqualTo(JudicialUser.builder()
+                    .idamId("12345")
+                    .build());
+        }
+
+
+        @Test
+        void shouldUpdateHearingJudgeIdIfLegalAdviser() {
+            when(judicialService.getJudgeUserIdFromEmail("test@test.com")).thenReturn(Optional.of("12345"));
+            when(legalAdviserUsersConfiguration.getLegalAdviserUUID("test@test.com")).thenReturn(Optional.of("12345"));
+            when(judicialUsersConfiguration.getJudgeUUID("test@test.com")).thenReturn(Optional.empty());
+            CaseData caseData = CaseData.builder()
+                .id(12345L)
+                .hearingDetails(ElementUtils.wrapElements(
+                    HearingBooking.builder()
+                        .startDate(now().plusDays(5))
+                        .endDate(now().plusDays(6))
+                        .judgeAndLegalAdvisor(JudgeAndLegalAdvisor.builder()
+                            .judgeTitle(JudgeOrMagistrateTitle.LEGAL_ADVISOR)
+                            .judgeLastName("Test")
+                            .judgeEmailAddress("test@test.com")
+                            .build())
+                        .build()
+                ))
+                .build();
+
+            AboutToStartOrSubmitCallbackResponse response = postAboutToSubmitEvent(
+                buildCaseDetails(caseData, migrationId));
+            CaseData responseData = extractCaseData(response);
+
+            assertThat(responseData.getHearingDetails()).hasSize(1);
+            assertThat(responseData.getHearingDetails().get(0).getValue().getJudgeAndLegalAdvisor())
+                .extracting("judgeJudicialUser")
+                .isEqualTo(JudicialUser.builder()
+                    .idamId("12345")
+                    .build());
+        }
+
+        @Test
+        void shouldUpdateHearingJudgeIdIfJudge() {
+            when(judicialService.getJudgeUserIdFromEmail("test@test.com")).thenReturn(Optional.of("12345"));
+            when(judicialUsersConfiguration.getJudgeUUID("test@test.com")).thenReturn(Optional.of("12345"));
+            when(legalAdviserUsersConfiguration.getLegalAdviserUUID("test@test.com")).thenReturn(Optional.empty());
+            CaseData caseData = CaseData.builder()
+                .id(12345L)
+                .hearingDetails(ElementUtils.wrapElements(
+                    HearingBooking.builder()
+                        .startDate(now().plusDays(5))
+                        .endDate(now().plusDays(6))
+                        .judgeAndLegalAdvisor(JudgeAndLegalAdvisor.builder()
+                            .judgeTitle(JudgeOrMagistrateTitle.HIS_HONOUR_JUDGE)
+                            .judgeLastName("Test")
+                            .judgeEmailAddress("test@test.com")
+                            .build())
+                        .build()
+                ))
+                .build();
+
+            AboutToStartOrSubmitCallbackResponse response = postAboutToSubmitEvent(
+                buildCaseDetails(caseData, migrationId));
+            CaseData responseData = extractCaseData(response);
+
+            assertThat(responseData.getHearingDetails()).hasSize(1);
+            assertThat(responseData.getHearingDetails().get(0).getValue().getJudgeAndLegalAdvisor())
+                .extracting("judgeJudicialUser")
+                .isEqualTo(JudicialUser.builder()
+                    .idamId("12345")
+                    .build());
+        }
+
+        @Test
+        void shouldLeaveHearingsUnchangedIfNotInMapping() {
+            when(judicialService.getJudgeUserIdFromEmail("test@test.com")).thenReturn(Optional.empty());
+            when(judicialUsersConfiguration.getJudgeUUID("test@test.com")).thenReturn(Optional.empty());
+            when(legalAdviserUsersConfiguration.getLegalAdviserUUID("test@test.com")).thenReturn(Optional.empty());
+            CaseData caseData = CaseData.builder()
+                .id(12345L)
+                .hearingDetails(ElementUtils.wrapElements(
+                    HearingBooking.builder()
+                        .startDate(now().plusDays(5))
+                        .endDate(now().plusDays(6))
+                        .judgeAndLegalAdvisor(JudgeAndLegalAdvisor.builder()
+                            .judgeTitle(JudgeOrMagistrateTitle.HIS_HONOUR_JUDGE)
+                            .judgeLastName("Test")
+                            .judgeEmailAddress("test@test.com")
+                            .build())
+                        .build()
+                ))
+                .build();
+
+            AboutToStartOrSubmitCallbackResponse response = postAboutToSubmitEvent(
+                buildCaseDetails(caseData, migrationId));
+            CaseData responseData = extractCaseData(response);
+
+            assertThat(responseData.getHearingDetails()).isEqualTo(caseData.getHearingDetails());
+        }
+
+        @Test
+        void shouldHaveNoChangeToHearingsIfNone() {
+            CaseData caseData = CaseData.builder()
+                .id(12345L)
+                .build();
+
+            AboutToStartOrSubmitCallbackResponse response = postAboutToSubmitEvent(
+                buildCaseDetails(caseData, migrationId));
+            CaseData responseData = extractCaseData(response);
+
+            assertThat(responseData.getHearingDetails()).isNull();
+        }
+
+        @Test
+        void shouldDoRollback() {
+            CaseData caseData = CaseData.builder()
+                .id(12345L)
+                .allocatedJudge(Judge.builder()
+                    .judgeTitle(JudgeOrMagistrateTitle.HIS_HONOUR_JUDGE)
+                    .judgeLastName("Test")
+                    .judgeEmailAddress("test@test.com")
+                    .judgeJudicialUser(JudicialUser.builder()
+                        .idamId("12345")
+                        .build())
+                    .build())
+                .hearingDetails(ElementUtils.wrapElements(
+                    HearingBooking.builder()
+                        .startDate(now().plusDays(5))
+                        .endDate(now().plusDays(6))
+                        .judgeAndLegalAdvisor(JudgeAndLegalAdvisor.builder()
+                            .judgeTitle(JudgeOrMagistrateTitle.HIS_HONOUR_JUDGE)
+                            .judgeLastName("Test")
+                            .judgeEmailAddress("test@test.com")
+                            .judgeJudicialUser(JudicialUser.builder()
+                                .idamId("12345")
+                                .build())
+                            .build())
+                        .build()
+                ))
+                .build();
+
+            AboutToStartOrSubmitCallbackResponse response = postAboutToSubmitEvent(
+                buildCaseDetails(caseData, migrationId + "-Rollback"));
+            CaseData responseData = extractCaseData(response);
+
+            assertThat(responseData.getHearingDetails()).hasSize(1);
+            assertThat(responseData.getHearingDetails().get(0).getValue().getJudgeAndLegalAdvisor())
+                .extracting("judgeJudicialUser")
+                .isNull();
+            assertThat(responseData.getAllocatedJudge()).extracting("judgeJudicialUser").isNull();
+        }
+
+        @Test
+        void shouldHaveNoChangeToHearingsInRollbackIfNone() {
+            CaseData caseData = CaseData.builder()
+                .id(12345L)
+                .build();
+
+            AboutToStartOrSubmitCallbackResponse response = postAboutToSubmitEvent(
+                buildCaseDetails(caseData, migrationId + "-Rollback"));
+            CaseData responseData = extractCaseData(response);
+
+            assertThat(responseData.getHearingDetails()).isNull();
+        }
+
+    }
+
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -59,7 +59,6 @@ public class MigrateCaseController extends CallbackController {
         "DFPL-CFV-Failure", this::runCfvFailure,
         "DFPL-CFV-dry", this::dryRunCFV,
         "DFPL-1940", this::run1940,
-        "DFPL-2177", this::run2177,
         "DFPL-AM", this::runAM,
         "DFPL-AM-Rollback", this::runAmRollback,
         "DFPL-1882", this::run1882,
@@ -354,7 +353,7 @@ public class MigrateCaseController extends CallbackController {
         // 3. Attempt to assign the new roles in AM
         migrateRoles(newCaseData);
     }
-  
+
     private void run1882(CaseDetails caseDetails) {
         var migrationId = "DFPL-1882";
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -8,23 +8,38 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.hmcts.reform.am.model.RoleAssignment;
+import uk.gov.hmcts.reform.am.model.RoleCategory;
 import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.controllers.CallbackController;
 import uk.gov.hmcts.reform.fpl.enums.YesNo;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
+import uk.gov.hmcts.reform.fpl.model.HearingBooking;
+import uk.gov.hmcts.reform.fpl.model.Judge;
+import uk.gov.hmcts.reform.fpl.model.JudicialUser;
+import uk.gov.hmcts.reform.fpl.model.common.Element;
+import uk.gov.hmcts.reform.fpl.service.JudicialService;
 import uk.gov.hmcts.reform.fpl.service.MigrateCFVService;
 import uk.gov.hmcts.reform.fpl.service.MigrateCaseService;
 import uk.gov.hmcts.reform.fpl.service.orders.ManageOrderDocumentScopedFieldsCalculator;
+import uk.gov.hmcts.reform.fpl.utils.RoleAssignmentUtils;
 
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
+
+import static org.apache.commons.lang3.ObjectUtils.isEmpty;
+import static uk.gov.hmcts.reform.fpl.enums.JudgeCaseRole.ALLOCATED_JUDGE;
+import static uk.gov.hmcts.reform.fpl.enums.LegalAdviserRole.ALLOCATED_LEGAL_ADVISER;
 
 @Api
 @Slf4j
@@ -36,6 +51,7 @@ public class MigrateCaseController extends CallbackController {
     private final ManageOrderDocumentScopedFieldsCalculator fieldsCalculator;
     private final MigrateCaseService migrateCaseService;
     private final MigrateCFVService migrateCFVService;
+    private final JudicialService judicialService;
 
     private final Map<String, Consumer<CaseDetails>> migrations = Map.of(
         "DFPL-CFV", this::runCFV,
@@ -43,7 +59,9 @@ public class MigrateCaseController extends CallbackController {
         "DFPL-CFV-Failure", this::runCfvFailure,
         "DFPL-CFV-dry", this::dryRunCFV,
         "DFPL-1940", this::run1940,
-        "DFPL-2177", this::run2177
+        "DFPL-2177", this::run2177,
+        "DFPL-AM", this::runAM,
+        "DFPL-AM-Rollback", this::runAmRollback
     );
 
     private static void pushChangesToCaseDetails(CaseDetails caseDetails, Map<String, Object> changes) {
@@ -197,5 +215,141 @@ public class MigrateCaseController extends CallbackController {
         CaseData caseData = getCaseData(caseDetails);
         migrateCaseService.verifyUrgentDirectionsOrderExists(caseData, migrationId, expectedDocumentId);
         caseDetails.getData().remove("urgentDirectionsOrder");
+    }
+
+    private void migrateRoles(CaseData caseData) {
+        List<RoleAssignment> rolesToAssign = new ArrayList<>();
+
+        // If we have an allocated judge with an IDAM ID (added in about-to-submit step from mapping)
+        Optional<Judge> allocatedJudge = judicialService.getAllocatedJudge(caseData);
+        if (allocatedJudge.isPresent()
+            && !isEmpty(allocatedJudge.get().getJudgeJudicialUser())
+            && !isEmpty(allocatedJudge.get().getJudgeJudicialUser().getIdamId())) {
+
+            Optional<RoleCategory> userRoleCategory = judicialService
+                .getUserRoleCategory(allocatedJudge.get().getJudgeEmailAddress());
+
+            if (userRoleCategory.isPresent()) {
+                // attempt to assign allocated-[role]
+                boolean isLegalAdviser = userRoleCategory.get().equals(RoleCategory.LEGAL_OPERATIONS);
+
+                rolesToAssign.add(RoleAssignmentUtils.buildRoleAssignment(
+                    caseData.getId(),
+                    allocatedJudge.get().getJudgeJudicialUser().getIdamId(),
+                    isLegalAdviser ? ALLOCATED_LEGAL_ADVISER.getRoleName() : ALLOCATED_JUDGE.getRoleName(),
+                    userRoleCategory.get(),
+                    ZonedDateTime.now(),
+                    null // no end date
+                ));
+            }
+        } else {
+            log.error("Could not assign allocated-judge on case {}, no UUID found on the case", caseData.getId());
+        }
+
+        // get hearing judge roles to add (if any)
+        rolesToAssign.addAll(judicialService.getHearingJudgeRolesForMigration(caseData));
+
+        log.info("Attempting to create {} roles on case {}", rolesToAssign.size(), caseData.getId());
+        judicialService.migrateJudgeRoles(rolesToAssign);
+    }
+
+    private void runAmRollback(CaseDetails caseDetails) {
+        var migrationId = "DFPL-AM-Rollback";
+        CaseData caseData = getCaseData(caseDetails);
+
+        Judge allocatedJudge = caseData.getAllocatedJudge();
+        if (!isEmpty(allocatedJudge)) {
+            caseDetails.getData().put("allocatedJudge", allocatedJudge.toBuilder()
+                .judgeEnterManually(null)
+                .judgeJudicialUser(null)
+                .build());
+        }
+
+        List<Element<HearingBooking>> hearingsWithIdamIdsStripped = caseData.getAllNonCancelledHearings()
+            .stream().map(hearing -> {
+                HearingBooking booking = hearing.getValue();
+
+                booking.setJudgeAndLegalAdvisor(booking.getJudgeAndLegalAdvisor().toBuilder()
+                    .judgeEnterManually(null)
+                    .judgeJudicialUser(null)
+                    .build());
+                hearing.setValue(booking);
+                return hearing;
+            }).toList();
+
+        if (caseData.getAllNonCancelledHearings().size() > 0) {
+            caseDetails.getData().put("hearingDetails", hearingsWithIdamIdsStripped);
+        }
+        caseDetails.getData().remove("hasBeenAMMigrated");
+
+        // delete all roles on the case - if this fails we WANT the migration to stop, as it has not been rolled back
+        judicialService.deleteAllRolesOnCase(caseData.getId());
+    }
+
+    private void runAM(CaseDetails caseDetails) {
+        var migrationId = "DFPL-AM";
+
+        CaseData caseData = getCaseData(caseDetails);
+
+        // 1. cleanup from past migration
+        judicialService.deleteAllRolesOnCase(caseData.getId());
+
+        // 2. Add UUIDs for judges + legal advisers
+        Judge allocatedJudge = caseData.getAllocatedJudge();
+        if (!isEmpty(allocatedJudge) && !isEmpty(allocatedJudge.getJudgeEmailAddress())) {
+            String email = allocatedJudge.getJudgeEmailAddress();
+            Optional<String> uuid = judicialService.getJudgeUserIdFromEmail(email);
+            // add the UUID to the allocated judge and save on the case
+
+            if (uuid.isEmpty()) {
+                log.info("Could not find judge UUID, caseId={}, allocatedJudge, ejudiciary={}, judgeTitle={}",
+                    caseData.getId(), email.toLowerCase().endsWith("@ejudiciary.net"), allocatedJudge.getJudgeTitle());
+            }
+
+            uuid.ifPresent(s -> caseDetails.getData().put("allocatedJudge", allocatedJudge.toBuilder()
+                .judgeJudicialUser(JudicialUser.builder()
+                    .idamId(s)
+                    .build())
+                .build()));
+        }
+
+        List<Element<HearingBooking>> hearings = caseData.getAllNonCancelledHearings();
+        List<Element<HearingBooking>> modified = hearings.stream()
+            .map(el -> {
+                HearingBooking val = el.getValue();
+                if (!isEmpty(val.getJudgeAndLegalAdvisor())
+                    && !isEmpty(val.getJudgeAndLegalAdvisor().getJudgeEmailAddress())) {
+
+                    String email = val.getJudgeAndLegalAdvisor().getJudgeEmailAddress();
+                    Optional<String> uuid = judicialService.getJudgeUserIdFromEmail(email);
+                    if (uuid.isPresent()) {
+                        el.setValue(val.toBuilder()
+                            .judgeAndLegalAdvisor(val.getJudgeAndLegalAdvisor().toBuilder()
+                                .judgeJudicialUser(JudicialUser.builder()
+                                    .idamId(uuid.get())
+                                    .build())
+                                .build())
+                            .build());
+                        return el;
+                    } else {
+                        log.info("Could not find judge UUID, caseId={}, hearingId={}, ejudiciary={}, judgeTitle={}",
+                            caseData.getId(), el.getId(), email.toLowerCase().endsWith("@ejudiciary.net"),
+                            val.getJudgeAndLegalAdvisor().getJudgeTitle());
+                    }
+                }
+                return el;
+            }).toList();
+
+        if (!hearings.isEmpty()) {
+            // don't add an empty array if there weren't any hearings beforehand
+            caseDetails.getData().put("hearingDetails", modified);
+        }
+        caseDetails.getData().put("hasBeenAMMigrated", "Yes");
+
+        // Convert our newly annotated case details payload to a case data object
+        CaseData newCaseData = getCaseData(caseDetails);
+
+        // 3. Attempt to assign the new roles in AM
+        migrateRoles(newCaseData);
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-1918


### Change description ###
 - Bringing back the runAM + runAMRollback migrations for one final run before WA NRO 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
