### PR TITLE
Fix flaky UploadTranslationsSubmittedControllerTest

### DIFF
--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/UploadTranslationsSubmittedControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/UploadTranslationsSubmittedControllerTest.java
@@ -8,6 +8,7 @@ import org.mockito.Captor;
 import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 import uk.gov.hmcts.reform.ccd.document.am.model.Document;
@@ -88,6 +89,7 @@ import static uk.gov.hmcts.reform.fpl.utils.TestDataHelper.testDocumentReference
 
 @WebMvcTest(UploadTranslationsController.class)
 @OverrideAutoConfiguration(enabled = true)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 class UploadTranslationsSubmittedControllerTest extends AbstractCallbackTest {
 
     private static final Long CASE_ID = 1614860986487554L;


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
UploadTranslationsSubmittedControllerTest is flaky and always need several rerun to make the pipeline green.
Think it's because of the concurrency stuff again. 
Same as the other flaky unit test, add `@DirtiesContext` to clear the context after each test method


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
