### PR TITLE
Suppress SonarCloud rule to fix master pipeline

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/config/security/SecurityConfiguration.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/config/security/SecurityConfiguration.java
@@ -14,7 +14,7 @@ import uk.gov.hmcts.reform.auth.checker.core.user.User;
 import uk.gov.hmcts.reform.auth.checker.spring.useronly.AuthCheckerUserOnlyFilter;
 
 @Configuration
-@SuppressWarnings("java:S1118")
+@SuppressWarnings({"java:S1118", "java:S4502"})
 public class SecurityConfiguration {
 
     @Configuration


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
 - Suppress CSRF rule being blocked by Sonar - is unchanged so unsure why it is popping up now!
 - Matches other teams approaches as CSRF protection shouldn't be needed on service-to-service communication


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
