### PR TITLE
[DFPL-2527] Fix to delete temporary fields when ManageOrders first called

### DIFF
--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ManageOrdersControllerAboutToStartTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ManageOrdersControllerAboutToStartTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.fpl.controllers;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.assertj.core.api.*;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -8,8 +9,8 @@ import uk.gov.hmcts.reform.fpl.enums.CMOStatus;
 import uk.gov.hmcts.reform.fpl.enums.OrderStatus;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.StandardDirectionOrder;
-import uk.gov.hmcts.reform.fpl.model.order.HearingOrder;
-import uk.gov.hmcts.reform.fpl.model.order.UrgentHearingOrder;
+import uk.gov.hmcts.reform.fpl.model.event.*;
+import uk.gov.hmcts.reform.fpl.model.order.*;
 import uk.gov.hmcts.reform.fpl.model.order.generated.GeneratedOrder;
 
 import java.time.LocalDate;
@@ -17,6 +18,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static uk.gov.hmcts.reform.fpl.enums.State.CASE_MANAGEMENT;
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.element;
 import static uk.gov.hmcts.reform.fpl.utils.assertions.DynamicListAssert.assertThat;
@@ -70,5 +72,24 @@ class ManageOrdersControllerAboutToStartTest extends AbstractCallbackTest {
                 Pair.of(sdoId, "Gatekeeping order - 2 February 0002"),
                 Pair.of(orderId, "some type of order - 1 January 0001")
             );
+    }
+
+    @Test
+    void shouldRemoveTemporaryFields() {
+        CaseData caseData = CaseData.builder()
+            .manageOrdersEventData(
+                ManageOrdersEventData.builder()
+                    .orderTempQuestions(
+                        OrderTempQuestions.builder()
+                            .manageOrdersExclusionRequirementDetails("NO")
+                            .manageOrdersVaryOrExtendSupervisionOrder("NO")
+                            .manageOrdersExpiryDateWithEndOfProceedings("NO")
+                            .build()
+                    ).build()
+            ).build();
+
+        CaseData responseData = extractCaseData(postAboutToStartEvent(asCaseDetails(caseData)));
+
+        Assertions.assertThat(responseData.getManageOrdersEventData().getOrderTempQuestions()).isNull();
     }
 }

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ManageOrdersControllerAboutToStartTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ManageOrdersControllerAboutToStartTest.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.reform.fpl.controllers;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.assertj.core.api.*;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -9,8 +9,10 @@ import uk.gov.hmcts.reform.fpl.enums.CMOStatus;
 import uk.gov.hmcts.reform.fpl.enums.OrderStatus;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.StandardDirectionOrder;
-import uk.gov.hmcts.reform.fpl.model.event.*;
-import uk.gov.hmcts.reform.fpl.model.order.*;
+import uk.gov.hmcts.reform.fpl.model.event.ManageOrdersEventData;
+import uk.gov.hmcts.reform.fpl.model.order.HearingOrder;
+import uk.gov.hmcts.reform.fpl.model.order.OrderTempQuestions;
+import uk.gov.hmcts.reform.fpl.model.order.UrgentHearingOrder;
 import uk.gov.hmcts.reform.fpl.model.order.generated.GeneratedOrder;
 
 import java.time.LocalDate;
@@ -18,7 +20,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static uk.gov.hmcts.reform.fpl.enums.State.CASE_MANAGEMENT;
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.element;
 import static uk.gov.hmcts.reform.fpl.utils.assertions.DynamicListAssert.assertThat;

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/ManageOrdersController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/ManageOrdersController.java
@@ -57,6 +57,10 @@ public class ManageOrdersController extends CallbackController {
         CaseDetails caseDetails = request.getCaseDetails();
         CaseData caseData = getCaseData(caseDetails);
 
+        /* Working data for some cases was accidentally stored.
+        This line removes the key so that a new order starts afresh. */
+        fieldsCalculator.calculate().forEach(caseDetails.getData()::remove);
+
         caseDetails.getData().put("manageOrdersAmendmentList", amendableOrderListBuilder.buildList(caseData));
 
         return respond(caseDetails);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-2527


### Change description ###
Fix to delete temporary fields when ManageOrders first called


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
