### PR TITLE
Switch old cached deps to jitpack

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -341,7 +341,7 @@ dependencies {
   implementation group: 'com.github.hmcts', name: 'document-management-client', version: '7.0.0'
   implementation group: 'com.github.hmcts', name: 'core-case-data-store-client', version: '4.7.6'
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '4.0.2'
-  implementation group: 'com.github.hmcts', name: 'auth-checker-lib', version: '2.1.4'
+  implementation group: 'com.github.hmcts', name: 'auth-checker-lib', version: '2.1.5'
   implementation group: 'com.github.hmcts', name: 'send-letter-client', version: '3.0.16'
   implementation group: 'uk.gov.service.notify', name: 'notifications-java-client', version: '3.17.3-RELEASE'
   implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.89'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -273,6 +273,7 @@ repositories {
   maven {
     url mirrorUrl
   }
+  maven { url 'https://jitpack.io' }
 }
 
 // it is important to specify logback classic and core packages explicitly as libraries like spring boot
@@ -333,14 +334,14 @@ dependencies {
   implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.3'
   implementation group: 'org.flywaydb', name: 'flyway-core', version: '8.5.13'
 
-  implementation group: 'uk.gov.hmcts.reform', name: 'logging', version: versions.reformLogging
-  implementation group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: versions.reformLogging
+  implementation group: 'com.github.hmcts', name: 'java-logging', version: versions.reformLogging
+  implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: versions.reformLogging
   implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
-  implementation group: 'uk.gov.hmcts.reform', name: 'idam-client', version: '2.0.0'
-  implementation group: 'uk.gov.hmcts.reform', name: 'document-management-client', version: '7.0.0'
-  implementation group: 'uk.gov.hmcts.reform', name: 'core-case-data-store-client', version: '4.7.6'
-  implementation group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '4.0.0'
-  implementation group: 'uk.gov.hmcts.reform.auth', name: 'auth-checker-lib', version: '2.1.4'
+  implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '2.0.1'
+  implementation group: 'com.github.hmcts', name: 'document-management-client', version: '7.0.0'
+  implementation group: 'com.github.hmcts', name: 'core-case-data-store-client', version: '4.7.6'
+  implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '4.0.2'
+  implementation group: 'com.github.hmcts', name: 'auth-checker-lib', version: '2.1.4'
   implementation group: 'com.github.hmcts', name: 'send-letter-client', version: '3.0.16'
   implementation group: 'uk.gov.service.notify', name: 'notifications-java-client', version: '3.17.3-RELEASE'
   implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.89'
@@ -414,7 +415,7 @@ dependencies {
   contractTestImplementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '4.1.1'
   contractTestImplementation group: 'org.springframework.cloud', name: 'spring-cloud-netflix-ribbon', version: '2.2.10.RELEASE'
   contractTestImplementation group: 'com.netflix.ribbon', name: 'ribbon-core', version: '2.7.18'
-  contractTestImplementation group: 'uk.gov.hmcts.reform', name: 'core-case-data-store-client', version: '4.7.6'
+  contractTestImplementation group: 'com.github.hmcts', name: 'core-case-data-store-client', version: '4.7.6'
   contractTestImplementation group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'
 }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
 - Use jitpack dependencies instead of cached jcenter ones
 - Bump versions where jitpack doesn't have a copy (TODO - UPGRADES!)
 - Bump auth-checker-lib (a little) to remove nested-dependency on jcenter


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
