### PR TITLE
Don't set WA user to 'D' when service shuttered.

### DIFF
--- a/ccd-definition/AuthorisationCaseType/AuthorisationCaseType-shuttered.json
+++ b/ccd-definition/AuthorisationCaseType/AuthorisationCaseType-shuttered.json
@@ -14,7 +14,6 @@
       "caseworker-publiclaw-rparobot",
       "caseworker-caa",
       "caseworker-approver",
-      "caseworker-wa-task-configuration",
       "caseworker-publiclaw-cafcasssystemupdate"
     ],
     "CRUD": "D"
@@ -23,6 +22,12 @@
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
     "UserRole": "caseworker-ras-validation",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "UserRole": "caseworker-wa-task-configuration",
     "CRUD": "CRU"
   },
   {


### PR DESCRIPTION

### JIRA link (if applicable) ###



### Change description ###

As a pre-implementation step for our releases we have been asked to "not set caseworker-wa-task-configuration to D as can cause issues". Updating the shuttered version of our CCD definition to comply with this.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
