### PR TITLE
DFPL 2512 Cafcass API Feature toggling by region (court)

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/cafcass/api/CafcassApiFeatureFlag.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/cafcass/api/CafcassApiFeatureFlag.java
@@ -1,0 +1,15 @@
+package uk.gov.hmcts.reform.fpl.model.cafcass.api;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@EqualsAndHashCode
+public class CafcassApiFeatureFlag {
+    private boolean enableApi;
+    private List<String> whitelist;
+}

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/FeatureToggleService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/FeatureToggleService.java
@@ -7,8 +7,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.fpl.model.Court;
+import uk.gov.hmcts.reform.fpl.model.cafcass.api.CafcassApiFeatureFlag;
 
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 
 @Service
 public class FeatureToggleService {
@@ -100,9 +105,31 @@ public class FeatureToggleService {
             createLDUser(Map.of(COURT_CODE_KEY, LDValue.of(court.getCode()))), true);
     }
 
-    public boolean isCafcassAPIEnabled(Court court) {
-        return ldClient.boolVariation("cafcass-api-court",
-            createLDUser(Map.of(COURT_CODE_KEY, LDValue.of(court.getCode()))), true);
+    public boolean isCafcassAPIEnabledForCourt(Court court) {
+        CafcassApiFeatureFlag flag = getCafcassAPIFlag();
+
+        if (flag.isEnableApi()) {
+            if (isEmpty(flag.getWhitelist())) {
+                return true;
+            } else {
+                return flag.getWhitelist().stream()
+                    .anyMatch(whiteListCode -> court.getCode().equalsIgnoreCase(whiteListCode));
+            }
+        }
+        return false;
+    }
+
+    public CafcassApiFeatureFlag getCafcassAPIFlag() {
+        LDValue flag = ldClient.jsonValueVariation("cafcass-api-court", createLDUser(), LDValue.ofNull());
+
+        LDValue whiteList = flag.get("whitelist");
+        return CafcassApiFeatureFlag.builder()
+            .enableApi(flag.get("enableApi").booleanValue())
+            .whitelist((!whiteList.isNull())
+                ? StreamSupport.stream(whiteList.valuesAs(LDValue.Convert.String).spliterator(), false)
+                    .collect(Collectors.toList())
+                : null)
+            .build();
     }
 
     private LDUser createLDUser() {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/FeatureToggleService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/FeatureToggleService.java
@@ -100,6 +100,11 @@ public class FeatureToggleService {
             createLDUser(Map.of(COURT_CODE_KEY, LDValue.of(court.getCode()))), true);
     }
 
+    public boolean isCafcassAPIEnabled(Court court) {
+        return ldClient.boolVariation("cafcass-api-court",
+            createLDUser(Map.of(COURT_CODE_KEY, LDValue.of(court.getCode()))), true);
+    }
+
     private LDUser createLDUser() {
         return createLDUser(Map.of());
     }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/cafcass/CafcassNotificationService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/cafcass/CafcassNotificationService.java
@@ -89,6 +89,13 @@ public class CafcassNotificationService {
                           Set<DocumentReference> documentReferences,
                           CafcassRequestEmailContentProvider provider,
                           CafcassData cafcassData) {
+        if (featureToggleService.isCafcassAPIEnabled(caseData.getCourt())) {
+            log.info("For case id: {} Cafcass API is enabled, skip notifying Cafcass for: {} via SendGrid",
+                caseData.getId(),
+                provider.name());
+            return;
+        }
+
         log.info("For case id: {} notifying Cafcass for: {}",
             caseData.getId(),
             provider.name());

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/cafcass/CafcassNotificationService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/cafcass/CafcassNotificationService.java
@@ -89,7 +89,7 @@ public class CafcassNotificationService {
                           Set<DocumentReference> documentReferences,
                           CafcassRequestEmailContentProvider provider,
                           CafcassData cafcassData) {
-        if (featureToggleService.isCafcassAPIEnabled(caseData.getCourt())) {
+        if (featureToggleService.isCafcassAPIEnabledForCourt(caseData.getCourt())) {
             log.info("For case id: {} Cafcass API is enabled, skip notifying Cafcass for: {}",
                 caseData.getId(),
                 provider.name());

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/cafcass/CafcassNotificationService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/cafcass/CafcassNotificationService.java
@@ -90,7 +90,7 @@ public class CafcassNotificationService {
                           CafcassRequestEmailContentProvider provider,
                           CafcassData cafcassData) {
         if (featureToggleService.isCafcassAPIEnabled(caseData.getCourt())) {
-            log.info("For case id: {} Cafcass API is enabled, skip notifying Cafcass for: {} via SendGrid",
+            log.info("For case id: {} Cafcass API is enabled, skip notifying Cafcass for: {}",
                 caseData.getId(),
                 provider.name());
             return;

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/cafcass/api/CafcassApiSearchCaseService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/cafcass/api/CafcassApiSearchCaseService.java
@@ -13,12 +13,12 @@ import uk.gov.hmcts.reform.fpl.service.CaseConverter;
 import uk.gov.hmcts.reform.fpl.service.FeatureToggleService;
 import uk.gov.hmcts.reform.fpl.service.search.SearchService;
 import uk.gov.hmcts.reform.fpl.utils.elasticsearch.BooleanQuery;
-import uk.gov.hmcts.reform.fpl.utils.elasticsearch.ESClause;
 import uk.gov.hmcts.reform.fpl.utils.elasticsearch.Filter;
 import uk.gov.hmcts.reform.fpl.utils.elasticsearch.MatchQuery;
 import uk.gov.hmcts.reform.fpl.utils.elasticsearch.Must;
 import uk.gov.hmcts.reform.fpl.utils.elasticsearch.MustNot;
 import uk.gov.hmcts.reform.fpl.utils.elasticsearch.RangeQuery;
+import uk.gov.hmcts.reform.fpl.utils.elasticsearch.TermsQuery;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -58,9 +58,7 @@ public class CafcassApiSearchCaseService {
 
             if (isNotEmpty(flag.getWhitelist())) {
                 searchCaseQuery.must(Must.builder()
-                    .clauses(flag.getWhitelist().stream()
-                        .map(courtCode -> (ESClause) MatchQuery.of("court.code", courtCode))
-                        .toList())
+                    .clauses(List.of(TermsQuery.of("data.court.code", flag.getWhitelist())))
                     .build());
             }
 

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/FeatureToggleServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/FeatureToggleServiceTest.java
@@ -172,6 +172,19 @@ class FeatureToggleServiceTest {
             eq(true));
     }
 
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldMakeCorrectCallForCafcassAPIEnabled(Boolean toggleState) {
+        givenToggle(toggleState);
+
+        assertThat(service.isCafcassAPIEnabled(Court.builder().code("151").build()))
+            .isEqualTo(toggleState);
+        verify(ldClient).boolVariation(
+            eq("cafcass-api-court"),
+            argThat(ldUser(ENVIRONMENT).build()),
+            eq(true));
+    }
+
     private static List<UserAttribute> buildAttributes(String... additionalAttributes) {
         List<UserAttribute> attributes = new ArrayList<>();
 

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/cafcass/CafcassNotificationServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/cafcass/CafcassNotificationServiceTest.java
@@ -157,7 +157,7 @@ class CafcassNotificationServiceTest {
                 entry("newApplication", "APPLICATION")
 
             ));
-        when(featureToggleService.isCafcassAPIEnabled(any())).thenReturn(false);
+        when(featureToggleService.isCafcassAPIEnabledForCourt(any())).thenReturn(false);
     }
 
     @ParameterizedTest
@@ -766,7 +766,7 @@ class CafcassNotificationServiceTest {
 
     @Test
     void shouldNotNotifyIfAPIEnabled() {
-        when(featureToggleService.isCafcassAPIEnabled(any())).thenReturn(true);
+        when(featureToggleService.isCafcassAPIEnabledForCourt(any())).thenReturn(true);
 
         underTest.sendEmail(caseData,
             of(getDocumentReference()),

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/cafcass/CafcassNotificationServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/cafcass/CafcassNotificationServiceTest.java
@@ -46,6 +46,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.mockito.quality.Strictness.LENIENT;
 import static uk.gov.hmcts.reform.fpl.enums.HearingType.CASE_MANAGEMENT;
@@ -156,6 +157,7 @@ class CafcassNotificationServiceTest {
                 entry("newApplication", "APPLICATION")
 
             ));
+        when(featureToggleService.isCafcassAPIEnabled(any())).thenReturn(false);
     }
 
     @ParameterizedTest
@@ -760,6 +762,26 @@ class CafcassNotificationServiceTest {
                         tuple(RECIPIENT_EMAIL,
                                 "Court Ref. FM1234.- new large document added - Expert reports",
                                 largeDocMessage));
+    }
+
+    @Test
+    void shouldNotNotifyIfAPIEnabled() {
+        when(featureToggleService.isCafcassAPIEnabled(any())).thenReturn(true);
+
+        underTest.sendEmail(caseData,
+            of(getDocumentReference()),
+            COURT_BUNDLE,
+            CourtBundleData.builder()
+                .hearingDetails(TITLE)
+                .build()
+        );
+
+        underTest.sendEmail(caseData,
+            CHANGE_OF_ADDRESS,
+            ChangeOfAddressData.builder().children(true).build()
+        );
+
+        verifyNoInteractions(emailService);
     }
 
     private DocumentReference getDocumentReference() {

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/cafcass/api/CafcassApiSearchCaseServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/cafcass/api/CafcassApiSearchCaseServiceTest.java
@@ -11,9 +11,9 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.CaseDefinitionConstants;
 import uk.gov.hmcts.reform.fpl.enums.State;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
-import uk.gov.hmcts.reform.fpl.model.Court;
 import uk.gov.hmcts.reform.fpl.model.cafcass.api.CafcassApiCase;
 import uk.gov.hmcts.reform.fpl.model.cafcass.api.CafcassApiCaseData;
+import uk.gov.hmcts.reform.fpl.model.cafcass.api.CafcassApiFeatureFlag;
 import uk.gov.hmcts.reform.fpl.service.CaseConverter;
 import uk.gov.hmcts.reform.fpl.service.FeatureToggleService;
 import uk.gov.hmcts.reform.fpl.service.search.SearchService;
@@ -21,6 +21,7 @@ import uk.gov.hmcts.reform.fpl.utils.elasticsearch.BooleanQuery;
 import uk.gov.hmcts.reform.fpl.utils.elasticsearch.ESQuery;
 import uk.gov.hmcts.reform.fpl.utils.elasticsearch.Filter;
 import uk.gov.hmcts.reform.fpl.utils.elasticsearch.MatchQuery;
+import uk.gov.hmcts.reform.fpl.utils.elasticsearch.Must;
 import uk.gov.hmcts.reform.fpl.utils.elasticsearch.MustNot;
 import uk.gov.hmcts.reform.fpl.utils.elasticsearch.RangeQuery;
 
@@ -67,6 +68,21 @@ public class CafcassApiSearchCaseServiceTest {
 
     private static final CafcassApiCaseData MOCK_CONVERTED_CAFCASSAPICASEDATA = mock(CafcassApiCaseData.class);
 
+    private static final CafcassApiCase EXPECTED_CAFCASS_CASE_1 = CafcassApiCase.builder()
+        .caseId(1L)
+        .jurisdiction(CaseDefinitionConstants.JURISDICTION)
+        .state(State.CASE_MANAGEMENT.getValue())
+        .caseTypeId(CaseDefinitionConstants.CASE_TYPE)
+        .createdDate(MOCK_CASE_DETAILS_1.getCreatedDate())
+        .lastModified(MOCK_CASE_DETAILS_1.getLastModified())
+        .caseData(MOCK_CONVERTED_CAFCASSAPICASEDATA)
+        .build();
+
+    private static final CafcassApiCase EXPECTED_CAFCASS_CASE_2 = EXPECTED_CAFCASS_CASE_1.toBuilder()
+        .caseId(2L)
+        .caseData(MOCK_CONVERTED_CAFCASSAPICASEDATA)
+        .build();
+
     @Mock
     private CaseConverter caseConverter;
     @Mock
@@ -86,6 +102,8 @@ public class CafcassApiSearchCaseServiceTest {
 
     @BeforeEach
     void setUpWithMockConverters() {
+        when(featureToggleService.getCafcassAPIFlag())
+            .thenReturn(CafcassApiFeatureFlag.builder().enableApi(true).build());
         underTest = new CafcassApiSearchCaseService(caseConverter, searchService,
             List.of(cafcassApiCaseDataConverter1, cafcassApiCaseDataConverter2, cafcassApiCaseDataConverter3),
             featureToggleService);
@@ -99,30 +117,14 @@ public class CafcassApiSearchCaseServiceTest {
         when(cafcassApiCaseDataConverter1.convert(any(), any())).thenReturn(mockBuilder);
         when(cafcassApiCaseDataConverter2.convert(any(), any())).thenReturn(mockBuilder);
         when(cafcassApiCaseDataConverter3.convert(any(), any())).thenReturn(mockBuilder);
-        when(featureToggleService.isCafcassAPIEnabled(any())).thenReturn(true);
 
         final List<CaseDetails> caseDetails = List.of(MOCK_CASE_DETAILS_1, MOCK_CASE_DETAILS_2);
         when(searchService.search(searchQueryCaptor.capture(), anyInt(), anyInt())).thenReturn(caseDetails);
         when(caseConverter.convert(MOCK_CASE_DETAILS_1)).thenReturn(MOCK_CASE_DATA_1);
         when(caseConverter.convert(MOCK_CASE_DETAILS_2)).thenReturn(MOCK_CASE_DATA_2);
 
-
-        CafcassApiCase expectedCafcassApiCase1 = CafcassApiCase.builder()
-            .caseId(1L)
-            .jurisdiction(CaseDefinitionConstants.JURISDICTION)
-            .state(State.CASE_MANAGEMENT.getValue())
-            .caseTypeId(CaseDefinitionConstants.CASE_TYPE)
-            .createdDate(MOCK_CASE_DETAILS_1.getCreatedDate())
-            .lastModified(MOCK_CASE_DETAILS_1.getLastModified())
-            .caseData(MOCK_CONVERTED_CAFCASSAPICASEDATA)
-            .build();
-        CafcassApiCase expectedCafcassApiCase2 = expectedCafcassApiCase1.toBuilder()
-            .caseId(2L)
-            .caseData(MOCK_CONVERTED_CAFCASSAPICASEDATA)
-            .build();
-
         List<CafcassApiCase> actual = underTest.searchCaseByDateRange(SEARCH_START_DATE, SEARCH_END_DATE);
-        List<CafcassApiCase> expected = List.of(expectedCafcassApiCase1, expectedCafcassApiCase2);
+        List<CafcassApiCase> expected = List.of(EXPECTED_CAFCASS_CASE_1, EXPECTED_CAFCASS_CASE_2);
 
         assertEquals(expected, actual);
         assertEquals(SEARCH_QUERY.toMap(), searchQueryCaptor.getValue().toMap());
@@ -148,7 +150,18 @@ public class CafcassApiSearchCaseServiceTest {
     }
 
     @Test
-    void shouldFilterCaseByCourtIfFeatureToggleEnabled() {
+    void shouldReturnEmptyListIfFeatureToggleDisabled() {
+        when(featureToggleService.getCafcassAPIFlag()).thenReturn(CafcassApiFeatureFlag.builder()
+            .enableApi(false).build());
+
+        List<CafcassApiCase> actual = underTest.searchCaseByDateRange(SEARCH_START_DATE, SEARCH_END_DATE);
+
+        assertEquals(List.of(), actual);
+
+    }
+
+    @Test
+    void shouldFilterCaseByCourtIfFeatureToggleEnabledWithWhiteList() {
         final CafcassApiCaseData.CafcassApiCaseDataBuilder mockBuilder =
             mock(CafcassApiCaseData.CafcassApiCaseDataBuilder.class);
         when(mockBuilder.build()).thenReturn(MOCK_CONVERTED_CAFCASSAPICASEDATA);
@@ -156,33 +169,36 @@ public class CafcassApiSearchCaseServiceTest {
         when(cafcassApiCaseDataConverter2.convert(any(), any())).thenReturn(mockBuilder);
         when(cafcassApiCaseDataConverter3.convert(any(), any())).thenReturn(mockBuilder);
 
-        Court enabledCourt = Court.builder().code("151").build();
-        Court disabledCourt = Court.builder().code("000").build();
-        when(featureToggleService.isCafcassAPIEnabled(enabledCourt)).thenReturn(true);
-        when(featureToggleService.isCafcassAPIEnabled(disabledCourt)).thenReturn(false);
-
-        CaseData enabledCase = CaseData.builder().court(enabledCourt).build();
-        CaseData filteredCase = CaseData.builder().court(disabledCourt).build();
+        when(featureToggleService.getCafcassAPIFlag()).thenReturn(CafcassApiFeatureFlag.builder()
+            .enableApi(true).whitelist(List.of("123", "321")).build());
 
         final List<CaseDetails> caseDetails = List.of(MOCK_CASE_DETAILS_1, MOCK_CASE_DETAILS_2);
-        when(searchService.search(any(), anyInt(), anyInt())).thenReturn(caseDetails);
-        when(caseConverter.convert(MOCK_CASE_DETAILS_1)).thenReturn(enabledCase);
-        when(caseConverter.convert(MOCK_CASE_DETAILS_2)).thenReturn(filteredCase);
-
-
-        CafcassApiCase expectedCafcassApiCase1 = CafcassApiCase.builder()
-            .caseId(1L)
-            .jurisdiction(CaseDefinitionConstants.JURISDICTION)
-            .state(State.CASE_MANAGEMENT.getValue())
-            .caseTypeId(CaseDefinitionConstants.CASE_TYPE)
-            .createdDate(MOCK_CASE_DETAILS_1.getCreatedDate())
-            .lastModified(MOCK_CASE_DETAILS_1.getLastModified())
-            .caseData(MOCK_CONVERTED_CAFCASSAPICASEDATA)
-            .build();
+        when(searchService.search(searchQueryCaptor.capture(), anyInt(), anyInt())).thenReturn(caseDetails);
+        when(caseConverter.convert(MOCK_CASE_DETAILS_1)).thenReturn(MOCK_CASE_DATA_1);
+        when(caseConverter.convert(MOCK_CASE_DETAILS_2)).thenReturn(MOCK_CASE_DATA_2);
 
         List<CafcassApiCase> actual = underTest.searchCaseByDateRange(SEARCH_START_DATE, SEARCH_END_DATE);
-        List<CafcassApiCase> expected = List.of(expectedCafcassApiCase1);
+        List<CafcassApiCase> expected = List.of(EXPECTED_CAFCASS_CASE_1, EXPECTED_CAFCASS_CASE_2);
+
+        BooleanQuery expectedSearchQuery = BooleanQuery.builder()
+            .mustNot(MustNot.builder()
+                .clauses(List.of(
+                    MatchQuery.of("state", "Open"),
+                    MatchQuery.of("state", "Deleted"),
+                    MatchQuery.of("state", "RETURNED")))
+                .build())
+            .filter(Filter.builder()
+                .clauses(List.of(RangeQuery.builder().field("last_modified")
+                    .greaterThanOrEqual(SEARCH_START_DATE).lessThanOrEqual(SEARCH_END_DATE).build()))
+                .build())
+            .must(Must.builder()
+                .clauses(List.of(
+                    MatchQuery.of("court.code", "123"),
+                    MatchQuery.of("court.code", "321")))
+                .build())
+            .build();
 
         assertEquals(expected, actual);
+        assertEquals(expectedSearchQuery.toMap(), searchQueryCaptor.getValue().toMap());
     }
 }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/cafcass/api/CafcassApiSearchCaseServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/cafcass/api/CafcassApiSearchCaseServiceTest.java
@@ -24,6 +24,7 @@ import uk.gov.hmcts.reform.fpl.utils.elasticsearch.MatchQuery;
 import uk.gov.hmcts.reform.fpl.utils.elasticsearch.Must;
 import uk.gov.hmcts.reform.fpl.utils.elasticsearch.MustNot;
 import uk.gov.hmcts.reform.fpl.utils.elasticsearch.RangeQuery;
+import uk.gov.hmcts.reform.fpl.utils.elasticsearch.TermsQuery;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -193,8 +194,7 @@ public class CafcassApiSearchCaseServiceTest {
                 .build())
             .must(Must.builder()
                 .clauses(List.of(
-                    MatchQuery.of("court.code", "123"),
-                    MatchQuery.of("court.code", "321")))
+                    TermsQuery.of("data.court.code", List.of("123", "321"))))
                 .build())
             .build();
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-2512


### Change description ###
We want to release the cafcass API for one / multiple region (court) only as trial, instead of a national rollout. 
 
**Acceptance criteria**
1. A new feature flag is configured with one / some court code
2. /search endpoint should only return cases in the court code list
3. No notification will be sent to cafcass if the case is in the court code list
4. If the court code list is updated, it should take effect without any additional code changes / release.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
