### PR TITLE
DFPL-2746: Reinstate temporaryApplicationDocuments when a case is returned

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/ReturnApplicationController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/ReturnApplicationController.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.events.ReturnedCaseEvent;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.common.DocumentReference;
+import uk.gov.hmcts.reform.fpl.service.ApplicationDocumentsService;
 import uk.gov.hmcts.reform.fpl.service.ReturnApplicationService;
 
 @RestController
@@ -21,6 +22,7 @@ public class ReturnApplicationController extends CallbackController {
     public static final String RETURN_APPLICATION = "returnApplication";
 
     private final ReturnApplicationService returnApplicationService;
+    private final ApplicationDocumentsService applicationDocumentsService;
 
     @PostMapping("/about-to-start")
     public AboutToStartOrSubmitCallbackResponse handleAboutToStart(@RequestBody CallbackRequest callbackrequest) {
@@ -45,6 +47,10 @@ public class ReturnApplicationController extends CallbackController {
         ));
 
         caseDetails.getData().remove("submittedForm");
+
+        // Rebuild the temporaryApplicationDocuments as they may need to modify those documents
+        caseDetails.getData().put("temporaryApplicationDocuments",
+            applicationDocumentsService.rebuildTemporaryApplicationDocuments(caseData));
 
         return respond(caseDetails);
     }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/ApplicationDocumentsService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/ApplicationDocumentsService.java
@@ -33,6 +33,7 @@ import static uk.gov.hmcts.reform.fpl.enums.ApplicationDocumentType.SWET;
 import static uk.gov.hmcts.reform.fpl.enums.ApplicationDocumentType.THRESHOLD;
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.element;
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.findElement;
+import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.nullSafeList;
 
 @Service
 @RequiredArgsConstructor(onConstructor_ = {@Autowired})
@@ -74,7 +75,6 @@ public class ApplicationDocumentsService {
         return ret;
     }
 
-    @SuppressWarnings("unchecked")
     public Map<String, Object> synchroniseToNewFields(List<Element<ApplicationDocument>> applicationDocuments) {
         Map<String, Object> ret = new HashMap<>();
         ret.putAll(synchroniseToNewFields(applicationDocuments, List.of(SWET, SOCIAL_WORK_CHRONOLOGY,
@@ -83,6 +83,61 @@ public class ApplicationDocumentsService {
         ret.putAll(synchroniseToNewFields(applicationDocuments, List.of(CARE_PLAN), "carePlanList"));
         ret.putAll(synchroniseToNewFields(applicationDocuments, List.of(THRESHOLD), "thresholdList"));
         return ret;
+    }
+
+    public List<Element<ApplicationDocument>> buildTemporaryApplicationDocumentsWithType(
+        List<Element<ManagedDocument>> nonConfidential,
+        List<Element<ManagedDocument>> confidential,
+        ApplicationDocumentType type) {
+
+        List<Element<ApplicationDocument>> documents = new ArrayList<>();
+
+        // rebuild confidential documents
+        for (Element<ManagedDocument> document : nullSafeList(confidential)) {
+            documents.add(element(document.getId(), ApplicationDocument.builder()
+                .document(document.getValue().getDocument())
+                .documentType(type)
+                .documentName(document.getValue().getDocument().getFilename())
+                .uploaderCaseRoles(document.getValue().getUploaderCaseRoles())
+                .uploaderType(document.getValue().getUploaderType())
+                .confidential(List.of("CONFIDENTIAL"))
+                .build()));
+        }
+
+        // rebuild non-confidential documents
+        for (Element<ManagedDocument> document : nullSafeList(nonConfidential)) {
+            documents.add(element(document.getId(), ApplicationDocument.builder()
+                .document(document.getValue().getDocument())
+                .documentType(type)
+                .documentName(document.getValue().getDocument().getFilename())
+                .uploaderCaseRoles(document.getValue().getUploaderCaseRoles())
+                .uploaderType(document.getValue().getUploaderType())
+                .build()));
+        }
+
+        return documents;
+    }
+
+    public List<Element<ApplicationDocument>> rebuildTemporaryApplicationDocuments(CaseData caseData) {
+        List<Element<ApplicationDocument>> documents = new ArrayList<>();
+
+        // documentsFiledOnIssueList -> ApplicationDocument.type(OTHER) as we have lost the type information
+        documents.addAll(buildTemporaryApplicationDocumentsWithType(
+            caseData.getDocumentsFiledOnIssueList(),
+            caseData.getDocumentsFiledOnIssueListLA(),
+            OTHER));
+
+        documents.addAll(buildTemporaryApplicationDocumentsWithType(
+            caseData.getCarePlanList(),
+            caseData.getCarePlanListLA(),
+            CARE_PLAN));
+
+        documents.addAll(buildTemporaryApplicationDocumentsWithType(
+            caseData.getThresholdList(),
+            caseData.getThresholdListLA(),
+            THRESHOLD));
+
+        return documents;
     }
 
     public Map<String, Object> updateApplicationDocuments(CaseData caseData,

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ApplicationDocumentsServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/ApplicationDocumentsServiceTest.java
@@ -401,4 +401,102 @@ class ApplicationDocumentsServiceTest {
         }
     }
 
+    @Nested
+    class RebuildTemporaryApplicationDocuments {
+
+        @Test
+        void shouldRebuildTemporaryDocumentsFromCarePlanDocs() {
+            UUID carePlanID = UUID.randomUUID();
+            ManagedDocument carePlan = ManagedDocument.builder()
+                .document(DocumentReference.builder().filename("carePlan").build())
+                .uploaderCaseRoles(List.of(CaseRole.LASOLICITOR))
+                .uploaderType(DocumentUploaderType.DESIGNATED_LOCAL_AUTHORITY)
+                .build();
+
+            CaseData caseData = CaseData.builder()
+                .carePlanList(List.of(element(carePlanID, carePlan)))
+                .build();
+
+            List<Element<ApplicationDocument>> expectedApplicationDocuments = List.of(
+                element(carePlanID,
+                    ApplicationDocument.builder()
+                        .document(carePlan.getDocument())
+                        .documentType(CARE_PLAN)
+                        .documentName("carePlan")
+                        .uploaderCaseRoles(carePlan.getUploaderCaseRoles())
+                        .uploaderType(carePlan.getUploaderType())
+                        .build()
+                ));
+
+            List<Element<ApplicationDocument>> applicationDocuments = applicationDocumentsService
+                .rebuildTemporaryApplicationDocuments(caseData);
+
+            assertThat(applicationDocuments).hasSize(1);
+            assertThat(applicationDocuments).isEqualTo(expectedApplicationDocuments);
+        }
+
+        @Test
+        void shouldRebuildTemporaryDocumentsFromThresholdDocs() {
+            UUID thresholdID = UUID.randomUUID();
+            ManagedDocument threshold = ManagedDocument.builder()
+                .document(DocumentReference.builder().filename("threshold").build())
+                .uploaderCaseRoles(List.of(CaseRole.LASOLICITOR))
+                .uploaderType(DocumentUploaderType.DESIGNATED_LOCAL_AUTHORITY)
+                .build();
+
+            CaseData caseData = CaseData.builder()
+                .thresholdList(List.of(element(thresholdID, threshold)))
+                .build();
+
+            List<Element<ApplicationDocument>> expectedApplicationDocuments = List.of(
+                element(thresholdID,
+                    ApplicationDocument.builder()
+                        .document(threshold.getDocument())
+                        .documentType(THRESHOLD)
+                        .documentName("threshold")
+                        .uploaderCaseRoles(threshold.getUploaderCaseRoles())
+                        .uploaderType(threshold.getUploaderType())
+                        .build()
+                ));
+
+            List<Element<ApplicationDocument>> applicationDocuments = applicationDocumentsService
+                .rebuildTemporaryApplicationDocuments(caseData);
+
+            assertThat(applicationDocuments).hasSize(1);
+            assertThat(applicationDocuments).isEqualTo(expectedApplicationDocuments);
+        }
+
+        @Test
+        void shouldRebuildTemporaryDocumentsFromDocumentsFiledOnIssue() {
+            UUID docFiledOnIssueID = UUID.randomUUID();
+            ManagedDocument docFiledOnIssue = ManagedDocument.builder()
+                .document(DocumentReference.builder().filename("SWET").build())
+                .uploaderCaseRoles(List.of(CaseRole.LASOLICITOR))
+                .uploaderType(DocumentUploaderType.DESIGNATED_LOCAL_AUTHORITY)
+                .build();
+
+            CaseData caseData = CaseData.builder()
+                .documentsFiledOnIssueList(List.of(element(docFiledOnIssueID, docFiledOnIssue)))
+                .build();
+
+            List<Element<ApplicationDocument>> expectedApplicationDocuments = List.of(
+                element(docFiledOnIssueID,
+                    ApplicationDocument.builder()
+                        .document(docFiledOnIssue.getDocument())
+                        .documentType(OTHER)
+                        .documentName("SWET")
+                        .uploaderCaseRoles(docFiledOnIssue.getUploaderCaseRoles())
+                        .uploaderType(docFiledOnIssue.getUploaderType())
+                        .build()
+                ));
+
+            List<Element<ApplicationDocument>> applicationDocuments = applicationDocumentsService
+                .rebuildTemporaryApplicationDocuments(caseData);
+
+            assertThat(applicationDocuments).hasSize(1);
+            assertThat(applicationDocuments).isEqualTo(expectedApplicationDocuments);
+        }
+
+    }
+
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
[DFPL-2746](https://tools.hmcts.net/jira/browse/DFPL-2746)


### Change description ###
 - When a case is returned, we rebuild the temporaryApplicationDocuments field used by the "Upload documents" event


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
