### PR TITLE
DFPL-2739: Remove draft order from additional application

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -45,7 +45,8 @@ public class MigrateCaseController extends CallbackController {
         "DFPL-2640", this::run2640,
         "DFPL-2487", this::run2487,
         "DFPL-2740", this::run2740,
-        "DFPL-2744", this::run2744
+        "DFPL-2744", this::run2744,
+        "DFPL-2729", this::run2729
     );
     private final CaseConverter caseConverter;
     private final JudicialService judicialService;
@@ -154,4 +155,13 @@ public class MigrateCaseController extends CallbackController {
         }
     }
 
+    private void run2729(CaseDetails caseDetails) {
+        CaseData caseData = getCaseData(caseDetails);
+
+        migrateCaseService.doCaseIdCheck(caseDetails.getId(), 1726944362364630L, "DFPL-2729");
+
+        caseDetails.getData().putAll(migrateCaseService.removeDraftOrderFromAdditionalApplication(caseData, "DFPL-2729",
+            UUID.fromString("3ef67b37-17ee-48ca-9d32-58c887a6918d"),
+            UUID.fromString("dbe742bb-f7a1-4373-8100-52261c81ef34")));
+    }
 }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseServiceTest.java
@@ -61,15 +61,12 @@ import uk.gov.hmcts.reform.fpl.model.SkeletonArgument;
 import uk.gov.hmcts.reform.fpl.model.StandardDirectionOrder;
 import uk.gov.hmcts.reform.fpl.model.Supplement;
 import uk.gov.hmcts.reform.fpl.model.SupportingEvidenceBundle;
-import uk.gov.hmcts.reform.fpl.model.common.DocumentBundle;
-import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
-import uk.gov.hmcts.reform.fpl.model.common.Element;
-import uk.gov.hmcts.reform.fpl.model.common.SubmittedC1WithSupplementBundle;
-import uk.gov.hmcts.reform.fpl.model.common.Telephone;
+import uk.gov.hmcts.reform.fpl.model.common.*;
 import uk.gov.hmcts.reform.fpl.model.common.dynamic.DynamicList;
 import uk.gov.hmcts.reform.fpl.model.common.dynamic.DynamicListElement;
 import uk.gov.hmcts.reform.fpl.model.event.PlacementEventData;
 import uk.gov.hmcts.reform.fpl.model.judicialmessage.JudicialMessage;
+import uk.gov.hmcts.reform.fpl.model.order.DraftOrder;
 import uk.gov.hmcts.reform.fpl.model.order.HearingOrder;
 import uk.gov.hmcts.reform.fpl.model.order.HearingOrdersBundle;
 import uk.gov.hmcts.reform.fpl.model.order.UrgentHearingOrder;
@@ -3554,4 +3551,80 @@ class MigrateCaseServiceTest {
 
     }
 
+    @Nested
+    class RemoveDraftOrderFromAdditionalApplicationBundle {
+
+        private final UUID bundleId = UUID.randomUUID();
+        private final UUID orderToRemoveId = UUID.randomUUID();
+        private final UUID orderToRetainId = UUID.randomUUID();
+        private final UUID nonExistentBundleId = UUID.randomUUID();
+        private final UUID nonExistentOrderId = UUID.randomUUID();
+
+        Element<DraftOrder> draftOrderToRemove = element(orderToRemoveId,
+                DraftOrder.builder()
+                    .title("Order to remove")
+                    .build()
+            );
+
+        Element<DraftOrder> draftOrderToRetain = element(orderToRetainId,
+                DraftOrder.builder()
+                    .title("Order to retain")
+                    .build()
+            );
+
+        private final Element<AdditionalApplicationsBundle> bundleWithOrder = element(bundleId,
+            AdditionalApplicationsBundle.builder()
+                .c2DocumentBundle(C2DocumentBundle.builder()
+                    .draftOrdersBundle(List.of(draftOrderToRemove, draftOrderToRetain))
+                    .build())
+                .build());
+
+        private final Element<AdditionalApplicationsBundle> bundleWithoutOrder = element(bundleId,
+            AdditionalApplicationsBundle.builder()
+                .c2DocumentBundle(C2DocumentBundle.builder()
+                    .build())
+                .build());
+
+        private final CaseData caseDataWithBundle = CaseData.builder()
+            .id(1L)
+            .additionalApplicationsBundle(List.of(bundleWithOrder))
+            .build();
+
+        private final CaseData caseDataWithoutDraftOrder = CaseData.builder()
+            .id(1L)
+            .additionalApplicationsBundle(List.of(bundleWithoutOrder))
+            .build();
+
+        @Test
+        void shouldRemoveDraftOrderFromBundle() {
+            Map<String, Object> result = underTest.removeDraftOrderFromAdditionalApplication(caseDataWithBundle,
+                MIGRATION_ID, bundleId, orderToRemoveId);
+
+            Element<AdditionalApplicationsBundle> expectedBundle = element(bundleId,
+                AdditionalApplicationsBundle.builder()
+                    .c2DocumentBundle(C2DocumentBundle.builder()
+                        .draftOrdersBundle(List.of(draftOrderToRetain))
+                        .build())
+                    .build());
+
+            assertThat(result).containsEntry("additionalApplicationsBundle", List.of(expectedBundle));
+        }
+
+        @Test
+        void shouldThrowExceptionIfBundleNotFound() {
+            assertThatThrownBy(() -> underTest.removeDraftOrderFromAdditionalApplication(caseDataWithoutDraftOrder,
+                MIGRATION_ID, nonExistentBundleId, orderToRemoveId))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("additional application bundle not found");
+        }
+
+        @Test
+        void shouldThrowExceptionIfOrderNotFoundInBundle() {
+            assertThatThrownBy(() -> underTest.removeDraftOrderFromAdditionalApplication(caseDataWithBundle,
+                MIGRATION_ID, bundleId, nonExistentOrderId))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining(String.format("draft order with id %s not found in c2DocumentsBundle",
+                    nonExistentOrderId));
+        }
+    }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DFPL-2739

### Change description ###

Add migration to remove draft order incorrectly uploaded to case via additional application.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
