### PR TITLE
DFPL-2611 Update user role for third party applicants to be EPSMANAGING

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/CaseInitiationService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/CaseInitiationService.java
@@ -30,11 +30,10 @@ import static java.util.Objects.nonNull;
 import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
 import static uk.gov.hmcts.reform.ccd.model.OrganisationPolicy.organisationPolicy;
-import static uk.gov.hmcts.reform.fpl.enums.CaseRole.CHILDSOLICITORA;
 import static uk.gov.hmcts.reform.fpl.enums.CaseRole.CREATOR;
+import static uk.gov.hmcts.reform.fpl.enums.CaseRole.EPSMANAGING;
 import static uk.gov.hmcts.reform.fpl.enums.CaseRole.LAMANAGING;
 import static uk.gov.hmcts.reform.fpl.enums.CaseRole.LASOLICITOR;
-import static uk.gov.hmcts.reform.fpl.enums.CaseRole.SOLICITORA;
 import static uk.gov.hmcts.reform.fpl.enums.OutsourcingType.EPS;
 import static uk.gov.hmcts.reform.fpl.enums.OutsourcingType.MLA;
 
@@ -240,7 +239,7 @@ public class CaseInitiationService {
                     .outsourcingPolicy(organisationPolicy(
                         currentUserOrganisationId,
                         currentUserOrganisationName,
-                        isRespondentSolicitor ? SOLICITORA : CHILDSOLICITORA))
+                        EPSMANAGING))
                     .caseLocalAuthority(caseData.getRelatingLA())
                     .caseLocalAuthorityName(localAuthorities.getLocalAuthorityName(caseData.getRelatingLA()))
                     .representativeType(caseData.getRepresentativeType())

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/CaseInitiationServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/CaseInitiationServiceTest.java
@@ -264,7 +264,7 @@ class CaseInitiationServiceTest {
             CaseData updatedCaseData = underTest.updateOrganisationsDetails(caseData);
 
             assertThat(updatedCaseData.getOutsourcingPolicy())
-                .isEqualTo(organisationPolicy(RS1.orgId, RS1.name, SOLICITORA));
+                .isEqualTo(organisationPolicy(RS1.orgId, RS1.name, EPSMANAGING));
             assertThat(updatedCaseData.getCaseLocalAuthority()).isEqualTo("SA");
             assertThat(updatedCaseData.getCaseLocalAuthorityName()).isEqualTo("Swansea");
         }
@@ -283,7 +283,7 @@ class CaseInitiationServiceTest {
             CaseData updatedCaseData = underTest.updateOrganisationsDetails(caseData);
 
             assertThat(updatedCaseData.getOutsourcingPolicy())
-                .isEqualTo(organisationPolicy(CS1.orgId, CS1.name, CHILDSOLICITORA));
+                .isEqualTo(organisationPolicy(CS1.orgId, CS1.name, EPSMANAGING));
             assertThat(updatedCaseData.getCaseLocalAuthority()).isEqualTo("SA");
             assertThat(updatedCaseData.getCaseLocalAuthorityName()).isEqualTo("Swansea");
         }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DFPL-2611

### Change description ###

On case initiation for third party applicants, the case creator's org should be assigned EPSMANAGING instead of SOLICITORA or CHILDSOLICITORA (depending on option selected in drop down they see when creating a case).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
