### PR TITLE
DFPL-1767-2: Fix Guardian's report document removal

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/enums/cfv/DocumentType.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/enums/cfv/DocumentType.java
@@ -213,7 +213,7 @@ public enum DocumentType {
     GUARDIAN_REPORT("Guardian report", standardResolver("guardianReportsList"),
         true, true, true,
         defaultWithDocumentBuilder(),
-        GUARDIAN_EVIDENCE, 350, CAFCASS_API_NOTIFICATION_CONFIG, "guardianReports"),
+        null, 350, CAFCASS_API_NOTIFICATION_CONFIG, "guardianReports"),
     ARCHIVED_DOCUMENTS("Archived migrated data", standardResolver("archivedDocumentsList"),
         true, true, true,
     defaultWithDocumentBuilder(),


### PR DESCRIPTION
[DFPL-1767](https://tools.hmcts.net/jira/browse/DFPL-1767)

Guardian's report unable to be removed due to incorrectly assigned to the guardian's evidence category through CFV should be standalone to allow for document removal to work without reworking the entire structure of guardian's evidence


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
