### PR TITLE
DFPL-2579: Remove urgent directions order from case

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -11,7 +11,6 @@ import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.controllers.CallbackController;
-import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.service.CaseConverter;
 import uk.gov.hmcts.reform.fpl.service.MigrateCaseService;
 import uk.gov.hmcts.reform.fpl.service.orders.ManageOrderDocumentScopedFieldsCalculator;
@@ -31,9 +30,7 @@ public class MigrateCaseController extends CallbackController {
 
     private final Map<String, Consumer<CaseDetails>> migrations = Map.of(
         "DFPL-log", this::runLog,
-        "DFPL-2551", this::run2551,
-        "DFPL-2507", this::run2507,
-        "DFPL-2580", this::run2580
+        "DFPL-2579", this::run2579
     );
     private final CaseConverter caseConverter;
 
@@ -61,33 +58,12 @@ public class MigrateCaseController extends CallbackController {
         log.info("Logging migration on case {}", caseDetails.getId());
     }
 
-    private void run2551(CaseDetails caseDetails) {
-        final String migrationId = "DFPL-2551";
-        final long expectedCaseId = 1726735474157650L;
+    private void run2579(CaseDetails caseDetails) {
+        final String migrationId = "DFPL-2579";
+        final long expectedCaseId = 1727273204426566L;
 
         migrateCaseService.doCaseIdCheck(caseDetails.getId(), expectedCaseId, migrationId);
 
-        final CaseData caseData = getCaseData(caseDetails);
-        caseDetails.getData().putAll(migrateCaseService.removeAddressFromEPO(caseData, migrationId));
-    }
-
-    private void run2507(CaseDetails caseDetails) {
-        final String migrationId = "DFPL-2507";
-        final long expectedCaseId = 1697635739516572L;
-
-        migrateCaseService.doCaseIdCheck(caseDetails.getId(), expectedCaseId, migrationId);
-        final CaseData caseData = getCaseData(caseDetails);
-
-        caseDetails.getData().putAll(migrateCaseService.updateCancelledHearingDetailsType(caseData, migrationId));
-    }
-
-    private void run2580(CaseDetails caseDetails) {
-        final String migrationId = "DFPL-2580";
-        final long expectedCaseId = 1726476888400895L;
-
-        migrateCaseService.doCaseIdCheck(caseDetails.getId(), expectedCaseId, migrationId);
-
-        final CaseData caseData = getCaseData(caseDetails);
-        caseDetails.getData().putAll(migrateCaseService.redactTypeReason(caseData, migrationId, 395, 404));
+        caseDetails.getData().remove("urgentDirectionsOrder");
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
[DFPL-2579](https://tools.hmcts.net/jira/browse/DFPL-2579)


### Change description ###
 - Reinstate old remove UDO migration, with updated caseId


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
