### PR TITLE
Update fortify-client to v1.4.9

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -376,7 +376,7 @@ dependencies {
   testImplementation group: 'org.mockito', name: 'mockito-inline', version: versions.mockito
 
   // Fortify client for Fortify scans
-  testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: '1.4.8', classifier: 'all'
+  testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: '1.4.9', classifier: 'all'
 
   testImplementation 'org.springframework.boot:spring-boot-starter-test'
 


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###

Update fortify-client to v1.4.9 to fix gradle build failing locally (looks like they removed the jar file for 1.4.8 from azure packages)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```