### PR TITLE
DFPL-2671: Add post-nominals to fullname/surname when using lookup

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/Judge.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/Judge.java
@@ -13,6 +13,8 @@ import uk.gov.hmcts.reform.rd.model.JudicialUserProfile;
 
 import java.util.Objects;
 
+import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
+
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class Judge extends AbstractJudge {
@@ -61,11 +63,15 @@ public class Judge extends AbstractJudge {
     }
 
     public static Judge fromJudicialUserProfile(JudicialUserProfile jup, YesNo judgeEnterManually) {
+        String postNominals = isNotEmpty(jup.getPostNominals())
+            ? (" " + jup.getPostNominals())
+            : "";
+
         return Judge.builder()
             .judgeTitle(JudgeOrMagistrateTitle.OTHER)
             .otherTitle(jup.getTitle())
-            .judgeLastName(jup.getSurname())
-            .judgeFullName(jup.getFullName())
+            .judgeLastName(jup.getSurname() + postNominals)
+            .judgeFullName(jup.getFullName() + postNominals)
             .judgeEmailAddress(jup.getEmailId())
             .judgeEnterManually(judgeEnterManually)
             .judgeJudicialUser(JudicialUser.builder()

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/common/JudgeAndLegalAdvisor.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/common/JudgeAndLegalAdvisor.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.reform.fpl.model.Judge;
 import uk.gov.hmcts.reform.fpl.model.JudicialUser;
 import uk.gov.hmcts.reform.rd.model.JudicialUserProfile;
 
+import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
 import static uk.gov.hmcts.reform.fpl.enums.YesNo.NO;
 import static uk.gov.hmcts.reform.fpl.enums.YesNo.YES;
 
@@ -81,11 +82,14 @@ public class JudgeAndLegalAdvisor extends AbstractJudge {
     }
 
     public static JudgeAndLegalAdvisor fromJudicialUserProfile(JudicialUserProfile jup) {
+        String postNominals = isNotEmpty(jup.getPostNominals())
+            ? (" " + jup.getPostNominals())
+            : "";
         return JudgeAndLegalAdvisor.builder()
             .judgeTitle(JudgeOrMagistrateTitle.OTHER)
             .otherTitle(jup.getTitle())
-            .judgeLastName(jup.getSurname())
-            .judgeFullName(jup.getFullName())
+            .judgeLastName(jup.getSurname() + postNominals)
+            .judgeFullName(jup.getFullName() + postNominals)
             .judgeEmailAddress(jup.getEmailId())
             .judgeEnterManually(NO)
             .judgeJudicialUser(JudicialUser.builder()

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/model/JudgeTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/model/JudgeTest.java
@@ -88,6 +88,22 @@ class JudgeTest {
         assertThat(judge.getJudgeFullName()).isEqualTo("HHJ John Smith KC");
     }
 
+    @Test
+    void shouldIgnoreNullPostNominalsWhenConvertingJudicialUserProfile() {
+        JudicialUserProfile jup = JudicialUserProfile.builder()
+            .title("HHJ")
+            .surname("Smith")
+            .fullName("HHJ John Smith")
+            .postNominals(null)
+            .build();
+
+        Judge judge = Judge.fromJudicialUserProfile(jup);
+
+        assertThat(judge.getJudgeLastName()).isEqualTo("Smith");
+        assertThat(judge.getJudgeFullName()).isEqualTo("HHJ John Smith");
+    }
+
+
     private Judge buildAllocatedJudge(JudgeOrMagistrateTitle title) {
         return Judge.builder()
             .judgeTitle(title)

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/model/JudgeTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/model/JudgeTest.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.fpl.model;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.fpl.enums.JudgeOrMagistrateTitle;
 import uk.gov.hmcts.reform.fpl.model.common.JudgeAndLegalAdvisor;
+import uk.gov.hmcts.reform.rd.model.JudicialUserProfile;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.reform.fpl.enums.JudgeOrMagistrateTitle.DEPUTY_DISTRICT_JUDGE;
@@ -70,6 +71,21 @@ class JudgeTest {
 
         Judge allocatedJudge = buildAllocatedJudge(judgeOrMagistrateTitle);
         assertThat(allocatedJudge.hasEqualJudgeFields(judgeAndLegalAdvisor)).isFalse();
+    }
+
+    @Test
+    void shouldHandlePostNominalsWhenConvertingJudicialUserProfile() {
+        JudicialUserProfile jup = JudicialUserProfile.builder()
+            .title("HHJ")
+            .surname("Smith")
+            .fullName("HHJ John Smith")
+            .postNominals("KC")
+            .build();
+
+        Judge judge = Judge.fromJudicialUserProfile(jup);
+
+        assertThat(judge.getJudgeLastName()).isEqualTo("Smith KC");
+        assertThat(judge.getJudgeFullName()).isEqualTo("HHJ John Smith KC");
     }
 
     private Judge buildAllocatedJudge(JudgeOrMagistrateTitle title) {


### PR DESCRIPTION
### JIRA link (if applicable) ###
[DFPL-2671](https://tools.hmcts.net/jira/browse/DFPL-2671)


### Change description ###
 - Appends post-nominals if present to full name + last name fields


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
