### PR TITLE
DFPL-2228: Disable unnecessary publishable events

### DIFF
--- a/ccd-definition/CaseEvent/CareSupervision/MultiState.json
+++ b/ccd-definition/CaseEvent/CareSupervision/MultiState.json
@@ -8,8 +8,7 @@
     "PostConditionState": "*",
     "SecurityClassification": "Public",
     "CallBackURLAboutToSubmitEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/migrate-case/about-to-submit",
-    "Comment": "Event is triggered by running migration tool - callback modifies the data.",
-    "Publish": "Y"
+    "Comment": "Event is triggered by running migration tool - callback modifies the data."
   },
   {
     "LiveFrom": "01/01/2017",
@@ -27,8 +26,7 @@
     "Name": "Update case summary",
     "PreConditionState(s)": "*",
     "PostConditionState": "*",
-    "SecurityClassification": "Public",
-    "Publish": "Y"
+    "SecurityClassification": "Public"
   },
   {
     "LiveFrom": "01/01/2017",

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -49,4 +49,11 @@
     <packageUrl regex="true">^pkg:maven/org.bouncycastle/bcprov-jdk15on@.*$</packageUrl>
     <cve>CVE-2023-33202</cve>
   </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: nimbus-jose-jwt-9.10.1.jar (shaded: net.minidev:json-smart:2.4.7)
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/net\.minidev/json\-smart@.*$</packageUrl>
+    <cve>CVE-2023-1370</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-2228


### Change description ###
 - Disable migrateCase + internal-change-case-summary as publishable, whilst we work on switching the legacy code over before WA release


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
