### PR TITLE
DFPL-2208 no longer need to attach the shared inbox from the config

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/LocalAuthorityRecipientsService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/LocalAuthorityRecipientsService.java
@@ -63,11 +63,6 @@ public class LocalAuthorityRecipientsService {
     public List<String> getDesignatedLocalAuthorityContacts(CaseData caseData) {
         final List<String> recipients = new ArrayList<>();
 
-        // from onboarding config
-        if (!featureToggles.isRestrictedFromPrimaryApplicantEmails(caseData.getId().toString())) {
-            localAuthorityInboxes.getSharedInbox(caseData.getCaseLocalAuthority()).ifPresent(recipients::add);
-        }
-
         if (isNotEmpty(caseData.getLocalAuthorities())) {
             Optional<LocalAuthority> localAuthority = getDesignatedLocalAuthority(caseData);
 

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/LocalAuthorityRecipientsServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/LocalAuthorityRecipientsServiceTest.java
@@ -102,7 +102,6 @@ class LocalAuthorityRecipientsServiceTest {
     void init() {
         given(localAuthorityIds.getLocalAuthorityCode(LA_1_ID)).willReturn(Optional.of(LA_1_CODE));
         given(localAuthorityIds.getLocalAuthorityCode(LA_2_ID)).willReturn(Optional.of(LA_2_CODE));
-        given(featureToggles.isRestrictedFromPrimaryApplicantEmails(CASE_ID.toString())).willReturn(false);
     }
 
     @Test
@@ -126,32 +125,6 @@ class LocalAuthorityRecipientsServiceTest {
 
     @Nested
     class DesignatedLocalAuthorityContacts {
-
-        @Test
-        void shouldSendToOnboardingConfigIfNotRestrictedCase() {
-            final CaseData caseData = CaseData.builder()
-                .id(CASE_ID)
-                .caseLocalAuthority(LA_1_CODE)
-                .localAuthorities(wrapElements(LocalAuthority.builder()
-                    .id(LA_1_ID)
-                    .designated(YES.getValue())
-                    .email(LA_2_INBOX)
-                    .colleagues(wrapElements(designatedLAColleague1, designatedLAColleague2, designatedLAColleague3))
-                    .build()))
-                .build();
-
-            final RecipientsRequest recipientsRequest = RecipientsRequest.builder()
-                .caseData(caseData)
-                .build();
-
-            given(localAuthorityEmails.getSharedInbox(LA_1_CODE)).willReturn(Optional.of(LA_1_INBOX));
-            given(featureToggles.emailsToSolicitorEnabled(LA_1_CODE)).willReturn(true);
-            given(featureToggles.isRestrictedFromPrimaryApplicantEmails("12345")).willReturn(false);
-
-            assertThat(underTest.getRecipients(recipientsRequest))
-                .containsExactlyInAnyOrder(LA_1_INBOX, LA_2_INBOX, designatedLAColleague2.getEmail(),
-                    designatedLAColleague3.getEmail());
-        }
 
         @Test
         void shouldNotSendToOnboardingConfigIfRestrictedCase() {
@@ -253,7 +226,7 @@ class LocalAuthorityRecipientsServiceTest {
         }
 
         @Test
-        void shouldReturnLocalAuthoritySharedEmailAndGroupEmailWhenAdditionalContactsAreToggledOff() {
+        void shouldReturnLocalAuthorityGroupEmailWhenAdditionalContactsAreToggledOff() {
             final CaseData caseData = CaseData.builder()
                 .id(CASE_ID)
                 .caseLocalAuthority(LA_1_CODE)
@@ -270,13 +243,12 @@ class LocalAuthorityRecipientsServiceTest {
             final RecipientsRequest recipientsRequest = RecipientsRequest.builder().caseData(caseData).build();
 
             assertThat(underTest.getRecipients(recipientsRequest)).containsExactlyInAnyOrder(
-                LA_1_INBOX,
                 LA_1_GROUP_EMAIL
             );
         }
 
         @Test
-        void shouldReturnGroupEmailAndLASharedInboxWhenNoNotificationRecipientsAmongColleagues() {
+        void shouldReturnGroupEmailOnlyWhenNoNotificationRecipientsAmongColleagues() {
 
             final CaseData caseData = CaseData.builder()
                 .id(CASE_ID)
@@ -296,7 +268,6 @@ class LocalAuthorityRecipientsServiceTest {
             final RecipientsRequest recipientsRequest = RecipientsRequest.builder().caseData(caseData).build();
 
             assertThat(underTest.getRecipients(recipientsRequest)).containsExactlyInAnyOrder(
-                LA_1_INBOX,
                 LA_1_GROUP_EMAIL
             );
         }
@@ -326,7 +297,7 @@ class LocalAuthorityRecipientsServiceTest {
         }
 
         @Test
-        void shouldReturnGroupEmailAndLASharedInboxAndAdditionalContactsEmails() {
+        void shouldReturnGroupEmailAndAdditionalContactsEmails() {
 
             final CaseData caseData = CaseData.builder()
                 .id(CASE_ID)
@@ -346,7 +317,6 @@ class LocalAuthorityRecipientsServiceTest {
             final RecipientsRequest recipientsRequest = RecipientsRequest.builder().caseData(caseData).build();
 
             assertThat(underTest.getRecipients(recipientsRequest)).containsExactlyInAnyOrder(
-                LA_1_INBOX,
                 LA_1_GROUP_EMAIL,
                 designatedLAColleague2.getEmail(),
                 designatedLAColleague3.getEmail());
@@ -367,7 +337,6 @@ class LocalAuthorityRecipientsServiceTest {
             final RecipientsRequest recipientsRequest = RecipientsRequest.builder().caseData(caseData).build();
 
             assertThat(underTest.getRecipients(recipientsRequest)).containsExactlyInAnyOrder(
-                LA_1_INBOX,
                 legacySolicitor.getEmail());
         }
 
@@ -500,7 +469,6 @@ class LocalAuthorityRecipientsServiceTest {
                 .caseData(caseData).build();
 
             assertThat(underTest.getRecipients(recipientsRequest)).containsExactlyInAnyOrder(
-                LA_1_INBOX,
                 LA_2_INBOX,
                 LA_2_GROUP_EMAIL
             );
@@ -652,7 +620,6 @@ class LocalAuthorityRecipientsServiceTest {
             .caseData(caseData).build();
 
         assertThat(underTest.getRecipients(recipientsRequest)).containsExactlyInAnyOrder(
-            LA_1_INBOX,
             LA_1_GROUP_EMAIL,
             LA_2_INBOX,
             designatedLAColleague2.getEmail(),


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-2208


### Change description ###
From ticket: we no longer need to attach the shared inbox from the config in any circumstances (as it is autofilled during case creation, and then possibly overridden on cases, so we're doing the reverse of what the applicant would have asked for)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
