### PR TITLE
Restrict solicitor access from children/respondents events

### DIFF
--- a/ccd-definition/AuthorisationCaseEvent/CareSupervision/AuthorisationCaseEvent.json
+++ b/ccd-definition/AuthorisationCaseEvent/CareSupervision/AuthorisationCaseEvent.json
@@ -460,7 +460,6 @@
           "[LASHARED]",
           "[SOLICITORA]",
           "[CHILDSOLICITORA]",
-          "caseworker-publiclaw-solicitor",
           "caseworker-publiclaw-judiciary"
         ],
         "CRUD": "CR"
@@ -1241,8 +1240,7 @@
           "[LAMANAGING]",
           "[LASHARED]",
           "[SOLICITORA]",
-          "[CHILDSOLICITORA]",
-          "caseworker-publiclaw-solicitor"
+          "[CHILDSOLICITORA]"
         ],
         "CRUD": "CR"
       },
@@ -1760,7 +1758,7 @@
         "CRUD": "CRU"
       }
     ]
-  },   
+  },
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ChildControllerAboutToStartTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ChildControllerAboutToStartTest.java
@@ -3,14 +3,24 @@ package uk.gov.hmcts.reform.fpl.controllers;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
+import uk.gov.hmcts.reform.fpl.service.RepresentativeService;
+
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 @WebMvcTest(ChildController.class)
 @OverrideAutoConfiguration(enabled = true)
 class ChildControllerAboutToStartTest extends AbstractCallbackTest {
+
+    @MockBean
+    private RepresentativeService representativeService;
 
     ChildControllerAboutToStartTest() {
         super("enter-children");
@@ -18,9 +28,26 @@ class ChildControllerAboutToStartTest extends AbstractCallbackTest {
 
     @Test
     void aboutToStartShouldPrepopulateChildrenDataWhenNoChildExists() {
+        when(representativeService.shouldUserHaveAccessToRespondentsChildrenEvent(any())).thenReturn(true);
+
         CaseData caseData = CaseData.builder().build();
         AboutToStartOrSubmitCallbackResponse callbackResponse = postAboutToStartEvent(caseData);
 
         assertThat(callbackResponse.getData()).containsKey("children1");
+        assertThat(callbackResponse.getErrors()).isNullOrEmpty();
     }
+
+    @Test
+    void shouldThrowErrorIfUserRestrictedFromAccessingEvent() {
+        when(representativeService.shouldUserHaveAccessToRespondentsChildrenEvent(any())).thenReturn(false);
+        CaseDetails caseDetails = CaseDetails.builder()
+            .data(Map.of("data", "some data"))
+            .build();
+
+        AboutToStartOrSubmitCallbackResponse callbackResponse = postAboutToStartEvent(caseDetails);
+
+        assertThat(callbackResponse.getErrors())
+            .contains("Contact the applicant or CTSC to modify children details.");
+    }
+
 }

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/RespondentControllerAboutToStartTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/RespondentControllerAboutToStartTest.java
@@ -3,16 +3,23 @@ package uk.gov.hmcts.reform.fpl.controllers;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.fpl.service.RepresentativeService;
 
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 @WebMvcTest(RespondentController.class)
 @OverrideAutoConfiguration(enabled = true)
 class RespondentControllerAboutToStartTest extends AbstractCallbackTest {
+
+    @MockBean
+    private RepresentativeService representativeService;
 
     RespondentControllerAboutToStartTest() {
         super("enter-respondents");
@@ -20,6 +27,8 @@ class RespondentControllerAboutToStartTest extends AbstractCallbackTest {
 
     @Test
     void aboutToStartShouldPrePopulateRespondent() {
+        when(representativeService.shouldUserHaveAccessToRespondentsChildrenEvent(any())).thenReturn(true);
+
         CaseDetails caseDetails = CaseDetails.builder()
             .data(Map.of("data", "some data"))
             .build();
@@ -27,5 +36,19 @@ class RespondentControllerAboutToStartTest extends AbstractCallbackTest {
         AboutToStartOrSubmitCallbackResponse callbackResponse = postAboutToStartEvent(caseDetails);
 
         assertThat(callbackResponse.getData()).containsKey("respondents1");
+        assertThat(callbackResponse.getErrors()).isNullOrEmpty();
+    }
+
+    @Test
+    void shouldThrowErrorIfUserRestrictedFromAccessingEvent() {
+        when(representativeService.shouldUserHaveAccessToRespondentsChildrenEvent(any())).thenReturn(false);
+        CaseDetails caseDetails = CaseDetails.builder()
+            .data(Map.of("data", "some data"))
+            .build();
+
+        AboutToStartOrSubmitCallbackResponse callbackResponse = postAboutToStartEvent(caseDetails);
+
+        assertThat(callbackResponse.getErrors())
+            .contains("Contact the applicant or CTSC to modify respondent details.");
     }
 }

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/handlers/PartyAddedToCaseEventHandlerEmailTemplateTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/handlers/PartyAddedToCaseEventHandlerEmailTemplateTest.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.reform.fpl.model.ChildParty;
 import uk.gov.hmcts.reform.fpl.model.Representative;
 import uk.gov.hmcts.reform.fpl.model.Respondent;
 import uk.gov.hmcts.reform.fpl.model.RespondentParty;
+import uk.gov.hmcts.reform.fpl.service.CaseRoleLookupService;
 import uk.gov.hmcts.reform.fpl.service.CaseService;
 import uk.gov.hmcts.reform.fpl.service.CaseUrlService;
 import uk.gov.hmcts.reform.fpl.service.OrganisationService;
@@ -41,7 +42,7 @@ import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.wrapElements;
 })
 @MockBeans({
     @MockBean(CaseService.class), @MockBean(OrganisationService.class), @MockBean(RepresentativeCaseRoleService.class),
-    @MockBean(ValidateEmailService.class)
+    @MockBean(ValidateEmailService.class), @MockBean(CaseRoleLookupService.class)
 })
 class PartyAddedToCaseEventHandlerEmailTemplateTest extends EmailTemplateTest {
     private static final String RESPONDENT_LAST_NAME = "Perturabo";

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/ChildController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/ChildController.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.fpl.events.ChildrenUpdated;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.service.ConfidentialDetailsService;
 import uk.gov.hmcts.reform.fpl.service.NoticeOfChangeService;
+import uk.gov.hmcts.reform.fpl.service.RepresentativeService;
 import uk.gov.hmcts.reform.fpl.service.RespondentAfterSubmissionRepresentationService;
 import uk.gov.hmcts.reform.fpl.service.children.ChildRepresentationService;
 import uk.gov.hmcts.reform.fpl.service.children.ChildrenEventDataFixer;
@@ -39,6 +40,7 @@ public class ChildController extends CallbackController {
     private static final List<State> RESTRICTED_STATES = List.of(OPEN, RETURNED);
 
     private final ConfidentialDetailsService confidentialDetailsService;
+    private final RepresentativeService representativeService;
     private final ChildRepresentationService childRepresentationService;
     private final NoticeOfChangeService noticeOfChangeService;
     private final RespondentAfterSubmissionRepresentationService respondentAfterSubmissionRepresentationService;
@@ -46,10 +48,16 @@ public class ChildController extends CallbackController {
     private final ChildrenEventDataFixer fixer;
     private final RepresentableLegalCounselUpdater representableCounselUpdater;
 
+    public static final String NO_ACCESS_ERROR = "Contact the applicant or CTSC to modify children details.";
+
     @PostMapping("/about-to-start")
     public CallbackResponse handleAboutToStart(@RequestBody CallbackRequest request) {
         CaseDetails caseDetails = request.getCaseDetails();
         CaseData caseData = getCaseData(caseDetails);
+
+        if (!representativeService.shouldUserHaveAccessToRespondentsChildrenEvent(caseData)) {
+            return respond(caseDetails, List.of(NO_ACCESS_ERROR));
+        }
 
         caseDetails.getData().put("children1", confidentialDetailsService.prepareCollection(
             caseData.getAllChildren(), caseData.getConfidentialChildren(), expandCollection()

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/RespondentController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/RespondentController.java
@@ -72,10 +72,16 @@ public class RespondentController extends CallbackController {
     private final NoticeOfChangeService noticeOfChangeService;
     private final RepresentableLegalCounselUpdater representableCounselUpdater;
 
+    public static final String NO_ACCESS_ERROR = "Contact the applicant or CTSC to modify respondent details.";
+
     @PostMapping("/about-to-start")
     public AboutToStartOrSubmitCallbackResponse handleAboutToStart(@RequestBody CallbackRequest callbackrequest) {
         CaseDetails caseDetails = callbackrequest.getCaseDetails();
         CaseData caseData = getCaseData(caseDetails);
+
+        if (!representativeService.shouldUserHaveAccessToRespondentsChildrenEvent(caseData)) {
+            return respond(caseDetails, List.of(NO_ACCESS_ERROR));
+        }
 
         caseDetails.getData().put(RESPONDENTS_KEY, confidentialDetailsService.prepareCollection(
             caseData.getAllRespondents(), caseData.getConfidentialRespondents(), expandCollection()));

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/RepresentativesServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/RepresentativesServiceTest.java
@@ -4,17 +4,22 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.reform.ccd.model.Organisation;
+import uk.gov.hmcts.reform.ccd.model.OrganisationPolicy;
 import uk.gov.hmcts.reform.fpl.enums.RepresentativeRole;
 import uk.gov.hmcts.reform.fpl.enums.RepresentativeRole.Type;
 import uk.gov.hmcts.reform.fpl.enums.RepresentativeServingPreferences;
+import uk.gov.hmcts.reform.fpl.enums.SolicitorRole;
 import uk.gov.hmcts.reform.fpl.model.Address;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.Other;
@@ -98,6 +103,9 @@ class RepresentativesServiceTest {
     @Mock
     private ValidateEmailService validateEmailService;
 
+    @Mock
+    private CaseRoleLookupService caseRoleLookupService;
+
     @InjectMocks
     private RepresentativeService representativesService;
 
@@ -105,7 +113,7 @@ class RepresentativesServiceTest {
     private static final String INVALID_EMAIL = "<John Doe> test@test.com";
 
     @BeforeEach
-    private void init() {
+    public void init() {
         when(requestData.authorisation()).thenReturn(authorisation);
         when(validateEmailService.isValid(VALID_EMAIL)).thenReturn(true);
         when(validateEmailService.isValid(INVALID_EMAIL)).thenReturn(false);
@@ -115,7 +123,7 @@ class RepresentativesServiceTest {
     }
 
     @AfterEach
-    private void verifyNoUnexpectedInteractions() {
+    public void verifyNoUnexpectedInteractions() {
         verifyNoMoreInteractions(organisationService);
         verifyNoMoreInteractions(caseService);
     }
@@ -743,4 +751,80 @@ class RepresentativesServiceTest {
             .stream().map(Representative::getRole).collect(Collectors.toSet()))
             .isEqualTo(Set.of(expected));
     }
+
+    @Nested
+    class BlockOutsourcedUsers {
+
+        @ParameterizedTest
+        @EnumSource(value = SolicitorRole.class, names = {"SOLICITORA", "CHILDSOLICITORA"})
+        void shouldBlockNonOutsourcedSolicitorFromAccessingEvent(SolicitorRole role) {
+            when(caseRoleLookupService.getCaseSolicitorRolesForCurrentUser(any()))
+                .thenReturn(List.of(role));
+            when(organisationService.findOrganisation())
+                .thenReturn(Optional.of(uk.gov.hmcts.reform.rd.model.Organisation.builder()
+                    .organisationIdentifier("ORG2")
+                    .build()));
+
+            CaseData caseData = CaseData.builder()
+                .outsourcingPolicy(OrganisationPolicy.builder()
+                    .organisation(Organisation.builder().organisationID("ORG1").build())
+                    .build())
+                .build();
+
+            assertThat(representativesService.shouldUserHaveAccessToRespondentsChildrenEvent(caseData)).isFalse();
+
+            verify(caseRoleLookupService).getCaseSolicitorRolesForCurrentUser(any());
+            verify(organisationService).findOrganisation();
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = SolicitorRole.class, names = {"SOLICITORA", "CHILDSOLICITORA"})
+        void shouldNotBlockOutsourcedSolicitorFromAccessingEvent(SolicitorRole role) {
+            when(caseRoleLookupService.getCaseSolicitorRolesForCurrentUser(any()))
+                .thenReturn(List.of(role));
+            when(organisationService.findOrganisation())
+                .thenReturn(Optional.of(uk.gov.hmcts.reform.rd.model.Organisation.builder()
+                    .organisationIdentifier("ORG1")
+                    .build()));
+
+            CaseData caseData = CaseData.builder()
+                .outsourcingPolicy(OrganisationPolicy.builder()
+                    .organisation(Organisation.builder().organisationID("ORG1").build())
+                    .build())
+                .build();
+
+            assertThat(representativesService.shouldUserHaveAccessToRespondentsChildrenEvent(caseData)).isTrue();
+
+            verify(caseRoleLookupService).getCaseSolicitorRolesForCurrentUser(any());
+            verify(organisationService).findOrganisation();
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = SolicitorRole.class, names = {"SOLICITORA", "CHILDSOLICITORA"})
+        void shouldBlockNonOutsourcedSolicitorWhenNoOutsourcingPolicy(SolicitorRole role) {
+            when(caseRoleLookupService.getCaseSolicitorRolesForCurrentUser(any()))
+                .thenReturn(List.of(role));
+
+            CaseData caseData = CaseData.builder()
+                .outsourcingPolicy(null)
+                .build();
+
+            assertThat(representativesService.shouldUserHaveAccessToRespondentsChildrenEvent(caseData)).isFalse();
+
+            verify(caseRoleLookupService).getCaseSolicitorRolesForCurrentUser(any());
+        }
+
+        @Test
+        void shouldNotBlockCtscFromAccessingEvent() {
+            when(caseRoleLookupService.getCaseSolicitorRolesForCurrentUser(any()))
+                .thenReturn(List.of());
+
+            CaseData caseData = CaseData.builder().build();
+
+            assertThat(representativesService.shouldUserHaveAccessToRespondentsChildrenEvent(caseData)).isTrue();
+
+            verify(caseRoleLookupService).getCaseSolicitorRolesForCurrentUser(any());
+        }
+    }
+
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

TBC

### Change description ###
 - Stop generic solicitor role from amending respondents/childrem
 - If SOLICITORA/CHILDSOLICITORA, programmatically restrict access to these events if they aren't the applicant (as determined by outsourcingPolicy)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
