### PR TITLE
DFPL-2731: Remove CTSC email on transferring courts

### DIFF
--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/la/ManageLocalAuthoritiesControllerSubmittedTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/la/ManageLocalAuthoritiesControllerSubmittedTest.java
@@ -337,12 +337,6 @@ class ManageLocalAuthoritiesControllerSubmittedTest extends AbstractCallbackTest
                 "child_solicitor@solicitor.com",
                 toMap(expectedNotifyData),
                 notificationReference(CASE_ID));
-            // notify ctsc admin
-            verify(notificationClient).sendEmail(
-                CASE_TRANSFERRED_TO_ANOTHER_COURT_TEMPLATE,
-                "FamilyPublicLaw+ctsc@gmail.com",
-                toMap(expectedNotifyData),
-                notificationReference(CASE_ID));
             // notify high court admin
             verify(notificationClient, times(isTransferredToRcjHighCourt ? 1 : 0)).sendEmail(
                 CASE_TRANSFERRED_TO_ANOTHER_COURT_TEMPLATE,

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/handlers/LocalAuthorityChangedHandlerEmailTemplateTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/handlers/LocalAuthorityChangedHandlerEmailTemplateTest.java
@@ -334,13 +334,6 @@ class LocalAuthorityChangedHandlerEmailTemplateTest extends EmailTemplateTest {
         }
 
         @Test
-        void notifyAdminAboutCaseTransferToOrdinaryCourt() {
-            underTest.notifyAdmin(
-                new CaseTransferredToAnotherCourt(caseDataTransferredToOrdinaryCourt, caseDataBefore));
-            verifyResponse();
-        }
-
-        @Test
         void notifyChildSolicitorsAboutCaseTransferToOrdinaryCourt() {
             underTest.notifyChildSolicitors(
                 new CaseTransferredToAnotherCourt(caseDataTransferredToOrdinaryCourt, caseDataBefore));
@@ -366,13 +359,6 @@ class LocalAuthorityChangedHandlerEmailTemplateTest extends EmailTemplateTest {
         @Test
         void notifyRespondentSolicitorsAboutCaseTransferToRcjHighCourt() {
             underTest.notifyRespondentSolicitors(
-                new CaseTransferredToAnotherCourt(caseDataTransferredToRcjHighCourt, caseDataBefore));
-            verifyResponse();
-        }
-
-        @Test
-        void notifyAdminAboutCaseTransferToRcjHighCourt() {
-            underTest.notifyAdmin(
                 new CaseTransferredToAnotherCourt(caseDataTransferredToRcjHighCourt, caseDataBefore));
             verifyResponse();
         }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/LocalAuthorityChangedHandler.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/handlers/LocalAuthorityChangedHandler.java
@@ -210,18 +210,6 @@ public class LocalAuthorityChangedHandler {
 
     @Async
     @EventListener
-    public void notifyAdmin(final CaseTransferredToAnotherCourt event) {
-        final CaseData caseData = event.getCaseData();
-        String recipient = courtService.getCourtEmail(caseData);
-        if (recipient != null) {
-            final NotifyData notifyData = contentProvider.getNotifyDataFoTransferredToAnotherCourt(caseData);
-            notificationService.sendEmail(CASE_TRANSFERRED_TO_ANOTHER_COURT_TEMPLATE, recipient, notifyData,
-                caseData.getId());
-        }
-    }
-
-    @Async
-    @EventListener
     public void notifyHighCourtAdmin(final CaseTransferredToAnotherCourt event) {
         final CaseData caseData = event.getCaseData();
         final String recipient = highCourtAdminEmailLookupConfiguration.getEmail();

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/LocalAuthorityChangedHandlerTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/handlers/LocalAuthorityChangedHandlerTest.java
@@ -351,22 +351,6 @@ class LocalAuthorityChangedHandlerTest {
         }
 
         @Test
-        void shouldNotifyAdmin() {
-            when(notifyDataProvider.getNotifyDataFoTransferredToAnotherCourt(caseDataTransferredToOrdinaryCourt))
-                .thenReturn(notifyData);
-            when(courtService.getCourtEmail(caseDataTransferredToOrdinaryCourt)).thenReturn("admin@test.com");
-
-            underTest.notifyAdmin(transferredToOrdinaryCourtEvent);
-
-            verify(notificationService).sendEmail(
-                CASE_TRANSFERRED_TO_ANOTHER_COURT_TEMPLATE,
-                "admin@test.com",
-                notifyData,
-                caseDataTransferredToOrdinaryCourt.getId());
-            verifyNoMoreInteractions(notificationService);
-        }
-
-        @Test
         void shouldNotifyHighCourtAdmin() {
             when(notifyDataProvider.getNotifyDataFoTransferredToAnotherCourt(caseDataTransferredToRcjHighCourt))
                 .thenReturn(notifyData);


### PR DESCRIPTION
### JIRA link (if applicable) ###
[DFPL-2731](https://tools.hmcts.net/jira/browse/DFPL-2731)


### Change description ###
 - Remove CTSC notification when a case is transferred between courts (high court to remain)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
