### PR TITLE
DFPL-2229: Fix flaky async tests verifying things in the wrong order

### DIFF
--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ListGatekeepingControllerSubmittedTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ListGatekeepingControllerSubmittedTest.java
@@ -180,6 +180,9 @@ class ListGatekeepingControllerSubmittedTest extends ManageHearingsControllerTes
     @Captor
     private ArgumentCaptor<Map<String, Object>> eventDataCaptor;
 
+    @Captor
+    private ArgumentCaptor<String> eventIdCaptor;
+
     @MockBean
     private CCDConcurrencyHelper concurrencyHelper;
 
@@ -654,11 +657,13 @@ class ListGatekeepingControllerSubmittedTest extends ManageHearingsControllerTes
 
         verifyNoInteractions(notificationClient);
 
-        verify(concurrencyHelper).startEvent(eq(CASE_ID), eq("internal-update-case-summary"));
+        verify(concurrencyHelper, timeout(ASYNC_METHOD_CALL_TIMEOUT).times(2))
+            .startEvent(eq(CASE_ID), eventIdCaptor.capture());
         verify(concurrencyHelper, timeout(ASYNC_METHOD_CALL_TIMEOUT))
             .submitEvent(startEventResponseArgumentCaptor.capture(), eq(CASE_ID), eventDataCaptor.capture());
-        verify(concurrencyHelper).startEvent(eq(CASE_ID), eq("internal-change-add-gatekeeping"));
 
+        assertThat(eventIdCaptor.getAllValues())
+            .containsExactlyInAnyOrder("internal-update-case-summary", "internal-change-add-gatekeeping");
         assertThat(startEventResponseArgumentCaptor.getAllValues().stream().map(StartEventResponse::getEventId))
             .containsExactly("internal-update-case-summary");
 
@@ -703,15 +708,15 @@ class ListGatekeepingControllerSubmittedTest extends ManageHearingsControllerTes
 
         verifyNoInteractions(notificationClient);
 
-        verify(concurrencyHelper, timeout(ASYNC_METHOD_CALL_TIMEOUT))
-            .startEvent(eq(CASE_ID), eq("internal-update-case-summary"));
+        verify(concurrencyHelper, timeout(ASYNC_METHOD_CALL_TIMEOUT).times(2))
+            .startEvent(eq(CASE_ID), eventIdCaptor.capture());
         verify(concurrencyHelper, timeout(ASYNC_METHOD_CALL_TIMEOUT))
             .submitEvent(startEventResponseArgumentCaptor.capture(), eq(CASE_ID), eventDataCaptor.capture());
-        verify(concurrencyHelper, timeout(ASYNC_METHOD_CALL_TIMEOUT))
-            .startEvent(eq(CASE_ID), eq("internal-change-add-gatekeeping"));
 
         assertThat(startEventResponseArgumentCaptor.getAllValues().stream().map(StartEventResponse::getEventId))
             .containsExactly("internal-update-case-summary");
+        assertThat(eventIdCaptor.getAllValues())
+            .containsExactlyInAnyOrder("internal-update-case-summary", "internal-change-add-gatekeeping");
 
         verifyNoMoreInteractions(concurrencyHelper);
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
DFPL-2229


### Change description ###
 - Instead of checking for individual invocations, check that exactly 2 events happen (WITH TIMEOUTS) and we capture the correct 2 event IDs (in any order)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
