### PR TITLE
DFPL-2471: Add missing permission for configuration DMN

### DIFF
--- a/ccd-definition/AuthorisationCaseField/CareSupervision/wa-task-configuration.json
+++ b/ccd-definition/AuthorisationCaseField/CareSupervision/wa-task-configuration.json
@@ -54,5 +54,12 @@
     "CaseFieldID": "orderReviewUrgency",
     "UserRole": "caseworker-wa-task-configuration",
     "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "CaseFieldID": "hearingDetails",
+    "UserRole": "caseworker-wa-task-configuration",
+    "CRUD": "R"
   }
 ]


### PR DESCRIPTION
### JIRA link (if applicable) ###
[DFPL-2471](https://tools.hmcts.net/jira/browse/DFPL-2471)


### Change description ###
 - Add permission so configuration DMN can access hearingDetails (for roleType parameterisation of hearing judge tasks)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
