### PR TITLE
DFPL-2654: When creating a new role, ensure it's end is offset 5 mins

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/JudicialService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/JudicialService.java
@@ -159,8 +159,10 @@ public class JudicialService {
     public void assignHearingJudge(Long caseId, HearingBooking hearing, Optional<HearingBooking> nextHearing,
                                    boolean startNow) {
         Optional<String> judgeId = getJudgeIdFromHearing(hearing);
+
+        // end this new role at the start of the next hearing (if present) MINUS 5 minutes to avoid overlapping roles
         ZonedDateTime possibleEndDate = nextHearing.map(HearingBooking::getStartDate)
-            .map(ld -> ld.atZone(ZoneId.systemDefault()))
+            .map(ld -> ld.minusMinutes(HEARING_EXPIRY_OFFSET_MINS).atZone(ZoneId.systemDefault()))
             .orElse(null);
 
         judgeId.ifPresentOrElse(s -> assignHearingJudgeRole(caseId,
@@ -423,8 +425,10 @@ public class JudicialService {
             && !isEmpty(hearing.getJudgeAndLegalAdvisor().getJudgeJudicialUser())
             && !isEmpty(hearing.getJudgeAndLegalAdvisor().getJudgeJudicialUser().getIdamId())) {
 
+            // delete the role for this hearing + offset by 5 minutes into the future, so we don't hit the old (bugged)
+            // hearing role assignments that may have ended at exactly this hearing time
             roleAssignmentService.deleteRoleAssignmentOnCaseAtTime(caseId,
-                hearing.getStartDate().atZone(ZoneId.systemDefault()),
+                hearing.getStartDate().plusMinutes(HEARING_EXPIRY_OFFSET_MINS).atZone(ZoneId.systemDefault()),
                 hearing.getJudgeAndLegalAdvisor().getJudgeJudicialUser().getIdamId(),
                 List.of(HEARING_JUDGE.getRoleName(), HEARING_LEGAL_ADVISER.getRoleName()));
         }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/JudicialServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/JudicialServiceTest.java
@@ -343,8 +343,9 @@ class JudicialServiceTest {
 
     @Test
     void shouldDeleteSpecificHearingRole() {
+        LocalDateTime start = LocalDateTime.now();
         HearingBooking hearing = HearingBooking.builder()
-            .startDate(LocalDateTime.now())
+            .startDate(start)
             .judgeAndLegalAdvisor(JudgeAndLegalAdvisor.builder()
                 .judgeEnterManually(YesNo.NO)
                 .judgeJudicialUser(JudicialUser.builder()
@@ -355,7 +356,11 @@ class JudicialServiceTest {
 
         underTest.deleteSpecificHearingRole(12345L, hearing);
 
-        verify(roleAssignmentService).deleteRoleAssignmentOnCaseAtTime(eq(12345L), any(), eq("idam"),
+        // delete the role starting at the time of the hearing (offset 5 mins into the role being active)
+        verify(roleAssignmentService).deleteRoleAssignmentOnCaseAtTime(
+            eq(12345L),
+            eq(start.plusMinutes(5).atZone(ZoneId.systemDefault())),
+            eq("idam"),
             eq(List.of("hearing-judge", "hearing-legal-adviser")));
     }
 
@@ -440,7 +445,7 @@ class JudicialServiceTest {
             List.of("idam"),
             JudgeCaseRole.HEARING_JUDGE,
             now.atZone(ZoneId.systemDefault()),
-            now.plusDays(2).atZone(ZoneId.systemDefault()));
+            now.plusDays(2).minusMinutes(5).atZone(ZoneId.systemDefault()));
     }
 
     @Nested


### PR DESCRIPTION
### JIRA link (if applicable) ###
[DFPL-2654](https://tools.hmcts.net/jira/browse/DFPL-2654)

### Change description ###
1.  When adding a new role, if there is a hearing afterwards (i.e. being added out of chronological order, editing a middle hearing), ensure it ends 5 mins before the next role starts
2. When deleting roles for a hearing, offset the deletion query by 5 minutes into the hearing start time, so we don't pickup any old, misconfigured hearing roles which end at the time of the current hearing (fixed going forwards in (1), but this saves a migration recreating all roles)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
