### PR TITLE
DFPL-2344: remove stages in smoke test, create e2e

### DIFF
--- a/playwright-e2e/tests/e2e-test.spec.ts
+++ b/playwright-e2e/tests/e2e-test.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "../fixtures/fixtures";
 import { BasePage } from "../pages/base-page";
 import { newSwanseaLocalAuthorityUserOne } from "../settings/user-credentials";
 
-test("Smoke Test @smoke-test @accessibility", async ({
+test("E2E Test @accessibility", async ({
   signInPage,
   createCase,
   ordersAndDirectionSought,

--- a/playwright-e2e/tests/e2e-test.spec.ts
+++ b/playwright-e2e/tests/e2e-test.spec.ts
@@ -9,12 +9,19 @@ test("Smoke Test @smoke-test @accessibility", async ({
   startApplication,
   hearingUrgency,
   groundsForTheApplication,
+  riskAndHarmToChildren,
+  factorsAffectingParenting,
   applicantDetails,
   allocationProposal,
   addApplicationDocuments,
   childDetails,
   respondentDetails,
+  welshLangRequirements,
   submitCase,
+  otherProceedings,
+  internationalElement,
+  courtServicesNeeded,
+  c1WithSupplement,
   page,
   makeAxeBuilder
 }, testInfo) => {
@@ -59,6 +66,14 @@ test("Smoke Test @smoke-test @accessibility", async ({
   await groundsForTheApplication.groundsForTheApplicationSmokeTest();
   await startApplication.groundsForTheApplicationHasBeenUpdated();
 
+  // Risk and harm to children
+  await startApplication.riskAndHarmToChildren();
+  await riskAndHarmToChildren.riskAndHarmToChildrenSmokeTest();
+
+  // Factors affecting parenting
+  await factorsAffectingParenting.addFactorsAffectingParenting();
+  await startApplication.addApplicationDetailsHeading.isVisible();
+
   // Add application documents
   await startApplication.addApplicationDetailsHeading.isVisible();
   await startApplication.addApplicationDocuments();
@@ -85,6 +100,26 @@ test("Smoke Test @smoke-test @accessibility", async ({
   await startApplication.allocationProposal();
   await allocationProposal.allocationProposalSmokeTest();
   await startApplication.allocationProposalHasBeenUpdated();
+
+  // Welsh language requirements
+  await startApplication.welshLanguageReq();
+  await welshLangRequirements.welshLanguageSmokeTest();
+  await startApplication.welshLanguageReqUpdated();
+
+  // Other Proceedings
+  await startApplication.otherProceedingsNeeded();
+  await otherProceedings.otherProceedingsSmokeTest();
+
+  // International element
+  await startApplication.internationalElementReqUpdated();
+  await internationalElement.internationalElementSmokeTest();
+
+  // Court Services Needed
+  await startApplication.courtServicesNeededReqUpdated();
+  await courtServicesNeeded.CourtServicesSmoketest();
+
+  // C1 With Supplement
+  await c1WithSupplement.c1WithSupplementSmokeTest();
 
   // Submit the case
   await startApplication.submitCase();

--- a/playwright-e2e/tests/e2e-tests/submit-basic-case-e2e.spec.ts
+++ b/playwright-e2e/tests/e2e-tests/submit-basic-case-e2e.spec.ts
@@ -1,8 +1,8 @@
-import { test, expect } from "../fixtures/fixtures";
-import { BasePage } from "../pages/base-page";
-import { newSwanseaLocalAuthorityUserOne } from "../settings/user-credentials";
+import { test, expect } from "../../fixtures/fixtures";
+import { BasePage } from "../../pages/base-page";
+import { newSwanseaLocalAuthorityUserOne } from "../../settings/user-credentials";
 
-test("E2E Test @accessibility", async ({
+test("e2e test: Submit basic case @e2e-test @accessibility", async ({
   signInPage,
   createCase,
   ordersAndDirectionSought,


### PR DESCRIPTION

https://tools.hmcts.net/jira/browse/DFPL-2344


Remove non mandatory stages from smoke test and create e2e test that uses removed smoke test stages



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
