### PR TITLE
DFPL-2585: Setup closed case role cleanup migration

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -12,7 +12,6 @@ import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.controllers.CallbackController;
 import uk.gov.hmcts.reform.fpl.enums.State;
-import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.service.CaseConverter;
 import uk.gov.hmcts.reform.fpl.service.MigrateCaseService;
 import uk.gov.hmcts.reform.fpl.service.RoleAssignmentService;

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -11,9 +11,11 @@ import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.controllers.CallbackController;
+import uk.gov.hmcts.reform.fpl.enums.State;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.service.CaseConverter;
 import uk.gov.hmcts.reform.fpl.service.MigrateCaseService;
+import uk.gov.hmcts.reform.fpl.service.RoleAssignmentService;
 import uk.gov.hmcts.reform.fpl.service.orders.ManageOrderDocumentScopedFieldsCalculator;
 
 import java.util.Map;
@@ -28,12 +30,11 @@ public class MigrateCaseController extends CallbackController {
     public static final String MIGRATION_ID_KEY = "migrationId";
     private final MigrateCaseService migrateCaseService;
     private final ManageOrderDocumentScopedFieldsCalculator fieldsCalculator;
+    private final RoleAssignmentService roleAssignmentService;
 
     private final Map<String, Consumer<CaseDetails>> migrations = Map.of(
         "DFPL-log", this::runLog,
-        "DFPL-2551", this::run2551,
-        "DFPL-2507", this::run2507,
-        "DFPL-2580", this::run2580
+        "DFPL-2585", this::run2585
     );
     private final CaseConverter caseConverter;
 
@@ -61,33 +62,11 @@ public class MigrateCaseController extends CallbackController {
         log.info("Logging migration on case {}", caseDetails.getId());
     }
 
-    private void run2551(CaseDetails caseDetails) {
-        final String migrationId = "DFPL-2551";
-        final long expectedCaseId = 1726735474157650L;
+    private void run2585(CaseDetails caseDetails) {
+        final String migrationId = "DFPL-2585";
+        migrateCaseService.doStateCheck(
+            caseDetails.getState(), State.CLOSED.toString(), caseDetails.getId(), migrationId);
 
-        migrateCaseService.doCaseIdCheck(caseDetails.getId(), expectedCaseId, migrationId);
-
-        final CaseData caseData = getCaseData(caseDetails);
-        caseDetails.getData().putAll(migrateCaseService.removeAddressFromEPO(caseData, migrationId));
-    }
-
-    private void run2507(CaseDetails caseDetails) {
-        final String migrationId = "DFPL-2507";
-        final long expectedCaseId = 1697635739516572L;
-
-        migrateCaseService.doCaseIdCheck(caseDetails.getId(), expectedCaseId, migrationId);
-        final CaseData caseData = getCaseData(caseDetails);
-
-        caseDetails.getData().putAll(migrateCaseService.updateCancelledHearingDetailsType(caseData, migrationId));
-    }
-
-    private void run2580(CaseDetails caseDetails) {
-        final String migrationId = "DFPL-2580";
-        final long expectedCaseId = 1726476888400895L;
-
-        migrateCaseService.doCaseIdCheck(caseDetails.getId(), expectedCaseId, migrationId);
-
-        final CaseData caseData = getCaseData(caseDetails);
-        caseDetails.getData().putAll(migrateCaseService.redactTypeReason(caseData, migrationId, 395, 404));
+        roleAssignmentService.deleteAllRolesOnCase(caseDetails.getId());
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseService.java
@@ -94,7 +94,7 @@ public class MigrateCaseService {
     public final OrganisationService organisationService;
     public final CourtLookUpService courtLookUpService;
 
-    private static final Map<String, HearingType> HEARING_TYPE_DETAILS_MAPPING = initialiseHearingMapping();
+    private static final Map<String, HearingType>  HEARING_TYPE_DETAILS_MAPPING = initialiseHearingMapping();
 
 
     private static Map<String, HearingType> initialiseHearingMapping() {
@@ -288,8 +288,8 @@ public class MigrateCaseService {
             : caseData.getHearingDocuments().getPosStmtChildList();
         Long caseId = caseData.getId();
         List<Element<PositionStatementChild>> newList = targetList.stream()
-            .filter(el -> !Arrays.asList(expectedIds).contains(el.getId()))
-            .toList();
+                .filter(el -> !Arrays.asList(expectedIds).contains(el.getId()))
+                .toList();
 
         if (newList.size() != targetList.size() - expectedIds.length) {
             throw new AssertionError(format(
@@ -383,7 +383,7 @@ public class MigrateCaseService {
     }
 
     public Map<String, Object> removeHearingBooking(CaseData caseData, final String migrationId,
-                                                    final UUID hearingIdToBeRemoved) {
+                                                     final UUID hearingIdToBeRemoved) {
         final Long caseId = caseData.getId();
 
         List<Element<HearingBooking>> hearingDetails = caseData.getHearingDetails();
@@ -416,7 +416,7 @@ public class MigrateCaseService {
                 );
             } else {
                 Map<String, Object> ret = new HashMap<>(Map.of(
-                    "hearingDetails", hearingDetails
+                        "hearingDetails", hearingDetails
                 ));
                 ret.put("selectedHearingId", null);
                 return ret;
@@ -472,7 +472,7 @@ public class MigrateCaseService {
             .equals(UUID.fromString(caseDocumentUrl.substring(caseDocumentUrl.length() - 36)))) {
             throw new AssertionError(format(
                 "Migration {id = %s, case reference = %s},"
-                    + " GateKeeping order - Urgent directions order document with Id %s not found",
+                + " GateKeeping order - Urgent directions order document with Id %s not found",
                 migrationId, caseData.getId(), documentId));
         }
     }
@@ -490,7 +490,7 @@ public class MigrateCaseService {
             .equals(UUID.fromString(caseDocumentUrl.substring(caseDocumentUrl.length() - 36)))) {
             throw new AssertionError(format(
                 "Migration {id = %s, case reference = %s},"
-                    + " GateKeeping order - Standard direction order document with Id %s not found",
+                + " GateKeeping order - Standard direction order document with Id %s not found",
                 migrationId, caseData.getId(), documentId));
         }
     }
@@ -588,7 +588,7 @@ public class MigrateCaseService {
         List<Element<Placement>> nonConfidentialNoticesPlacementsToKeep = caseData.getPlacementEventData()
             .getPlacementsNonConfidential(true);
 
-        Map<String, Object> ret = new HashMap<String, Object>();
+        Map<String, Object> ret =  new HashMap<String, Object>();
         ret.put(PLACEMENT, placementsToKeep.isEmpty() ? null : placementsToKeep);
         ret.put(PLACEMENT_NON_CONFIDENTIAL, nonConfidentialPlacementsToKeep.isEmpty() ? null :
             nonConfidentialPlacementsToKeep);
@@ -629,8 +629,8 @@ public class MigrateCaseService {
 
     public Map<String, Object> removeJudicialMessage(CaseData caseData, String migrationId, String messageId) {
         return Map.of("judicialMessages",
-            removeJudicialMessageFormList(caseData.getJudicialMessages(), messageId, migrationId,
-                caseData.getId()));
+                removeJudicialMessageFormList(caseData.getJudicialMessages(), messageId, migrationId,
+                    caseData.getId()));
     }
 
     public Map<String, Object> removeClosedJudicialMessage(CaseData caseData, String migrationId, String messageId) {
@@ -641,7 +641,7 @@ public class MigrateCaseService {
     }
 
     private List<Element<JudicialMessage>> removeJudicialMessageFormList(List<Element<JudicialMessage>> messages,
-                                                                         String messageId, String migrationId, Long caseId) {
+                                                              String messageId, String migrationId, Long caseId) {
         if (messages == null) {
             throw new AssertionError(format("Migration {id = %s, case reference = %s}, judicial message is null",
                 migrationId, caseId));
@@ -686,7 +686,7 @@ public class MigrateCaseService {
     }
 
     public Map<String, Object> removeNoticeOfProceedingsBundle(CaseData caseData, String noticeOfProceedingsBundleId,
-                                                               String migrationId) {
+                                                      String migrationId) {
         Long caseId = caseData.getId();
         List<Element<DocumentBundle>> noticeOfProceedingsBundle = caseData.getNoticeOfProceedingsBundle();
 
@@ -711,7 +711,7 @@ public class MigrateCaseService {
     }
 
     public Map<String, Object> removeDocumentFiledOnIssue(CaseData caseData, UUID documentFiledOnIssueId,
-                                                          String migrationId) {
+                                                      String migrationId) {
         Long caseId = caseData.getId();
         List<Element<ManagedDocument>> documentsFiledOnIssueList = caseData.getDocumentsFiledOnIssueList();
 
@@ -873,8 +873,8 @@ public class MigrateCaseService {
     }
 
     public Map<String, List<Element<LocalAuthority>>> removeElementFromLocalAuthorities(CaseData caseData,
-                                                                                        String migrationId,
-                                                                                        UUID expectedLocalAuthorityId) {
+                                                                 String migrationId,
+                                                                 UUID expectedLocalAuthorityId) {
         Long caseId = caseData.getId();
         List<Element<LocalAuthority>> localAuthoritiesList =
             caseData.getLocalAuthorities().stream()
@@ -923,9 +923,9 @@ public class MigrateCaseService {
 
         return Map.of("court", court.toBuilder().epimmsId(correctBaseLocation).build(),
             "caseManagementLocation", CaseLocation.builder()
-                .baseLocation(correctBaseLocation)
-                .region(correctRegion)
-                .build());
+            .baseLocation(correctBaseLocation)
+            .region(correctRegion)
+            .build());
     }
 
     /**
@@ -977,9 +977,9 @@ public class MigrateCaseService {
             .orgPolicyCaseAssignedRole(applicantCaseRole).build());
     }
 
-    public Map<String, Object> removeApplicantEmailAndStopNotifyingTheirColleagues(CaseData caseData,
-                                                                                   String migrationId,
-                                                                                   String applicantUuid) {
+    public  Map<String, Object> removeApplicantEmailAndStopNotifyingTheirColleagues(CaseData caseData,
+                                                                                    String migrationId,
+                                                                                    String applicantUuid) {
         UUID targetApplicantUuid = UUID.fromString(applicantUuid);
 
         List<Element<LocalAuthority>> localAuthorities = caseData.getLocalAuthorities();
@@ -1081,7 +1081,7 @@ public class MigrateCaseService {
             .findFirst()
             .orElseThrow(() ->
                 new AssertionError(format("Migration {id = %s, case reference = %s} approval date not found",
-                    migrationId, caseData.getId())));
+                migrationId, caseData.getId())));
 
         CloseCase existingCloseCaseField = Optional.ofNullable(caseData.getCloseCaseTabField())
             .orElse(CloseCase.builder().build());
@@ -1282,7 +1282,7 @@ public class MigrateCaseService {
             .respondentsAwareReason(null)
             .build();
 
-        return Map.of("hearing", hearing);
+        return Map.of("hearing",hearing);
     }
 
     public Map<String, Object> redactTypeReason(CaseData caseData, String migrationId, int startLoc, int endLoc) {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseService.java
@@ -94,7 +94,7 @@ public class MigrateCaseService {
     public final OrganisationService organisationService;
     public final CourtLookUpService courtLookUpService;
 
-    private static final Map<String, HearingType>  HEARING_TYPE_DETAILS_MAPPING = initialiseHearingMapping();
+    private static final Map<String, HearingType> HEARING_TYPE_DETAILS_MAPPING = initialiseHearingMapping();
 
 
     private static Map<String, HearingType> initialiseHearingMapping() {
@@ -216,7 +216,8 @@ public class MigrateCaseService {
         return Map.of("hearingOrdersBundlesDrafts", bundles);
     }
 
-    public void doStateCheck(String state, String expectedState, long caseId, String migrationId) throws AssertionError {
+    public void doStateCheck(String state, String expectedState, long caseId, String migrationId)
+        throws AssertionError {
         if (!state.equals(expectedState)) {
             throw new AssertionError(format(
                 "Migration {id = %s, case reference = %s}, state was %s, expected %s",
@@ -287,8 +288,8 @@ public class MigrateCaseService {
             : caseData.getHearingDocuments().getPosStmtChildList();
         Long caseId = caseData.getId();
         List<Element<PositionStatementChild>> newList = targetList.stream()
-                .filter(el -> !Arrays.asList(expectedIds).contains(el.getId()))
-                .toList();
+            .filter(el -> !Arrays.asList(expectedIds).contains(el.getId()))
+            .toList();
 
         if (newList.size() != targetList.size() - expectedIds.length) {
             throw new AssertionError(format(
@@ -382,7 +383,7 @@ public class MigrateCaseService {
     }
 
     public Map<String, Object> removeHearingBooking(CaseData caseData, final String migrationId,
-                                                     final UUID hearingIdToBeRemoved) {
+                                                    final UUID hearingIdToBeRemoved) {
         final Long caseId = caseData.getId();
 
         List<Element<HearingBooking>> hearingDetails = caseData.getHearingDetails();
@@ -415,7 +416,7 @@ public class MigrateCaseService {
                 );
             } else {
                 Map<String, Object> ret = new HashMap<>(Map.of(
-                        "hearingDetails", hearingDetails
+                    "hearingDetails", hearingDetails
                 ));
                 ret.put("selectedHearingId", null);
                 return ret;
@@ -471,7 +472,7 @@ public class MigrateCaseService {
             .equals(UUID.fromString(caseDocumentUrl.substring(caseDocumentUrl.length() - 36)))) {
             throw new AssertionError(format(
                 "Migration {id = %s, case reference = %s},"
-                + " GateKeeping order - Urgent directions order document with Id %s not found",
+                    + " GateKeeping order - Urgent directions order document with Id %s not found",
                 migrationId, caseData.getId(), documentId));
         }
     }
@@ -489,7 +490,7 @@ public class MigrateCaseService {
             .equals(UUID.fromString(caseDocumentUrl.substring(caseDocumentUrl.length() - 36)))) {
             throw new AssertionError(format(
                 "Migration {id = %s, case reference = %s},"
-                + " GateKeeping order - Standard direction order document with Id %s not found",
+                    + " GateKeeping order - Standard direction order document with Id %s not found",
                 migrationId, caseData.getId(), documentId));
         }
     }
@@ -587,7 +588,7 @@ public class MigrateCaseService {
         List<Element<Placement>> nonConfidentialNoticesPlacementsToKeep = caseData.getPlacementEventData()
             .getPlacementsNonConfidential(true);
 
-        Map<String, Object> ret =  new HashMap<String, Object>();
+        Map<String, Object> ret = new HashMap<String, Object>();
         ret.put(PLACEMENT, placementsToKeep.isEmpty() ? null : placementsToKeep);
         ret.put(PLACEMENT_NON_CONFIDENTIAL, nonConfidentialPlacementsToKeep.isEmpty() ? null :
             nonConfidentialPlacementsToKeep);
@@ -628,8 +629,8 @@ public class MigrateCaseService {
 
     public Map<String, Object> removeJudicialMessage(CaseData caseData, String migrationId, String messageId) {
         return Map.of("judicialMessages",
-                removeJudicialMessageFormList(caseData.getJudicialMessages(), messageId, migrationId,
-                    caseData.getId()));
+            removeJudicialMessageFormList(caseData.getJudicialMessages(), messageId, migrationId,
+                caseData.getId()));
     }
 
     public Map<String, Object> removeClosedJudicialMessage(CaseData caseData, String migrationId, String messageId) {
@@ -640,7 +641,7 @@ public class MigrateCaseService {
     }
 
     private List<Element<JudicialMessage>> removeJudicialMessageFormList(List<Element<JudicialMessage>> messages,
-                                                              String messageId, String migrationId, Long caseId) {
+                                                                         String messageId, String migrationId, Long caseId) {
         if (messages == null) {
             throw new AssertionError(format("Migration {id = %s, case reference = %s}, judicial message is null",
                 migrationId, caseId));
@@ -685,7 +686,7 @@ public class MigrateCaseService {
     }
 
     public Map<String, Object> removeNoticeOfProceedingsBundle(CaseData caseData, String noticeOfProceedingsBundleId,
-                                                      String migrationId) {
+                                                               String migrationId) {
         Long caseId = caseData.getId();
         List<Element<DocumentBundle>> noticeOfProceedingsBundle = caseData.getNoticeOfProceedingsBundle();
 
@@ -710,7 +711,7 @@ public class MigrateCaseService {
     }
 
     public Map<String, Object> removeDocumentFiledOnIssue(CaseData caseData, UUID documentFiledOnIssueId,
-                                                      String migrationId) {
+                                                          String migrationId) {
         Long caseId = caseData.getId();
         List<Element<ManagedDocument>> documentsFiledOnIssueList = caseData.getDocumentsFiledOnIssueList();
 
@@ -872,8 +873,8 @@ public class MigrateCaseService {
     }
 
     public Map<String, List<Element<LocalAuthority>>> removeElementFromLocalAuthorities(CaseData caseData,
-                                                                 String migrationId,
-                                                                 UUID expectedLocalAuthorityId) {
+                                                                                        String migrationId,
+                                                                                        UUID expectedLocalAuthorityId) {
         Long caseId = caseData.getId();
         List<Element<LocalAuthority>> localAuthoritiesList =
             caseData.getLocalAuthorities().stream()
@@ -922,9 +923,9 @@ public class MigrateCaseService {
 
         return Map.of("court", court.toBuilder().epimmsId(correctBaseLocation).build(),
             "caseManagementLocation", CaseLocation.builder()
-            .baseLocation(correctBaseLocation)
-            .region(correctRegion)
-            .build());
+                .baseLocation(correctBaseLocation)
+                .region(correctRegion)
+                .build());
     }
 
     /**
@@ -976,9 +977,9 @@ public class MigrateCaseService {
             .orgPolicyCaseAssignedRole(applicantCaseRole).build());
     }
 
-    public  Map<String, Object> removeApplicantEmailAndStopNotifyingTheirColleagues(CaseData caseData,
-                                                                                    String migrationId,
-                                                                                    String applicantUuid) {
+    public Map<String, Object> removeApplicantEmailAndStopNotifyingTheirColleagues(CaseData caseData,
+                                                                                   String migrationId,
+                                                                                   String applicantUuid) {
         UUID targetApplicantUuid = UUID.fromString(applicantUuid);
 
         List<Element<LocalAuthority>> localAuthorities = caseData.getLocalAuthorities();
@@ -1080,7 +1081,7 @@ public class MigrateCaseService {
             .findFirst()
             .orElseThrow(() ->
                 new AssertionError(format("Migration {id = %s, case reference = %s} approval date not found",
-                migrationId, caseData.getId())));
+                    migrationId, caseData.getId())));
 
         CloseCase existingCloseCaseField = Optional.ofNullable(caseData.getCloseCaseTabField())
             .orElse(CloseCase.builder().build());
@@ -1281,7 +1282,7 @@ public class MigrateCaseService {
             .respondentsAwareReason(null)
             .build();
 
-        return Map.of("hearing",hearing);
+        return Map.of("hearing", hearing);
     }
 
     public Map<String, Object> redactTypeReason(CaseData caseData, String migrationId, int startLoc, int endLoc) {

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseService.java
@@ -216,6 +216,15 @@ public class MigrateCaseService {
         return Map.of("hearingOrdersBundlesDrafts", bundles);
     }
 
+    public void doStateCheck(String state, String expectedState, long caseId, String migrationId) throws AssertionError {
+        if (!state.equals(expectedState)) {
+            throw new AssertionError(format(
+                "Migration {id = %s, case reference = %s}, state was %s, expected %s",
+                migrationId, caseId, state, expectedState
+            ));
+        }
+    }
+
     public void doCaseIdCheck(long caseId, long expectedCaseId, String migrationId) throws AssertionError {
         if (caseId != expectedCaseId) {
             throw new AssertionError(format(

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseServiceTest.java
@@ -153,6 +153,25 @@ class MigrateCaseServiceTest {
         assertThrows(AssertionError.class, () -> underTest.doCaseIdCheckList(1L, List.of(2L, 3L), MIGRATION_ID));
     }
 
+    @Test
+    void shouldDoStateCheck() {
+        assertDoesNotThrow(() -> underTest.doStateCheck(
+            State.CASE_MANAGEMENT.toString(),
+            State.CASE_MANAGEMENT.toString(),
+            1L,
+            MIGRATION_ID));
+    }
+
+    @Test
+    void shouldThrowExceptionIfStateCheckFails() {
+        assertThrows(AssertionError.class, () -> underTest.doStateCheck(
+            State.CASE_MANAGEMENT.toString(),
+            State.CLOSED.toString(),
+            1L,
+            MIGRATION_ID
+        ));
+    }
+
     @Mock
     private CaseConverter caseConverter;
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
[DFPL-2585](https://tools.hmcts.net/jira/browse/DFPL-2585)


### Change description ###
 - Add migration to remove all judicial/legal adviser case roles if case is closed as part of pre-WA release cleanup


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
