### PR TITLE
DFPL-2641: Move address known type to confidential tab

### DIFF
--- a/service/src/functionalTest/resources/enter-others/extract-confidential-data.json
+++ b/service/src/functionalTest/resources/enter-others/extract-confidential-data.json
@@ -36,7 +36,8 @@
               "telephone": null,
               "childInformation": null,
               "litigationIssues": "NO",
-              "detailsHidden": "Yes"
+              "detailsHidden": "Yes",
+              "addressKnowV2": "Yes"
             },
             "additionalOthers": []
           }

--- a/service/src/functionalTest/resources/enter-others/extract-confidential-data.json
+++ b/service/src/functionalTest/resources/enter-others/extract-confidential-data.json
@@ -91,6 +91,7 @@
             "litigationIssues": "NO",
             "litigationIssuesDetails": null,
             "detailsHidden": "Yes",
+            "addressKnowV2": null,
             "detailsHiddenReason": null,
             "representedBy": [],
             "DOB": "2000-07-12",

--- a/service/src/functionalTest/resources/enter-others/extract-confidential-data.json
+++ b/service/src/functionalTest/resources/enter-others/extract-confidential-data.json
@@ -24,7 +24,6 @@
               "DOB": "2000-07-12",
               "gender": "Male",
               "birthPlace": "London",
-              "addressKnowV2": "Yes",
               "address": {
                 "AddressLine1": "1st Avenue",
                 "AddressLine2": "5 Saffron Central Square",
@@ -94,7 +93,6 @@
             "detailsHiddenReason": null,
             "representedBy": [],
             "DOB": "2000-07-12",
-            "addressKnowV2": "Yes",
             "addressNotKnowReason": null
           },
           "additionalOthers": []
@@ -124,7 +122,7 @@
               "detailsHiddenReason": null,
               "representedBy": [],
               "DOB": null,
-              "addressKnowV2": null,
+              "addressKnowV2": "Yes",
               "addressNotKnowReason": null
             }
           }

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ChangeFromOtherUtils.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ChangeFromOtherUtils.java
@@ -102,6 +102,7 @@ public abstract class ChangeFromOtherUtils {
             (selectedOtherSeq == 0 ? firstOther : additionalOthers.get(selectedOtherSeq - 1).getValue())
                 .toBuilder()
                 .detailsHidden(null)
+                .addressKnowV2(IsAddressKnowType.YES)
                 .telephone("123456789")
                 .address(buildHiddenAddress("selected other"))
                 .build())
@@ -145,6 +146,7 @@ public abstract class ChangeFromOtherUtils {
                 e.getValue()
                     .toBuilder()
                     .detailsHidden(null)
+                    .addressKnowV2(IsAddressKnowType.YES)
                     .telephone("123456789")
                     .address(buildHiddenAddress(e.getValue().getName()))
                     .build())
@@ -194,15 +196,15 @@ public abstract class ChangeFromOtherUtils {
             .build();
     }
 
-    public static Respondent prepareExpectedTransformedRespondent(boolean contactDeatilsHidden) {
+    public static Respondent prepareExpectedTransformedRespondent(boolean contactDetailsHidden) {
         return Respondent.builder()
             .party(RespondentParty.builder()
                 .firstName("Johnny")
-                .telephoneNumber(contactDeatilsHidden ? null : Telephone.builder()
+                .telephoneNumber(contactDetailsHidden ? null : Telephone.builder()
                     .telephoneNumber("123456789").build())
-                .address(contactDeatilsHidden ? null : buildHiddenAddress("Converting"))
-                .addressKnow(IsAddressKnowType.YES)
-                .contactDetailsHidden(YesNo.from(contactDeatilsHidden).getValue())
+                .address(contactDetailsHidden ? null : buildHiddenAddress("Converting"))
+                .addressKnow(contactDetailsHidden ? null : IsAddressKnowType.YES)
+                .contactDetailsHidden(YesNo.from(contactDetailsHidden).getValue())
                 .build())
             .legalRepresentation("No")
             .build();

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/OthersControllerAboutToSubmitTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/OthersControllerAboutToSubmitTest.java
@@ -119,7 +119,6 @@ class OthersControllerAboutToSubmitTest extends AbstractCallbackTest {
     private Other otherWithDetailsRemoved() {
         return Other.builder()
             .name("other")
-            .addressKnowV2(IsAddressKnowType.YES)
             .detailsHidden("Yes")
             .build();
     }
@@ -129,6 +128,7 @@ class OthersControllerAboutToSubmitTest extends AbstractCallbackTest {
             .name("additional other")
             .address(Address.builder().addressLine1("101 London Road").build())
             .telephone("07122 123456")
+            .addressKnowV2(IsAddressKnowType.YES)
             .detailsHidden("No")
             .build()));
     }
@@ -148,6 +148,7 @@ class OthersControllerAboutToSubmitTest extends AbstractCallbackTest {
             .name("other")
             .address(Address.builder().addressLine1("506 Abbey Lane").build())
             .telephone("01227 123456")
+            .addressKnowV2(IsAddressKnowType.YES)
             .build();
     }
 
@@ -155,6 +156,7 @@ class OthersControllerAboutToSubmitTest extends AbstractCallbackTest {
         return Other.builder()
             .name("additional other")
             .telephone("07122 123456")
+            .addressKnowV2(IsAddressKnowType.NO)
             .build();
     }
 }

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/RespondentControllerChangeFromOtherAboutToSubmitTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/RespondentControllerChangeFromOtherAboutToSubmitTest.java
@@ -1,9 +1,7 @@
 package uk.gov.hmcts.reform.fpl.controllers;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -41,7 +39,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -105,6 +102,10 @@ class RespondentControllerChangeFromOtherAboutToSubmitTest extends AbstractCallb
     @MockBean
     private UserService userService;
 
+    private static final int SELECTED_OTHER = 0;
+    private static final int NUM_ADDITIONAL_OTHERS = 3;
+    private static final int NUM_RESPONDENTS = 2;
+
     RespondentControllerChangeFromOtherAboutToSubmitTest() {
         super("enter-respondents/change-from-other");
     }
@@ -114,98 +115,73 @@ class RespondentControllerChangeFromOtherAboutToSubmitTest extends AbstractCallb
         given(requestData.userRoles()).willReturn(Set.of(UserRole.HMCTS_ADMIN.getRoleName()));
     }
 
-    public static Stream<Arguments> othersToRespondentParam() {
-        Stream.Builder<Arguments> builder = Stream.builder();
-        for (int i = 0; i < 10; i++) { // selectedOtherSeq
-            for (int j = 0; j <= 9; j++) { // numberOfAdditionalOther
-                for (int k = 1; k <= 9; k++) { // numberOfRespondent
-                    if (i <= j) {
-                        builder.add(Arguments.of(i, j, k));
-                    }
-                }
-            }
-        }
-        return builder.build();
-    }
-
     @WithMockUser
-    @ParameterizedTest
-    @MethodSource("othersToRespondentParam")
-    void shouldConvertOthersToRespondent(int selectedOtherSeq, int numberOfAdditionalOther,
-                                         int numberOfRespondent) {
-        Others others = prepareOthersTestingData(numberOfAdditionalOther, false, false);
-        List<Respondent> respondents = prepareRespondentsTestingData(numberOfRespondent);
+    @Test
+    void shouldConvertOthersToRespondent() {
+        Others others = prepareOthersTestingData(NUM_ADDITIONAL_OTHERS, false, false);
+        List<Respondent> respondents = prepareRespondentsTestingData(NUM_RESPONDENTS);
         Respondent transformedRespondent = prepareTransformedRespondentTestingData(false);
 
         CaseData caseData = CaseData.builder()
             .localAuthorities(localAuthorities())
             .others(others)
             .respondents1(wrapElementsWithRandomUUID(respondents))
-            .otherToRespondentEventData(otherToRespondentEventData(transformedRespondent, others, selectedOtherSeq))
+            .otherToRespondentEventData(otherToRespondentEventData(transformedRespondent, others, SELECTED_OTHER))
             .build();
 
         AboutToStartOrSubmitCallbackResponse callbackResponse = postAboutToSubmitEvent(caseData);
         CaseData responseCaseData = extractCaseData(callbackResponse);
 
-        assertThat(responseCaseData.getAllOthers()).hasSize(numberOfAdditionalOther);
+        assertThat(responseCaseData.getAllOthers()).hasSize(NUM_ADDITIONAL_OTHERS);
         assertThat(responseCaseData.getAllOthers().stream()
-            .filter(o -> String.format("Marco %s", selectedOtherSeq).equals(o.getValue().getName()))).isEmpty();
-        if (numberOfAdditionalOther > 0) {
-            assertThat(responseCaseData.getOthers().getFirstOther()).isEqualTo(
-                Other.builder()
-                    .detailsHidden("No")
-                    .name(String.format("Marco %s", selectedOtherSeq == 0 ? 1 : 0))
-                    .build());
-        } else {
-            assertThat(responseCaseData.getOthers()).isNull();
-        }
-        assertThat(responseCaseData.getAllRespondents()).hasSize(numberOfRespondent + 1);
-        assertThat(responseCaseData.findRespondent(numberOfRespondent)).contains(transformedRespondent);
+            .filter(o -> String.format("Marco %s", SELECTED_OTHER).equals(o.getValue().getName()))).isEmpty();
+        assertThat(responseCaseData.getOthers().getFirstOther()).isEqualTo(
+            Other.builder()
+                .detailsHidden("No")
+                .name(String.format("Marco %s", 1))
+                .build());
+
+        assertThat(responseCaseData.getAllRespondents()).hasSize(NUM_RESPONDENTS + 1);
+        assertThat(responseCaseData.findRespondent(NUM_RESPONDENTS)).contains(transformedRespondent);
     }
 
     @WithMockUser
-    @ParameterizedTest
-    @MethodSource("othersToRespondentParam")
-    void shouldConvertOthersWithHiddenDetailsToRespondentWhereNoConfidentialRespondent(
-        int selectedOtherSeq, int numberOfAdditionalOther, int numberOfRespondent) {
-        Others others = prepareOthersTestingData(numberOfAdditionalOther, false,
-            (i) -> (selectedOtherSeq - 1) == i);
+    @Test
+    void shouldConvertOthersWithHiddenDetailsToRespondentWhereNoConfidentialRespondent() {
+        Others others = prepareOthersTestingData(NUM_ADDITIONAL_OTHERS, false,
+            (i) -> (SELECTED_OTHER - 1) == i);
         Other firstOther = others.getFirstOther();
         List<Element<Other>> additionalOthers = others.getAdditionalOthers();
-        List<Respondent> respondents = prepareRespondentsTestingData(numberOfRespondent);
+        List<Respondent> respondents = prepareRespondentsTestingData(NUM_RESPONDENTS);
         Respondent transformedRespondent = prepareTransformedRespondentTestingData(true);
 
         CaseData caseData = CaseData.builder()
-            .confidentialOthers(prepareSingleConfidentialOther(selectedOtherSeq, firstOther, additionalOthers))
+            .confidentialOthers(prepareSingleConfidentialOther(SELECTED_OTHER, firstOther, additionalOthers))
             .localAuthorities(localAuthorities())
             .others(others)
             .respondents1(wrapElementsWithRandomUUID(respondents))
-            .otherToRespondentEventData(otherToRespondentEventData(transformedRespondent, others, selectedOtherSeq))
+            .otherToRespondentEventData(otherToRespondentEventData(transformedRespondent, others, SELECTED_OTHER))
             .build();
 
         AboutToStartOrSubmitCallbackResponse callbackResponse = postAboutToSubmitEvent(caseData);
         CaseData responseCaseData = extractCaseData(callbackResponse);
 
-        assertThat(responseCaseData.getAllOthers()).hasSize(numberOfAdditionalOther);
+        assertThat(responseCaseData.getAllOthers()).hasSize(NUM_ADDITIONAL_OTHERS);
         assertThat(responseCaseData.getAllOthers().stream()
-            .filter(o -> String.format("Marco %s", selectedOtherSeq).equals(o.getValue().getName()))).isEmpty();
-        if (numberOfAdditionalOther > 0) {
-            assertThat(responseCaseData.getOthers().getFirstOther()).isEqualTo(
-                Other.builder()
-                    .name(String.format("Marco %s", selectedOtherSeq == 0 ? 1 : 0))
-                    .detailsHidden("No")
-                    .build());
-        } else {
-            assertThat(responseCaseData.getOthers()).isNull();
-        }
+            .filter(o -> String.format("Marco %s", SELECTED_OTHER).equals(o.getValue().getName()))).isEmpty();
+        assertThat(responseCaseData.getOthers().getFirstOther()).isEqualTo(
+            Other.builder()
+                .name(String.format("Marco %s", 1))
+                .detailsHidden("No")
+                .build());
         assertThat(responseCaseData.getConfidentialOthers()).hasSize(0);
         assertThat(responseCaseData.getConfidentialRespondents()).hasSize(1);
-        assertThat(responseCaseData.getAllRespondents()).hasSize(numberOfRespondent + 1);
-        assertThat(responseCaseData.findRespondent(numberOfRespondent)).contains(
+        assertThat(responseCaseData.getAllRespondents()).hasSize(NUM_RESPONDENTS + 1);
+        assertThat(responseCaseData.findRespondent(NUM_RESPONDENTS)).contains(
             prepareExpectedTransformedRespondent(true));
 
         UUID targetUUID = responseCaseData.getAllRespondents().stream().filter(
-            e -> Objects.equals(e.getValue(), responseCaseData.findRespondent(numberOfRespondent).get())
+            e -> Objects.equals(e.getValue(), responseCaseData.findRespondent(NUM_RESPONDENTS).get())
         ).map(Element::getId).findFirst().orElse(UUID.randomUUID());
         assertThat(responseCaseData.getConfidentialRespondents().stream()
             .filter(e -> targetUUID.equals(e.getId())).map(Element::getValue).findFirst())
@@ -213,54 +189,46 @@ class RespondentControllerChangeFromOtherAboutToSubmitTest extends AbstractCallb
     }
 
     @WithMockUser
-    @ParameterizedTest
-    @MethodSource("othersToRespondentParam")
-    void shouldConvertConfidentialOthersToConfidentialRespondentAndNoMoreConfidentialOthers(
-        int selectedOtherSeq,
-        int numberOfAdditionalOther,
-        int numberOfRespondent) {
-        Others others = prepareOthersTestingData(numberOfAdditionalOther, selectedOtherSeq == 0,
-            (i) -> (selectedOtherSeq - 1) == i);
+    @Test
+    void shouldConvertConfidentialOthersToConfidentialRespondentAndNoMoreConfidentialOthers() {
+        Others others = prepareOthersTestingData(NUM_ADDITIONAL_OTHERS, SELECTED_OTHER == 0,
+            (i) -> (SELECTED_OTHER - 1) == i);
         Other firstOther = others.getFirstOther();
         List<Element<Other>> additionalOthers = others.getAdditionalOthers();
 
-        List<Respondent> respondents = prepareRespondentsTestingData(numberOfRespondent, true);
+        List<Respondent> respondents = prepareRespondentsTestingData(NUM_RESPONDENTS, true);
         Respondent transformedRespondent = prepareTransformedRespondentTestingData(true);
 
         List<Element<Respondent>> respondents1 = wrapElementsWithRandomUUID(respondents);
 
         CaseData caseData = CaseData.builder()
             .confidentialRespondents(prepareConfidentialRespondentsFromRespondents1(respondents1))
-            .confidentialOthers(prepareSingleConfidentialOther(selectedOtherSeq, firstOther, additionalOthers))
+            .confidentialOthers(prepareSingleConfidentialOther(SELECTED_OTHER, firstOther, additionalOthers))
             .localAuthorities(localAuthorities())
             .others(others)
             .respondents1(respondents1)
-            .otherToRespondentEventData(otherToRespondentEventData(transformedRespondent, others, selectedOtherSeq))
+            .otherToRespondentEventData(otherToRespondentEventData(transformedRespondent, others, SELECTED_OTHER))
             .build();
 
         AboutToStartOrSubmitCallbackResponse callbackResponse = postAboutToSubmitEvent(caseData);
         CaseData responseCaseData = extractCaseData(callbackResponse);
 
-        assertThat(responseCaseData.getAllOthers()).hasSize(numberOfAdditionalOther);
+        assertThat(responseCaseData.getAllOthers()).hasSize(NUM_ADDITIONAL_OTHERS);
         assertThat(responseCaseData.getAllOthers().stream()
-            .filter(o -> String.format("Marco %s", selectedOtherSeq).equals(o.getValue().getName()))).isEmpty();
-        if (numberOfAdditionalOther > 0) {
-            assertThat(responseCaseData.getOthers().getFirstOther()).isEqualTo(
-                Other.builder()
-                    .name(String.format("Marco %s", selectedOtherSeq == 0 ? 1 : 0))
-                    .detailsHidden("No")
-                    .build());
-        } else {
-            assertThat(responseCaseData.getOthers()).isNull();
-        }
+            .filter(o -> String.format("Marco %s", SELECTED_OTHER).equals(o.getValue().getName()))).isEmpty();
+        assertThat(responseCaseData.getOthers().getFirstOther()).isEqualTo(
+            Other.builder()
+                .name(String.format("Marco %s", 1))
+                .detailsHidden("No")
+                .build());
         assertThat(responseCaseData.getConfidentialOthers()).hasSize(0);
-        assertThat(responseCaseData.getConfidentialRespondents()).hasSize(numberOfRespondent + 1);
-        assertThat(responseCaseData.getAllRespondents()).hasSize(numberOfRespondent + 1);
-        assertThat(responseCaseData.findRespondent(numberOfRespondent)).contains(
+        assertThat(responseCaseData.getConfidentialRespondents()).hasSize(NUM_RESPONDENTS + 1);
+        assertThat(responseCaseData.getAllRespondents()).hasSize(NUM_RESPONDENTS + 1);
+        assertThat(responseCaseData.findRespondent(NUM_RESPONDENTS)).contains(
             prepareExpectedTransformedRespondent(true));
         // Check converted respondent's confidential address
         UUID targetUUID = responseCaseData.getAllRespondents().stream().filter(
-            e -> Objects.equals(e.getValue(), responseCaseData.findRespondent(numberOfRespondent).get())
+            e -> Objects.equals(e.getValue(), responseCaseData.findRespondent(NUM_RESPONDENTS).get())
         ).map(Element::getId).findFirst().orElse(UUID.randomUUID());
         assertThat(responseCaseData.getConfidentialRespondents().stream()
             .filter(e -> targetUUID.equals(e.getId()))
@@ -269,29 +237,27 @@ class RespondentControllerChangeFromOtherAboutToSubmitTest extends AbstractCallb
             .contains(prepareExpectedTransformedConfidentialRespondent());
         // Check existing respondent address
         UUID prevExistingRespondentUUID = responseCaseData.getAllRespondents().stream().filter(
-            e -> Objects.equals(e.getValue(), responseCaseData.findRespondent(numberOfRespondent - 1).get())
+            e -> Objects.equals(e.getValue(), responseCaseData.findRespondent(NUM_RESPONDENTS - 1).get())
         ).map(Element::getId).findFirst().orElse(UUID.randomUUID());
         assertThat(responseCaseData.getConfidentialRespondents().stream()
             .filter(e -> prevExistingRespondentUUID.equals(e.getId()))
             .map(Element::getValue)
             .findFirst())
-            .contains(prepareExpectedExistingConfidentialRespondent(numberOfRespondent - 1));
+            .contains(prepareExpectedExistingConfidentialRespondent(NUM_RESPONDENTS - 1));
     }
 
     @WithMockUser
-    @ParameterizedTest
-    @MethodSource("othersToRespondentParam")
-    void shouldConvertConfidentialOthersToConfidentialRespondentAndRetainConfidentialOthers(
-        int selectedOtherSeq, int numberOfAdditionalOther, int numberOfRespondent) {
+    @Test
+    void shouldConvertConfidentialOthersToConfidentialRespondentAndRetainConfidentialOthers() {
         boolean firstOtherDetailsHidden = true;
         boolean additionalOtherDetailsHidden = true;
-        Others others = prepareOthersTestingData(numberOfAdditionalOther, firstOtherDetailsHidden,
+        Others others = prepareOthersTestingData(NUM_ADDITIONAL_OTHERS, firstOtherDetailsHidden,
             additionalOtherDetailsHidden);
         List<Element<Other>> allOthers = new ArrayList<>();
         allOthers.add(element(others.getFirstOther()));
         allOthers.addAll(others.getAdditionalOthers());
 
-        List<Respondent> respondents = prepareRespondentsTestingData(numberOfRespondent, true);
+        List<Respondent> respondents = prepareRespondentsTestingData(NUM_RESPONDENTS, true);
         Respondent transformedRespondent = prepareTransformedRespondentTestingData(true);
 
         List<Element<Respondent>> respondents1 = wrapElementsWithRandomUUID(respondents);
@@ -304,67 +270,59 @@ class RespondentControllerChangeFromOtherAboutToSubmitTest extends AbstractCallb
             .others(others)
             .confidentialOthers(prepareConfidentialOthersTestingData(others, firstOtherDetailsHidden,
                 (i) -> additionalOtherDetailsHidden))
-            .otherToRespondentEventData(otherToRespondentEventData(transformedRespondent, others, selectedOtherSeq))
+            .otherToRespondentEventData(otherToRespondentEventData(transformedRespondent, others, SELECTED_OTHER))
             .build();
 
         AboutToStartOrSubmitCallbackResponse callbackResponse = postAboutToSubmitEvent(caseData);
         CaseData responseCaseData = extractCaseData(callbackResponse);
 
-        assertThat(responseCaseData.getAllOthers()).hasSize(numberOfAdditionalOther);
+        assertThat(responseCaseData.getAllOthers()).hasSize(NUM_ADDITIONAL_OTHERS);
         assertThat(responseCaseData.getAllOthers().stream()
-            .filter(o -> String.format("Marco %s", selectedOtherSeq).equals(o.getValue().getName()))).isEmpty();
-        if (numberOfAdditionalOther > 0) {
-            assertThat(responseCaseData.getOthers().getFirstOther()).isEqualTo(
-                Other.builder()
-                    .name(String.format("Marco %s", selectedOtherSeq == 0 ? 1 : 0))
-                    .detailsHidden("Yes")
-                    .build());
-        } else {
-            assertThat(responseCaseData.getOthers()).isNull();
-        }
-        assertThat(responseCaseData.getConfidentialOthers()).hasSize(numberOfAdditionalOther);
-        assertThat(responseCaseData.getConfidentialRespondents()).hasSize(numberOfRespondent + 1);
-        assertThat(responseCaseData.getAllRespondents()).hasSize(numberOfRespondent + 1);
-        assertThat(responseCaseData.findRespondent(numberOfRespondent)).contains(
+            .filter(o -> String.format("Marco %s", SELECTED_OTHER).equals(o.getValue().getName()))).isEmpty();
+        assertThat(responseCaseData.getOthers().getFirstOther()).isEqualTo(
+            Other.builder()
+                .name(String.format("Marco %s", 1))
+                .detailsHidden("Yes")
+                .build());
+        assertThat(responseCaseData.getConfidentialOthers()).hasSize(NUM_ADDITIONAL_OTHERS);
+        assertThat(responseCaseData.getConfidentialRespondents()).hasSize(NUM_RESPONDENTS + 1);
+        assertThat(responseCaseData.getAllRespondents()).hasSize(NUM_RESPONDENTS + 1);
+        assertThat(responseCaseData.findRespondent(NUM_RESPONDENTS)).contains(
             prepareExpectedTransformedRespondent(true));
         // Check converted respondent's confidential address
         UUID targetUUID = responseCaseData.getAllRespondents().stream().filter(
-            e -> Objects.equals(e.getValue(), responseCaseData.findRespondent(numberOfRespondent).get())
+            e -> Objects.equals(e.getValue(), responseCaseData.findRespondent(NUM_RESPONDENTS).get())
         ).map(Element::getId).findFirst().orElse(UUID.randomUUID());
         assertThat(responseCaseData.getConfidentialRespondents().stream()
             .filter(e -> targetUUID.equals(e.getId())).map(Element::getValue).findFirst())
             .contains(prepareExpectedTransformedConfidentialRespondent());
         // Check existing respondent address
         UUID prevExistingRespondentUUID = responseCaseData.getAllRespondents().stream().filter(
-            e -> Objects.equals(e.getValue(), responseCaseData.findRespondent(numberOfRespondent - 1).get())
+            e -> Objects.equals(e.getValue(), responseCaseData.findRespondent(NUM_RESPONDENTS - 1).get())
         ).map(Element::getId).findFirst().orElse(UUID.randomUUID());
         assertThat(responseCaseData.getConfidentialRespondents().stream()
             .filter(e -> prevExistingRespondentUUID.equals(e.getId()))
             .map(Element::getValue)
             .findFirst())
-            .contains(prepareExpectedExistingConfidentialRespondent(numberOfRespondent - 1));
+            .contains(prepareExpectedExistingConfidentialRespondent(NUM_RESPONDENTS - 1));
     }
 
     @WithMockUser
-    @ParameterizedTest
-    @MethodSource("othersToRespondentParam")
-    void shouldConvertOthersWithRepresentativeToRespondent(
-        int selectedOtherSeq,
-        int numberOfAdditionalOther,
-        int numberOfRespondent) {
-        Others others = prepareOthersTestingData(numberOfAdditionalOther, false, false);
-        Element<Representative> representativeForOther = element(prepareOtherRepresentative(selectedOtherSeq));
-        if (selectedOtherSeq == 0) {
+    @Test
+    void shouldConvertOthersWithRepresentativeToRespondent() {
+        Others others = prepareOthersTestingData(NUM_ADDITIONAL_OTHERS, false, false);
+        Element<Representative> representativeForOther = element(prepareOtherRepresentative(SELECTED_OTHER));
+        if (SELECTED_OTHER == 0) {
             others.getFirstOther().addRepresentative(representativeForOther.getId());
         } else {
-            others.getAdditionalOthers().get(selectedOtherSeq - 1).getValue()
+            others.getAdditionalOthers().get(SELECTED_OTHER - 1).getValue()
                 .addRepresentative(representativeForOther.getId());
         }
 
         Respondent transformedRespondent = prepareTransformedRespondentTestingData(false);
         transformedRespondent.addRepresentative(representativeForOther.getId());
 
-        List<Respondent> respondents = prepareRespondentsTestingData(numberOfRespondent);
+        List<Respondent> respondents = prepareRespondentsTestingData(NUM_RESPONDENTS);
         List<Element<Respondent>> respondents1 = wrapElementsWithRandomUUID(respondents);
 
         CaseData caseData = CaseData.builder()
@@ -372,53 +330,45 @@ class RespondentControllerChangeFromOtherAboutToSubmitTest extends AbstractCallb
             .localAuthorities(localAuthorities())
             .others(others)
             .respondents1(respondents1)
-            .otherToRespondentEventData(otherToRespondentEventData(transformedRespondent, others, selectedOtherSeq))
+            .otherToRespondentEventData(otherToRespondentEventData(transformedRespondent, others, SELECTED_OTHER))
             .build();
 
         AboutToStartOrSubmitCallbackResponse callbackResponse = postAboutToSubmitEvent(caseData);
         CaseData responseCaseData = extractCaseData(callbackResponse);
 
-        assertThat(responseCaseData.getAllOthers()).hasSize(numberOfAdditionalOther);
+        assertThat(responseCaseData.getAllOthers()).hasSize(NUM_ADDITIONAL_OTHERS);
         assertThat(responseCaseData.getAllOthers().stream()
-            .filter(o -> String.format("Marco %s", selectedOtherSeq).equals(o.getValue().getName()))).isEmpty();
-        if (numberOfAdditionalOther > 0) {
-            assertThat(responseCaseData.getOthers().getFirstOther()).isEqualTo(
-                Other.builder()
-                    .name(String.format("Marco %s", selectedOtherSeq == 0 ? 1 : 0))
-                    .detailsHidden("No")
-                    .build());
-        } else {
-            assertThat(responseCaseData.getOthers()).isNull();
-        }
-        assertThat(responseCaseData.getAllRespondents()).hasSize(numberOfRespondent + 1);
-        assertThat(responseCaseData.findRespondent(numberOfRespondent).map(Respondent::getParty))
+            .filter(o -> String.format("Marco %s", SELECTED_OTHER).equals(o.getValue().getName()))).isEmpty();
+        assertThat(responseCaseData.getOthers().getFirstOther()).isEqualTo(
+            Other.builder()
+                .name(String.format("Marco %s", 1))
+                .detailsHidden("No")
+                .build());
+        assertThat(responseCaseData.getAllRespondents()).hasSize(NUM_RESPONDENTS + 1);
+        assertThat(responseCaseData.findRespondent(NUM_RESPONDENTS).map(Respondent::getParty))
             .contains(prepareExpectedTransformedRespondent(false).getParty());
-        assertThat(responseCaseData.findRespondent(numberOfRespondent).map(Respondent::getRepresentedBy).map(
+        assertThat(responseCaseData.findRespondent(NUM_RESPONDENTS).map(Respondent::getRepresentedBy).map(
             ElementUtils::unwrapElements).orElse(List.of())).isEqualTo(List.of(representativeForOther.getId()));
         assertThat(responseCaseData.getRepresentatives()).hasSize(1);
         assertThat(unwrapElements(responseCaseData.getRepresentatives()).stream()
             .map(Representative::getRole).findFirst())
-            .contains(resolveRespondentRepresentativeRole(numberOfRespondent + 1));
+            .contains(resolveRespondentRepresentativeRole(NUM_RESPONDENTS + 1));
     }
 
     @WithMockUser
-    @ParameterizedTest
-    @MethodSource("othersToRespondentParam")
-    void shouldConvertOthersWithRepresentativesToRespondent(
-            int selectedOtherSeq,
-            int numberOfAdditionalOther,
-            int numberOfRespondent) {
-        Others others = prepareOthersTestingData(numberOfAdditionalOther, false, false);
+    @Test
+    void shouldConvertOthersWithRepresentativesToRespondent() {
+        Others others = prepareOthersTestingData(NUM_ADDITIONAL_OTHERS, false, false);
         List<Element<Representative>> representatives = new ArrayList<>();
         List<UUID> representativeIdsInTransformedRespondent = new ArrayList<>();
-        for (int i = 0; i < numberOfAdditionalOther + 1; i++) {
+        for (int i = 0; i < NUM_ADDITIONAL_OTHERS + 1; i++) {
             Element<Representative> representativeElement = element(prepareOtherRepresentative(i));
             if (i == 0) {
                 others.getFirstOther().addRepresentative(representativeElement.getId());
             } else {
                 others.getAdditionalOthers().get(i - 1).getValue().addRepresentative(representativeElement.getId());
             }
-            if (i == selectedOtherSeq) {
+            if (i == SELECTED_OTHER) {
                 representativeIdsInTransformedRespondent.add(representativeElement.getId());
             }
             representatives.add(representativeElement);
@@ -427,7 +377,7 @@ class RespondentControllerChangeFromOtherAboutToSubmitTest extends AbstractCallb
         Respondent transformedRespondent = prepareTransformedRespondentTestingData(false);
         representativeIdsInTransformedRespondent.forEach(uuid -> transformedRespondent.addRepresentative(uuid));
 
-        List<Respondent> respondents = prepareRespondentsTestingData(numberOfRespondent);
+        List<Respondent> respondents = prepareRespondentsTestingData(NUM_RESPONDENTS);
         List<Element<Respondent>> respondents1 = wrapElementsWithRandomUUID(respondents);
 
         CaseData caseData = CaseData.builder()
@@ -435,40 +385,35 @@ class RespondentControllerChangeFromOtherAboutToSubmitTest extends AbstractCallb
             .localAuthorities(localAuthorities())
             .others(others)
             .respondents1(respondents1)
-            .otherToRespondentEventData(otherToRespondentEventData(transformedRespondent, others, selectedOtherSeq))
+            .otherToRespondentEventData(otherToRespondentEventData(transformedRespondent, others, SELECTED_OTHER))
             .build();
 
         AboutToStartOrSubmitCallbackResponse callbackResponse = postAboutToSubmitEvent(caseData);
         CaseData responseCaseData = extractCaseData(callbackResponse);
 
-        assertThat(responseCaseData.getAllOthers()).hasSize(numberOfAdditionalOther);
+        assertThat(responseCaseData.getAllOthers()).hasSize(NUM_ADDITIONAL_OTHERS);
         assertThat(responseCaseData.getAllOthers().stream()
-            .filter(o -> String.format("Marco %s", selectedOtherSeq).equals(o.getValue().getName()))).isEmpty();
-        if (numberOfAdditionalOther > 0) {
-            Other expectedFirstOther = Other.builder()
-                .name(String.format("Marco %s", selectedOtherSeq == 0 ? 1 : 0))
-                .detailsHidden("No")
-                .build();
-            if (selectedOtherSeq == 0) {
-                expectedFirstOther.getRepresentedBy().addAll(
-                    caseData.getOthers().getAdditionalOthers().get(0).getValue().getRepresentedBy());
-            } else {
-                expectedFirstOther.getRepresentedBy().addAll(caseData.getOthers().getFirstOther().getRepresentedBy());
-            }
-            assertThat(responseCaseData.getOthers().getFirstOther()).isEqualTo(expectedFirstOther);
-        } else {
-            assertThat(responseCaseData.getOthers()).isNull();
-        }
+            .filter(o -> String.format("Marco %s", SELECTED_OTHER).equals(o.getValue().getName()))).isEmpty();
+        Other expectedFirstOther = Other.builder()
+            .name(String.format("Marco %s", 1))
+            .detailsHidden("No")
+            .build();
+
+        expectedFirstOther.getRepresentedBy().addAll(
+            caseData.getOthers().getAdditionalOthers().get(0).getValue().getRepresentedBy());
+
+        assertThat(responseCaseData.getOthers().getFirstOther()).isEqualTo(expectedFirstOther);
+
         // verify the respondent count should be increased by 1
-        assertThat(responseCaseData.getAllRespondents()).hasSize(numberOfRespondent + 1);
+        assertThat(responseCaseData.getAllRespondents()).hasSize(NUM_RESPONDENTS + 1);
         // verify respondent content was transferred successfully
-        assertThat(responseCaseData.findRespondent(numberOfRespondent).map(Respondent::getParty))
+        assertThat(responseCaseData.findRespondent(NUM_RESPONDENTS).map(Respondent::getParty))
             .contains(prepareExpectedTransformedRespondent(false).getParty());
         // verify if the transformed respondent's representative ids are migrated to respondent's representedBy
-        assertThat(responseCaseData.findRespondent(numberOfRespondent).map(Respondent::getRepresentedBy).map(
+        assertThat(responseCaseData.findRespondent(NUM_RESPONDENTS).map(Respondent::getRepresentedBy).map(
             ElementUtils::unwrapElements).orElse(List.of())).isEqualTo(representativeIdsInTransformedRespondent);
         // verify if the representative's count = other's count
-        assertThat(responseCaseData.getRepresentatives()).hasSize(numberOfAdditionalOther + 1);
+        assertThat(responseCaseData.getRepresentatives()).hasSize(NUM_ADDITIONAL_OTHERS + 1);
         // verify the new respondent's roles
         representativeIdsInTransformedRespondent.forEach(representativeId -> {
             assertThat(
@@ -476,7 +421,7 @@ class RespondentControllerChangeFromOtherAboutToSubmitTest extends AbstractCallb
                     .map(Element::getValue)
                     .map(Representative::getRole)
                     .stream().collect(toSet())
-            ).isEqualTo(Set.of(resolveRespondentRepresentativeRole(numberOfRespondent + 1)));
+            ).isEqualTo(Set.of(resolveRespondentRepresentativeRole(NUM_RESPONDENTS + 1)));
         });
         // verify the non-affected other's representatives
         List<Element<Other>> responseAllOthers = responseCaseData.getAllOthers();
@@ -497,26 +442,22 @@ class RespondentControllerChangeFromOtherAboutToSubmitTest extends AbstractCallb
     }
 
     @WithMockUser
-    @ParameterizedTest
-    @MethodSource("othersToRespondentParam")
-    void shouldConvertConfidentialOthersWithRepresentativesToRespondent(
-        int selectedOtherSeq,
-        int numberOfAdditionalOther,
-        int numberOfRespondent) {
+    @Test
+    void shouldConvertConfidentialOthersWithRepresentativesToRespondent() {
         boolean firstOtherDetailsHidden = true;
         boolean additionalOtherDetailsHidden = true;
-        Others others = prepareOthersTestingData(numberOfAdditionalOther, firstOtherDetailsHidden,
+        Others others = prepareOthersTestingData(NUM_ADDITIONAL_OTHERS, firstOtherDetailsHidden,
             additionalOtherDetailsHidden);
         List<Element<Representative>> representatives = new ArrayList<>();
         List<UUID> representativeIdsInTransformedRespondent = new ArrayList<>();
-        for (int i = 0; i < numberOfAdditionalOther + 1; i++) {
+        for (int i = 0; i < NUM_ADDITIONAL_OTHERS + 1; i++) {
             Element<Representative> representativeElement = element(prepareOtherRepresentative(i));
             if (i == 0) {
                 others.getFirstOther().addRepresentative(representativeElement.getId());
             } else {
                 others.getAdditionalOthers().get(i - 1).getValue().addRepresentative(representativeElement.getId());
             }
-            if (i == selectedOtherSeq) {
+            if (i == SELECTED_OTHER) {
                 representativeIdsInTransformedRespondent.add(representativeElement.getId());
             }
             representatives.add(representativeElement);
@@ -525,7 +466,7 @@ class RespondentControllerChangeFromOtherAboutToSubmitTest extends AbstractCallb
         Respondent transformedRespondent = prepareTransformedRespondentTestingData(true);
         representativeIdsInTransformedRespondent.forEach(uuid -> transformedRespondent.addRepresentative(uuid));
 
-        List<Respondent> respondents = prepareRespondentsTestingData(numberOfRespondent);
+        List<Respondent> respondents = prepareRespondentsTestingData(NUM_RESPONDENTS);
         List<Element<Respondent>> respondents1 = wrapElementsWithRandomUUID(respondents);
 
         CaseData caseData = CaseData.builder()
@@ -535,40 +476,34 @@ class RespondentControllerChangeFromOtherAboutToSubmitTest extends AbstractCallb
             .confidentialOthers(prepareConfidentialOthersTestingData(others, firstOtherDetailsHidden,
                 (i) -> additionalOtherDetailsHidden))
             .respondents1(respondents1)
-            .otherToRespondentEventData(otherToRespondentEventData(transformedRespondent, others, selectedOtherSeq))
+            .otherToRespondentEventData(otherToRespondentEventData(transformedRespondent, others, SELECTED_OTHER))
             .build();
 
         AboutToStartOrSubmitCallbackResponse callbackResponse = postAboutToSubmitEvent(caseData);
         CaseData responseCaseData = extractCaseData(callbackResponse);
 
-        assertThat(responseCaseData.getAllOthers()).hasSize(numberOfAdditionalOther);
+        assertThat(responseCaseData.getAllOthers()).hasSize(NUM_ADDITIONAL_OTHERS);
         assertThat(responseCaseData.getAllOthers().stream()
-            .filter(o -> String.format("Marco %s", selectedOtherSeq).equals(o.getValue().getName()))).isEmpty();
-        if (numberOfAdditionalOther > 0) {
-            Other expectedFirstOther = Other.builder()
-                .name(String.format("Marco %s", selectedOtherSeq == 0 ? 1 : 0))
-                .detailsHidden("Yes")
-                .build();
-            if (selectedOtherSeq == 0) {
-                expectedFirstOther.getRepresentedBy().addAll(
-                    caseData.getOthers().getAdditionalOthers().get(0).getValue().getRepresentedBy());
-            } else {
-                expectedFirstOther.getRepresentedBy().addAll(caseData.getOthers().getFirstOther().getRepresentedBy());
-            }
-            assertThat(responseCaseData.getOthers().getFirstOther()).isEqualTo(expectedFirstOther);
-        } else {
-            assertThat(responseCaseData.getOthers()).isNull();
-        }
+            .filter(o -> String.format("Marco %s", SELECTED_OTHER).equals(o.getValue().getName()))).isEmpty();
+
+        Other expectedFirstOther = Other.builder()
+            .name(String.format("Marco %s", SELECTED_OTHER == 0 ? 1 : 0))
+            .detailsHidden("Yes")
+            .build();
+        expectedFirstOther.getRepresentedBy().addAll(
+            caseData.getOthers().getAdditionalOthers().get(0).getValue().getRepresentedBy());
+        assertThat(responseCaseData.getOthers().getFirstOther()).isEqualTo(expectedFirstOther);
+
         // verify the respondent count should be increased by 1
-        assertThat(responseCaseData.getAllRespondents()).hasSize(numberOfRespondent + 1);
+        assertThat(responseCaseData.getAllRespondents()).hasSize(NUM_RESPONDENTS + 1);
         // verify respondent content was transferred successfully
-        assertThat(responseCaseData.findRespondent(numberOfRespondent).map(Respondent::getParty))
+        assertThat(responseCaseData.findRespondent(NUM_RESPONDENTS).map(Respondent::getParty))
             .contains(prepareExpectedTransformedRespondent(true).getParty());
         // verify if the transformed respondent's representative ids are migrated to respondent's representedBy
-        assertThat(responseCaseData.findRespondent(numberOfRespondent).map(Respondent::getRepresentedBy).map(
+        assertThat(responseCaseData.findRespondent(NUM_RESPONDENTS).map(Respondent::getRepresentedBy).map(
             ElementUtils::unwrapElements).orElse(List.of())).isEqualTo(representativeIdsInTransformedRespondent);
         // verify if the representative's count = other's count
-        assertThat(responseCaseData.getRepresentatives()).hasSize(numberOfAdditionalOther + 1);
+        assertThat(responseCaseData.getRepresentatives()).hasSize(NUM_ADDITIONAL_OTHERS + 1);
         // verify the new respondent's roles
         representativeIdsInTransformedRespondent.forEach(representativeId -> {
             assertThat(
@@ -576,7 +511,7 @@ class RespondentControllerChangeFromOtherAboutToSubmitTest extends AbstractCallb
                     .map(Element::getValue)
                     .map(Representative::getRole)
                     .stream().collect(toSet())
-            ).isEqualTo(Set.of(resolveRespondentRepresentativeRole(numberOfRespondent + 1)));
+            ).isEqualTo(Set.of(resolveRespondentRepresentativeRole(NUM_RESPONDENTS + 1)));
         });
         // verify the non-affected other's representatives
         List<Element<Other>> responseAllOthers = responseCaseData.getAllOthers();

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/Other.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/Other.java
@@ -117,6 +117,7 @@ public class Other implements Representable, ConfidentialParty<Other> {
     @Override
     public Other extractConfidentialDetails() {
         return Other.builder()
+            .addressKnowV2(this.addressKnowV2)
             .name(this.name)
             .address(this.address)
             .telephone(this.telephone)
@@ -131,6 +132,7 @@ public class Other implements Representable, ConfidentialParty<Other> {
     @Override
     public Other removeConfidentialDetails() {
         Other other =  this.toBuilder()
+            .addressKnowV2(null)
             .address(null)
             .telephone(null)
             .build();

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/Respondent.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/Respondent.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 
 import static java.util.UUID.randomUUID;
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.element;
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.unwrapElements;
@@ -71,6 +72,7 @@ public class Respondent implements Representable, WithSolicitor, ConfidentialPar
     public Respondent extractConfidentialDetails() {
         return Respondent.builder()
             .party(RespondentParty.builder()
+                .addressKnow(this.party.getAddressKnow())
                 .firstName(this.party.getFirstName())
                 .lastName(this.party.getLastName())
                 .addressKnow(this.party.getAddressKnow())
@@ -83,14 +85,19 @@ public class Respondent implements Representable, WithSolicitor, ConfidentialPar
 
     @Override
     public Respondent addConfidentialDetails(Party party) {
+        RespondentParty.RespondentPartyBuilder partyBuilder = this.getParty().toBuilder()
+            .firstName(party.getFirstName())
+            .lastName(party.getLastName())
+            .address(party.getAddress())
+            .telephoneNumber(party.getTelephoneNumber())
+            .email(party.getEmail());
+
+        if (!isEmpty(((RespondentParty) party).getAddressKnow())) {
+            partyBuilder.addressKnow(((RespondentParty) party).getAddressKnow());
+        }
+
         return this.toBuilder()
-            .party(this.getParty().toBuilder()
-                .firstName(party.getFirstName())
-                .lastName(party.getLastName())
-                .address(party.getAddress())
-                .telephoneNumber(party.getTelephoneNumber())
-                .email(party.getEmail())
-                .build())
+            .party(partyBuilder.build())
             .build();
     }
 
@@ -98,6 +105,7 @@ public class Respondent implements Representable, WithSolicitor, ConfidentialPar
     public Respondent removeConfidentialDetails() {
         return this.toBuilder()
             .party(this.party.toBuilder()
+                .addressKnow(null)
                 .address(null)
                 .telephoneNumber(null)
                 .email(null)

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/OthersService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/OthersService.java
@@ -23,7 +23,7 @@ import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
-import static uk.gov.hmcts.reform.fpl.utils.ConfidentialDetailsHelper.getConfidentialItemToAdd;
+import static uk.gov.hmcts.reform.fpl.utils.ConfidentialDetailsHelper.getConfidentialOtherToAdd;
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.element;
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.nullSafeCollection;
 
@@ -71,7 +71,7 @@ public class OthersService {
 
         caseData.getAllOthers().forEach(element -> {
             if (element.getValue().containsConfidentialDetails()) {
-                Other confidentialOther = getConfidentialItemToAdd(caseData.getConfidentialOthers(), element);
+                Other confidentialOther = getConfidentialOtherToAdd(caseData.getConfidentialOthers(), element);
                 others.add(element(element.getId(), addConfidentialDetails(confidentialOther, element)));
             } else {
                 others.add(element);
@@ -146,11 +146,15 @@ public class OthersService {
     }
 
     public Other addConfidentialDetails(Other confidentialOther, Element<Other> other) {
-        Other ret = other.getValue().toBuilder()
+        Other.OtherBuilder retBuilder = other.getValue().toBuilder()
             .telephone(confidentialOther.getTelephone())
-            .address(confidentialOther.getAddress())
-            .build();
-        return ret;
+            .address(confidentialOther.getAddress());
+
+        if (isEmpty(other.getValue().getAddressKnowV2())) {
+            retBuilder.addressKnowV2(confidentialOther.getAddressKnowV2());
+        }
+
+        return retBuilder.build();
     }
 
     // This finds firstOther element id in confidential others that doesn't match.

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/utils/ConfidentialDetailsHelper.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/utils/ConfidentialDetailsHelper.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.fpl.utils;
 
+import uk.gov.hmcts.reform.fpl.model.Other;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
 
 import java.util.List;
@@ -13,6 +14,16 @@ public class ConfidentialDetailsHelper {
     public static <T> T getConfidentialItemToAdd(List<Element<T>> confidential, Element<T> element) {
         return confidential.stream()
             .filter(item -> item.getId().equals(element.getId()))
+            .map(Element::getValue)
+            .findFirst()
+            .orElse(element.getValue());
+    }
+
+    // TODO - Move this back into the above function, once Others has been refactored into a collection like respondents
+    public static Other getConfidentialOtherToAdd(List<Element<Other>> confidential, Element<Other> element) {
+        return confidential.stream()
+            .filter(item -> item.getId().equals(element.getId())
+                || item.getValue().getName().equals(element.getValue().getName()))
             .map(Element::getValue)
             .findFirst()
             .orElse(element.getValue());

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/OthersServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/OthersServiceTest.java
@@ -184,10 +184,11 @@ class OthersServiceTest {
 
     @Test
     void shouldPrepareOthersWithConfidentialValuesWhenConfidentialOthersIsNotEmpty() {
-        List<Element<Other>> additionalOthersList = othersWithConfidentialFields(randomUUID());
+        List<Element<Other>> additionalOthersList = othersWithConfidentialFields(randomUUID(), "John");
 
-        Other firstOther = othersWithRemovedConfidentialFields().get(0).getValue();
-        List<Element<Other>> confidentialOthers = othersWithConfidentialFields(ID);
+        // firstOther should be the "same" (in name) as the first confidential other, if they have conf data
+        Other firstOther = othersWithRemovedConfidentialFields("Jack").get(0).getValue();
+        List<Element<Other>> confidentialOthers = othersWithConfidentialFields(ID, "Jack");
 
         CaseData caseData = buildCaseDataWithOthers(firstOther, additionalOthersList, confidentialOthers);
 
@@ -198,8 +199,8 @@ class OthersServiceTest {
 
     @Test
     void shouldReturnOtherWithoutConfidentialDetailsWhenThereIsNoMatchingConfidentialOther() {
-        Other firstOther = othersWithRemovedConfidentialFields().get(0).getValue();
-        List<Element<Other>> additionalOther = othersWithRemovedConfidentialFields();
+        Other firstOther = othersWithRemovedConfidentialFields("James").get(0).getValue();
+        List<Element<Other>> additionalOther = othersWithRemovedConfidentialFields("Jack");
         List<Element<Other>> confidentialOther = othersWithConfidentialFields(randomUUID());
 
         CaseData caseData = buildCaseDataWithOthers(firstOther, additionalOther, confidentialOther);
@@ -227,14 +228,14 @@ class OthersServiceTest {
         UUID otherId = randomUUID();
 
         List<Element<Other>> others = List.of(
-            othersWithRemovedConfidentialFields().get(0),
+            othersWithRemovedConfidentialFields("James").get(0),
             othersWithConfidentialFields(otherId).get(0));
 
         List<Element<Other>> confidentialOthers = List.of(othersWithConfidentialFields(otherId).get(0));
 
         CaseData caseData = CaseData.builder()
             .others(Others.builder()
-                .firstOther(othersWithRemovedConfidentialFields().get(0).getValue())
+                .firstOther(othersWithRemovedConfidentialFields("Jack").get(0).getValue())
                 .additionalOthers(others)
                 .build())
             .confidentialOthers(confidentialOthers)
@@ -347,8 +348,12 @@ class OthersServiceTest {
     }
 
     private List<Element<Other>> othersWithConfidentialFields(UUID id) {
+        return othersWithConfidentialFields(id, "Joan");
+    }
+
+    private List<Element<Other>> othersWithConfidentialFields(UUID id, String name) {
         return newArrayList(element(id, Other.builder()
-            .name("James")
+            .name(name)
             .gender("Female")
             .detailsHidden("Yes")
             .address(Address.builder().addressLine1("Address Line 1").build())
@@ -357,12 +362,17 @@ class OthersServiceTest {
     }
 
     private List<Element<Other>> othersWithRemovedConfidentialFields() {
+        return othersWithRemovedConfidentialFields("James");
+    }
+
+    private List<Element<Other>> othersWithRemovedConfidentialFields(String name) {
         return newArrayList(element(ID, Other.builder()
-            .name("James")
+            .name(name)
             .gender("Female")
             .detailsHidden("Yes")
             .build()));
     }
+
 
     private DynamicList buildSingleSelector(int selectedIdx) {
         return buildSingleSelector(selectedIdx, null);

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/utils/ConfidentialDetailsHelperTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/utils/ConfidentialDetailsHelperTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.fpl.utils;
 
 import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.fpl.enums.IsAddressKnowType;
 import uk.gov.hmcts.reform.fpl.model.Address;
 import uk.gov.hmcts.reform.fpl.model.Other;
 import uk.gov.hmcts.reform.fpl.model.common.Element;
@@ -11,6 +12,7 @@ import java.util.UUID;
 import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.reform.fpl.utils.ConfidentialDetailsHelper.getConfidentialItemToAdd;
+import static uk.gov.hmcts.reform.fpl.utils.ConfidentialDetailsHelper.getConfidentialOtherToAdd;
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.element;
 
 class ConfidentialDetailsHelperTest {
@@ -41,6 +43,32 @@ class ConfidentialDetailsHelperTest {
 
         assertThat(confidentialOthers).isEqualToComparingFieldByField(othersNotConfidential.getValue());
     }
+
+    @Test
+    void shouldReturnOtherByNameIfNoUUIDMatch() {
+        List<Element<Other>> others = List.of(element(UUID.randomUUID(),
+            Other.builder().name("John Smith").addressKnowV2(IsAddressKnowType.LIVE_IN_REFUGE).build()));
+
+        Other confidentialOther = getConfidentialOtherToAdd(others,
+            element(UUID.randomUUID(), Other.builder().name("John Smith").build()));
+
+        assertThat(confidentialOther).extracting("addressKnowV2")
+            .isEqualTo(IsAddressKnowType.LIVE_IN_REFUGE);
+    }
+
+    @Test
+    void shouldReturnOtherIfUUIDMatch() {
+        UUID id = UUID.randomUUID();
+        List<Element<Other>> others = List.of(element(id,
+            Other.builder().name("John Smith").addressKnowV2(IsAddressKnowType.LIVE_IN_REFUGE).build()));
+
+        Other confidentialOther = getConfidentialOtherToAdd(others,
+            element(id, Other.builder().name("John Smith").build()));
+
+        assertThat(confidentialOther).extracting("addressKnowV2")
+            .isEqualTo(IsAddressKnowType.LIVE_IN_REFUGE);
+    }
+
 
     private Other.OtherBuilder baseOtherBuilder(String detailsHidden) {
         return Other.builder()


### PR DESCRIPTION
### JIRA link (if applicable) ###
[DFPL-2641](https://tools.hmcts.net/jira/browse/DFPL-2641)


### Change description ###
 - Move address known type (for respondents) and address known type v2 (for others) to the confidential information tab.
   - Note - Others doesn't have a method for rebuilding the non-conf + conf objects, so doesn't work quite the same way (presumably as other parties can access the others event, so could leak info)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
