### PR TITLE
DFPL-2713: redact 'child' subfields in change of representatives

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -1,7 +1,7 @@
 #!groovy
 
 properties([
-    pipelineTriggers([cron('H 13 * * 1-5')]),
+    pipelineTriggers([cron('H 15 * * 1-5')]),
     parameters([
         string(name: 'FE_BASE_URL', defaultValue: 'https://manage-case.aat.platform.hmcts.net',
             description: 'The URL you want to run the full functional tests against'),

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseControllerTest.java
@@ -57,6 +57,7 @@ class MigrateCaseControllerTest extends AbstractCallbackTest {
         @Test
         void shouldRedactStrings() {
             CaseData caseData = CaseData.builder()
+                .id(1734095429043780L)
                 .changeOfRepresentatives(List.of(
                     element(UUID.randomUUID(), ChangeOfRepresentation.builder()
                         .child("unchanged name")

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseControllerTest.java
@@ -1,16 +1,23 @@
 package uk.gov.hmcts.reform.fpl.controllers.support;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.controllers.AbstractCallbackTest;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
+import uk.gov.hmcts.reform.fpl.model.common.Element;
+import uk.gov.hmcts.reform.fpl.model.noc.ChangeOfRepresentation;
 
+import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.element;
 
 @WebMvcTest(MigrateCaseController.class)
 @OverrideAutoConfiguration(enabled = true)
@@ -42,5 +49,38 @@ class MigrateCaseControllerTest extends AbstractCallbackTest {
     void setup() {
         givenSystemUser();
         givenFplService();
+    }
+
+    @Nested
+    class Dfpl2713 {
+
+        @Test
+        void shouldRedactStrings() {
+            CaseData caseData = CaseData.builder()
+                .changeOfRepresentatives(List.of(
+                    element(UUID.randomUUID(), ChangeOfRepresentation.builder()
+                        .child("unchanged name")
+                        .build()),
+                    element(UUID.fromString("673396a8-dcba-451e-a4df-5a2162ac2828"),
+                        ChangeOfRepresentation.builder()
+                            .child("aaaaaaa bbbbbb")
+                            .build()),
+                    element(UUID.fromString("64e99c83-6eb3-48f7-8ba6-2de983af1a8d"),
+                        ChangeOfRepresentation.builder()
+                            .child("ccccccccc ddd")
+                            .build())
+                ))
+                .build();
+
+            CaseData after = extractCaseData(postAboutToSubmitEvent(buildCaseDetails(caseData, "DFPL-2713")));
+
+            assertThat(after.getChangeOfRepresentatives()).hasSize(3);
+            assertThat(after.getChangeOfRepresentatives().stream()
+                .map(Element::getValue)
+                .map(ChangeOfRepresentation::getChild))
+                .containsExactly("unchanged name", "aaaaaaa", "ccccccccc");
+            ;
+        }
+
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/noc/ChangeOfRepresentation.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/noc/ChangeOfRepresentation.java
@@ -6,7 +6,7 @@ import lombok.Value;
 import java.time.LocalDate;
 
 @Value
-@Builder
+@Builder(toBuilder = true)
 public class ChangeOfRepresentation {
     String respondent;
     String child;


### PR DESCRIPTION
### JIRA link (if applicable) ###
[DFPL-2713](https://tools.hmcts.net/jira/browse/DFPL-2713)


### Change description ###
 - Redact parts of the child subfields on change of representatives.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
