### PR TITLE
DFPL-2558: Show event in history tab for CTSC/Court Admins

### DIFF
--- a/ccd-definition/AuthorisationCaseEvent/CareSupervision/AuthorisationCaseEvent.json
+++ b/ccd-definition/AuthorisationCaseEvent/CareSupervision/AuthorisationCaseEvent.json
@@ -1218,7 +1218,13 @@
         "UserRoles": [
           "caseworker-publiclaw-judiciary"
         ],
-        "CRUD": "CRU"
+        "CRUD": "CR"
+      },
+      {
+        "UserRoles": [
+          "caseworker-publiclaw-courtadmin"
+        ],
+        "CRUD": "R"
       }
     ]
   },


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-2558


### Change description ###

- Make Review additional application event visible in the history tab
- Fix unnecessary U permission on event for judiciary.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
