### PR TITLE
DFPL-2740: Reinstate redaction migration + combine with removing C6

### DIFF
--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseControllerTest.java
@@ -1,16 +1,23 @@
 package uk.gov.hmcts.reform.fpl.controllers.support;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.controllers.AbstractCallbackTest;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
+import uk.gov.hmcts.reform.fpl.model.common.Element;
+import uk.gov.hmcts.reform.fpl.model.noc.ChangeOfRepresentation;
 
+import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.element;
 
 @WebMvcTest(MigrateCaseController.class)
 @OverrideAutoConfiguration(enabled = true)
@@ -42,5 +49,35 @@ class MigrateCaseControllerTest extends AbstractCallbackTest {
     void setup() {
         givenSystemUser();
         givenFplService();
+    }
+
+    @Nested
+    class Dfpl2740 {
+
+        @Test
+        void shouldRedactStrings() {
+            CaseData caseData = CaseData.builder()
+                .id(1743167066103323L)
+                .changeOfRepresentatives(List.of(
+                    element(UUID.randomUUID(), ChangeOfRepresentation.builder()
+                        .child("unchanged name")
+                        .build()),
+                    element(UUID.fromString("625f113c-5673-4b35-bbf1-6507fcf9ec43"),
+                        ChangeOfRepresentation.builder()
+                            .child("AAAAA BBBB")
+                            .build())
+                ))
+                .build();
+
+            CaseData after = extractCaseData(postAboutToSubmitEvent(buildCaseDetails(caseData, "DFPL-2740")));
+
+            assertThat(after.getChangeOfRepresentatives()).hasSize(2);
+            assertThat(after.getChangeOfRepresentatives().stream()
+                .map(Element::getValue)
+                .map(ChangeOfRepresentation::getChild))
+                .containsExactly("unchanged name", "AAAAA");
+            ;
+        }
+
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -13,6 +13,8 @@ import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.controllers.CallbackController;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
+import uk.gov.hmcts.reform.fpl.model.common.Element;
+import uk.gov.hmcts.reform.fpl.model.noc.ChangeOfRepresentation;
 import uk.gov.hmcts.reform.fpl.service.CaseConverter;
 import uk.gov.hmcts.reform.fpl.service.JudicialService;
 import uk.gov.hmcts.reform.fpl.service.MigrateCaseService;
@@ -22,6 +24,7 @@ import uk.gov.hmcts.reform.fpl.service.orders.ManageOrderDocumentScopedFieldsCal
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.UUID;
 import java.util.function.Consumer;
 
 @Slf4j
@@ -41,7 +44,7 @@ public class MigrateCaseController extends CallbackController {
         "DFPL-2642", this::run2642,
         "DFPL-2640", this::run2640,
         "DFPL-2487", this::run2487,
-        "DFPL-2713", this::run2713
+        "DFPL-2740", this::run2740
     );
     private final CaseConverter caseConverter;
     private final JudicialService judicialService;
@@ -116,9 +119,23 @@ public class MigrateCaseController extends CallbackController {
         judicialService.migrateJudgeRoles(rolesToAssign);
     }
 
-    private void run2713(CaseDetails caseDetails) {
-        migrateCaseService.doCaseIdCheck(caseDetails.getId(), 1734095429043780L, "DFPL-2713");
+    private void run2740(CaseDetails caseDetails) {
+        CaseData caseData = getCaseData(caseDetails);
 
+        migrateCaseService.doCaseIdCheck(caseDetails.getId(), 1743167066103323L, "DFPL-2740");
+
+        List<Element<ChangeOfRepresentation>> changes = caseData.getChangeOfRepresentatives();
+        List<Element<ChangeOfRepresentation>> after = changes.stream().map(element -> {
+            ChangeOfRepresentation value = element.getValue();
+            if (element.getId().equals(UUID.fromString("625f113c-5673-4b35-bbf1-6507fcf9ec43"))) {
+                element.setValue(value.toBuilder()
+                    .child(value.getChild().substring(0, 5))
+                    .build());
+            }
+            return element;
+        }).toList();
+
+        caseDetails.getData().put("changeOfRepresentatives", after);
         caseDetails.getData().remove("noticeOfProceedingsBundle");
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
[DFPL-2740](https://tools.hmcts.net/jira/browse/DFPL-2740)


### Change description ###
 - Remove noticeOfProceedingsBundle
 - Redact name from changeOfRepresentatives


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
