### PR TITLE
DFPL-2421 fix 2421 roll back left over

### DIFF
--- a/ccd-definition/ComplexTypes/CareSupervision/2_Others.json
+++ b/ccd-definition/ComplexTypes/CareSupervision/2_Others.json
@@ -10,6 +10,22 @@
   {
     "LiveFrom": "01/01/2017",
     "ID": "Others",
+    "ListElementCode": "firstName",
+    "FieldType": "Text",
+    "ElementLabel": "First name",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "Others",
+    "ListElementCode": "lastName",
+    "FieldType": "Text",
+    "ElementLabel": "Last name",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "Others",
     "ListElementCode": "DOB",
     "FieldType": "Date",
     "ElementLabel": "Date of birth",
@@ -93,11 +109,38 @@
   {
     "LiveFrom": "01/01/2017",
     "ID": "Others",
+    "ListElementCode": "whereaboutsUnknownDetails",
+    "FieldType": "TextArea",
+    "ElementLabel": "Give more details",
+    "SecurityClassification": "Public",
+    "FieldShowCondition": "addressKnowV2=\"No\" AND addressNotKnowReason=\"Whereabouts unknown\""
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "Others",
+    "ListElementCode": "hideAddress",
+    "FieldType": "YesOrNo",
+    "ElementLabel": "Do you need to keep the address confidential?",
+    "FieldShowCondition": "addressKnowV2=\"Yes\"",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "Others",
     "ListElementCode": "telephone",
     "FieldType": "Text",
     "ElementLabel": "Telephone number",
     "Max": "24",
     "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "Others",
+    "ListElementCode": "hideTelephone",
+    "FieldType": "YesOrNo",
+    "ElementLabel": "Do you need to keep the contact number confidential?",
+    "SecurityClassification": "Public",
+    "FieldShowCondition": "telephone=\"*\""
   },
   {
     "LiveFrom": "01/01/2017",


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
DFPL-2421 fix 2421 roll back left over
adding the  new "others" field CCD definition introduced by DFPL-2421 (Which has rolled back)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
