### PR TITLE
DFPL-2156: Retry securedocstore document download and add backoff delay of 5s

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/utils/SecureDocStoreHelper.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/utils/SecureDocStoreHelper.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.reform.fpl.utils;
 
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import uk.gov.hmcts.reform.ccd.document.am.model.Classification;
 import uk.gov.hmcts.reform.ccd.document.am.model.Document;
 import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
@@ -37,6 +39,7 @@ public class SecureDocStoreHelper {
      *                           otherwise, UnsupportedOperationException will be thrown.
      * @return byte array of the file
      */
+    @Retryable(value = UnsupportedOperationException.class, maxAttempts = 5, backoff = @Backoff(delay = 500))
     @SneakyThrows
     public byte[] download(final String documentUrlString, Callable<byte[]> oldDmStoreApproach) {
         try {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DFPL-2156

### Change description ###

Retry securedocstore document download 5 times and add backoff delay of 5s between each retry attempt

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```