### PR TITLE
DFPL-2323: Migration remove temp manage order fields

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -65,8 +65,8 @@ public class MigrateCaseController extends CallbackController {
 
     private void run2323(CaseDetails caseDetails) {
         final String migrationId = "DFPL-2323";
-        //final long expectedCaseId = 1665658311601974L;
-        final long expectedCaseId = 1698663538904244L;
+        final long expectedCaseId = 1665658311601974L;
+
         migrateCaseService.doCaseIdCheck(caseDetails.getId(), expectedCaseId, migrationId);
         CaseData caseData = getCaseData(caseDetails);
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -11,13 +11,17 @@ import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.controllers.CallbackController;
+import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.service.CaseAccessService;
 import uk.gov.hmcts.reform.fpl.service.FeatureToggleService;
 import uk.gov.hmcts.reform.fpl.service.MigrateCaseService;
+import uk.gov.hmcts.reform.fpl.service.orders.ManageOrderDocumentScopedFieldsCalculator;
 
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.function.Consumer;
+
+import static java.lang.String.format;
 
 @Slf4j
 @RestController
@@ -28,10 +32,11 @@ public class MigrateCaseController extends CallbackController {
     private final MigrateCaseService migrateCaseService;
     private final CaseAccessService caseAccessService;
     private final FeatureToggleService featureToggleService;
+    private final ManageOrderDocumentScopedFieldsCalculator fieldsCalculator;
 
     private final Map<String, Consumer<CaseDetails>> migrations = Map.of(
         "DFPL-log", this::runLog,
-        "DFPL-2331", this::run2331
+        "DFPL-2331", this::run2323
     );
 
     @PostMapping("/about-to-submit")
@@ -58,12 +63,21 @@ public class MigrateCaseController extends CallbackController {
         log.info("Logging migration on case {}", caseDetails.getId());
     }
 
-    private void run2331(CaseDetails caseDetails) {
-        final String migrationId = "DFPL-2331";
-        final long expectedCaseId = 1711533734054404L;
+    private void run2323(CaseDetails caseDetails) {
+        final String migrationId = "DFPL-2323";
+        final long expectedCaseId = 1665658311601974L;
 
         migrateCaseService.doCaseIdCheck(caseDetails.getId(), expectedCaseId, migrationId);
-        caseDetails.getData().putAll(migrateCaseService
-            .removeNamesFromOtherProceedings(getCaseData(caseDetails), migrationId));
+        CaseData caseData = getCaseData(caseDetails);
+
+        Long caseId = caseData.getId();
+        if (caseId != expectedCaseId) {
+            throw new AssertionError(format(
+                "Migration {id = %s, case reference = %s}, expected case id %d",
+                migrationId, caseId, expectedCaseId
+            ));
+        }
+
+        fieldsCalculator.calculate().forEach(caseDetails.getData()::remove);
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -36,7 +36,7 @@ public class MigrateCaseController extends CallbackController {
 
     private final Map<String, Consumer<CaseDetails>> migrations = Map.of(
         "DFPL-log", this::runLog,
-        "DFPL-2331", this::run2323
+        "DFPL-2323", this::run2323
     );
 
     @PostMapping("/about-to-submit")
@@ -65,8 +65,8 @@ public class MigrateCaseController extends CallbackController {
 
     private void run2323(CaseDetails caseDetails) {
         final String migrationId = "DFPL-2323";
-        final long expectedCaseId = 1665658311601974L;
-
+        //final long expectedCaseId = 1665658311601974L;
+        final long expectedCaseId = 1698663538904244L;
         migrateCaseService.doCaseIdCheck(caseDetails.getId(), expectedCaseId, migrationId);
         CaseData caseData = getCaseData(caseDetails);
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DFPL-2323

Remove temp fields from manage order flow blocking order upload

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
