### PR TITLE
DFPL-2784: Show Represeting as empty if on LAApplicant flow

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/model/RepresentingDetails.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/model/RepresentingDetails.java
@@ -15,6 +15,10 @@ public class RepresentingDetails {
 
     @JsonIgnore
     public String getFullName() {
-        return firstName + " " + lastName;
+        if (firstName != null || lastName != null) {
+            return firstName + " " + lastName;
+        } else {
+            return "";
+        }
     }
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DFPL-2784

Only set representingDetails if first and last name are present

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
