### PR TITLE
DFPL-2538: Add optional closure note to judicial messages

### DIFF
--- a/ccd-definition/CaseEventToComplexTypes/messageJudge/judicialMessageReply.json
+++ b/ccd-definition/CaseEventToComplexTypes/messageJudge/judicialMessageReply.json
@@ -122,9 +122,20 @@
     "ID": "JudicialMessageReply",
     "CaseEventID": "replyToMessageJudgeOrLegalAdviser",
     "CaseFieldID": "judicialMessageReply",
+    "ListElementCode": "closureNote",
+    "EventElementLabel": "Add closure note",
+    "FieldDisplayOrder": 12,
+    "DisplayContext": "OPTIONAL",
+    "FieldShowCondition": "judicialMessageReply.isReplying=\"No\""
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "JudicialMessageReply",
+    "CaseEventID": "replyToMessageJudgeOrLegalAdviser",
+    "CaseFieldID": "judicialMessageReply",
     "ListElementCode": "closeMessageLabel",
     "EventElementLabel": "This message will now be marked as closed",
-    "FieldDisplayOrder": 12,
+    "FieldDisplayOrder": 13,
     "DisplayContext": "READONLY",
     "FieldShowCondition": "judicialMessageReply.isReplying=\"No\""
   }

--- a/ccd-definition/ComplexTypes/CareSupervision/JudicialMessage/JudicialMessage.json
+++ b/ccd-definition/ComplexTypes/CareSupervision/JudicialMessage/JudicialMessage.json
@@ -107,6 +107,14 @@
   {
     "LiveFrom": "01/01/2017",
     "ID": "JudicialMessage",
+    "ListElementCode": "closureNote",
+    "FieldType": "TextArea",
+    "ElementLabel": "Closure note",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "JudicialMessage",
     "ListElementCode": "relatedDocuments",
     "FieldType": "Collection",
     "FieldTypeParameter": "Document",

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/judicialmessage/JudicialMessage.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/judicialmessage/JudicialMessage.java
@@ -36,6 +36,7 @@ public class JudicialMessage extends JudicialMessageMetaData {
     private final String isReplying;
     private final String latestMessage;
     private final String messageHistory;
+    private final String closureNote;
     private final String replyFrom;
     private final String replyTo;
 

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/ReplyToMessageJudgeService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/ReplyToMessageJudgeService.java
@@ -108,7 +108,8 @@ public class ReplyToMessageJudgeService extends MessageJudgeService {
 
         if (NO.getValue().equals(judicialMessageReply.getIsReplying())) {
             return closeJudicialMessage(
-                selectedJudicialMessageId, caseData.getJudicialMessages(), caseData.getClosedJudicialMessages());
+                selectedJudicialMessageId, caseData.getJudicialMessages(), caseData.getClosedJudicialMessages(),
+                judicialMessageReply.getClosureNote());
         } else {
             List<Element<JudicialMessage>> updatedMessages = replyToJudicialMessage(
                 selectedJudicialMessageId, judicialMessageReply, caseData.getJudicialMessages());
@@ -119,7 +120,8 @@ public class ReplyToMessageJudgeService extends MessageJudgeService {
 
     private Map<String, Object> closeJudicialMessage(UUID selectedJudicialMessageId,
                                                      List<Element<JudicialMessage>> openJudicialMessages,
-                                                     List<Element<JudicialMessage>> closedJudicialMessages) {
+                                                     List<Element<JudicialMessage>> closedJudicialMessages,
+                                                     String closureNote) {
 
         Element<JudicialMessage> judicialMessageElement = openJudicialMessages.stream()
             .filter(message -> selectedJudicialMessageId.equals(message.getId()))
@@ -133,7 +135,11 @@ public class ReplyToMessageJudgeService extends MessageJudgeService {
             Optional.ofNullable(closedJudicialMessages).orElse(newArrayList()));
 
         updatedClosedJudicialMessages.add(element(judicialMessageElement.getId(),
-            judicialMessageElement.getValue().toBuilder().status(CLOSED).updatedTime(time.now()).build()));
+            judicialMessageElement.getValue().toBuilder()
+                .status(CLOSED)
+                .closureNote(closureNote)
+                .updatedTime(time.now())
+                .build()));
 
         return Map.of("judicialMessages", updatedJudicialMessages,
             "closedJudicialMessages", sortJudicialMessages(updatedClosedJudicialMessages));
@@ -160,6 +166,7 @@ public class ReplyToMessageJudgeService extends MessageJudgeService {
                         .recipient(resolveRecipientEmailAddress(judicialMessageReply.getRecipientType(),
                             judicialMessageReply.getReplyTo()))
                         .messageHistory(buildMessageHistory(judicialMessageReply, judicialMessage, sender))
+                        .closureNote(judicialMessageReply.getClosureNote())
                         .latestMessage(judicialMessageReply.getLatestMessage())
                         .build();
 

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ReplyToMessageJudgeServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ReplyToMessageJudgeServiceTest.java
@@ -479,10 +479,14 @@ class ReplyToMessageJudgeServiceTest {
         List<Element<JudicialMessage>> updatedClosedMessages =
             (List<Element<JudicialMessage>>) updatedJudicialMessages.get("closedJudicialMessages");
         assertThat(updatedClosedMessages)
-            .extracting(Element::getId, judicialMessageElement -> judicialMessageElement.getValue().getStatus())
+            .extracting(
+                Element::getId,
+                judicialMessageElement -> judicialMessageElement.getValue().getStatus(),
+                judicialMessageElement -> judicialMessageElement.getValue().getClosureNote()
+            )
             .containsExactly(
-                tuple(selectedJudicialMessage.getId(), CLOSED),
-                tuple(closedJudicialMessage.getId(), CLOSED));
+                tuple(selectedJudicialMessage.getId(), CLOSED, "Closure note"),
+                tuple(closedJudicialMessage.getId(), CLOSED, null));
     }
 
     @Test
@@ -522,6 +526,7 @@ class ReplyToMessageJudgeServiceTest {
                 .latestMessage(isReplying ? messageReply : null)
                 .replyFrom(sender)
                 .replyTo(recipient)
+                .closureNote(isReplying ? null : "Closure note")
                 .recipientType(JudicialMessageRoleType.LOCAL_COURT_ADMIN)
                 .senderType(JudicialMessageRoleType.OTHER)
                 .build())


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-2538


### Change description ###
 - Adds optional textbox for a closure note when marking a judicial message as closed
 - This will not be sent anywhere, just recorded on the Judicial Messages tab


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
