### PR TITLE
DFPL-2856: Add back superuser change name event

### DIFF
--- a/ccd-definition/AuthorisationCaseEvent/CareSupervision/AuthorisationCaseEvent.json
+++ b/ccd-definition/AuthorisationCaseEvent/CareSupervision/AuthorisationCaseEvent.json
@@ -249,7 +249,7 @@
     "CaseTypeID": "CARE_SUPERVISION_EPO",
     "CaseEventID": "changeCaseName-superuser",
     "UserRole": "caseworker-publiclaw-superuser",
-    "CRUD": "R"
+    "CRUD": "CR"
   },
   {
     "LiveFrom": "01/01/2017",

--- a/ccd-definition/CaseEvent/CareSupervision/DEPRECATED.json
+++ b/ccd-definition/CaseEvent/CareSupervision/DEPRECATED.json
@@ -415,20 +415,5 @@
     "ShowEventNotes": "N",
     "EndButtonLabel": "Save and continue",
     "CallBackURLSubmittedEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/callback/update-task-list/submitted"
-  },
-  {
-    "LiveFrom": "01/01/2017",
-    "CaseTypeID": "CARE_SUPERVISION_EPO",
-    "ID": "changeCaseName-superuser",
-    "Name": "Change case name",
-    "Description": "Change case name",
-    "DisplayOrder": 20,
-    "PreConditionState(s)": "Submitted;Gatekeeping;PREPARE_FOR_HEARING;FINAL_HEARING;CLOSED",
-    "PostConditionState": "*",
-    "SecurityClassification": "Public",
-    "ShowSummary": "Y",
-    "ShowEventNotes": "N",
-    "Publish": "Y",
-    "EndButtonLabel": "Save and continue"
   }
 ]

--- a/ccd-definition/CaseEvent/CareSupervision/MultiState.json
+++ b/ccd-definition/CaseEvent/CareSupervision/MultiState.json
@@ -568,6 +568,21 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "ID": "changeCaseName-superuser",
+    "Name": "Change case name",
+    "Description": "Change case name",
+    "DisplayOrder": 20,
+    "PreConditionState(s)": "Submitted;Gatekeeping;PREPARE_FOR_HEARING;FINAL_HEARING;CLOSED",
+    "PostConditionState": "*",
+    "SecurityClassification": "Public",
+    "ShowSummary": "Y",
+    "ShowEventNotes": "N",
+    "Publish": "Y",
+    "EndButtonLabel": "Save and continue"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
     "ID": "placement",
     "Name": "Placement",
     "Description": "Placement",


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DFPL-2856

Un-deprecate admin manual case name change

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
