### PR TITLE
Adding missing config for new expert report types

### DIFF
--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -336,6 +336,30 @@ cafcass:
       expertReports: EXPERT
       drugAndAlcoholReports: EXPERT
       letterOfInstruction: EXPERT
+      adultPsychiatricReportOnParents: EXPERT
+      familyCentreAssessmentsNonResidential: EXPERT
+      familyCentreAssessmentsResidential: EXPERT
+      haematologist: EXPERT
+      independentSocialWorker: EXPERT
+      multiDisciplinaryAssessment: EXPERT
+      neurosurgeon: EXPERT
+      ophthalmologist: EXPERT
+      otherExpertReport: EXPERT
+      otherMedicalReport: EXPERT
+      pediatric: EXPERT
+      pediatricRadiologist: EXPERT
+      professionalDnaTesting: EXPERT
+      professionalDrugAlcohol: EXPERT
+      professionalHairStrand: EXPERT
+      professionalOther: EXPERT
+      psychiatricChildOnly: EXPERT
+      psychiatricChildAndParent: EXPERT
+      psychologicalReportChildOnlyClinical: EXPERT
+      psychologicalReportChildOnlyEducational: EXPERT
+      psychologicalReportParentAndChild: EXPERT
+      psychologicalReportParentFullCognitive: EXPERT
+      psychologicalReportParentFullFunctioning: EXPERT
+      toxicologyReport: EXPERT
       medicalRecords: EXPERT
       childsGuardianReports: REPORTING TO COURT
       guardianEvidence: REPORTING TO COURT


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-2589


### Change description ###
Adding new expert report types to map to EXPERT as email subject for email notifications sent to CAFCASS England.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
