### PR TITLE
Fix test with hardcoded "future" date in it

### DIFF
--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/CaseExtensionControllerMidEventTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/CaseExtensionControllerMidEventTest.java
@@ -66,7 +66,7 @@ class CaseExtensionControllerMidEventTest extends AbstractCallbackTest {
                 .childExtension1(ChildExtension.builder()
                         .id(id2)
                         .caseExtensionTimeList(CaseExtensionTime.OTHER_EXTENSION)
-                        .extensionDateOther(LocalDate.of(2024, 3, 4))
+                        .extensionDateOther(LocalDate.now().plusYears(1))
                         .caseExtensionReasonList(INTERNATIONAL_ASPECT)
                         .index("2")
                         .build())


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
 - Fix test for "Other" extension date to be 1 year ahead of the _current_ date not a hardcoded date (now in the past)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
