### PR TITLE
Fix flaky ChildControllerSubmittedTest

### DIFF
--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ChildControllerSubmittedTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ChildControllerSubmittedTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.annotation.DirtiesContext;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 import uk.gov.hmcts.reform.ccd.model.CaseAssignedUserRoleWithOrganisation;
@@ -60,6 +61,7 @@ import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.wrapElements;
 
 @WebMvcTest(ChildController.class)
 @OverrideAutoConfiguration(enabled = true)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 class ChildControllerSubmittedTest extends AbstractCallbackTest {
 
     private static final State NON_RESTRICTED_STATE = SUBMITTED;


### PR DESCRIPTION
### JIRA link (if applicable) ###


### Change description ###
Fix flaky ChildControllerSubmittedTest by clearing context after each method 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
