### PR TITLE
DFPL-3145: Generate generic task instead of error when no valid am role

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/additionalapplications/UploadAdditionalApplicationsService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/additionalapplications/UploadAdditionalApplicationsService.java
@@ -9,7 +9,6 @@ import uk.gov.hmcts.reform.fpl.enums.ApplicationType;
 import uk.gov.hmcts.reform.fpl.enums.CaseRole;
 import uk.gov.hmcts.reform.fpl.enums.JudicialMessageRoleType;
 import uk.gov.hmcts.reform.fpl.enums.YesNo;
-import uk.gov.hmcts.reform.fpl.exceptions.UserLookupException;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.HearingBooking;
 import uk.gov.hmcts.reform.fpl.model.Judge;

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/additionalapplications/UploadAdditionalApplicationsService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/additionalapplications/UploadAdditionalApplicationsService.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.fpl.service.additionalapplications;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.am.model.RoleAssignment;
@@ -66,6 +67,7 @@ import static uk.gov.hmcts.reform.fpl.enums.YesNo.YES;
 import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.DATE_TIME;
 import static uk.gov.hmcts.reform.fpl.utils.DateFormatterHelper.formatLocalDateTimeBaseUsingFormat;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class UploadAdditionalApplicationsService {
@@ -366,7 +368,7 @@ public class UploadAdditionalApplicationsService {
             } else if (roleTypes.contains(ALLOCATED_LEGAL_ADVISER.getRoleName())) {
                 return JudicialMessageRoleType.OTHER;
             } else {
-                // If no valid AM roles on case return a generic task
+                log.info("No valid am role found for case id: {}, creating generic task", caseData.getId());
                 return JudicialMessageRoleType.CTSC;
             }
         }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/additionalapplications/UploadAdditionalApplicationsService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/additionalapplications/UploadAdditionalApplicationsService.java
@@ -367,9 +367,8 @@ public class UploadAdditionalApplicationsService {
             } else if (roleTypes.contains(ALLOCATED_LEGAL_ADVISER.getRoleName())) {
                 return JudicialMessageRoleType.OTHER;
             } else {
-                throw new UserLookupException(
-                    String.format("Allocated judge or legal adviser has invalid am role for case id: %s",
-                        caseData.getId()));
+                // If no valid AM roles on case return a generic task
+                return JudicialMessageRoleType.CTSC;
             }
         }
     }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/additionalapplications/UploadAdditionalApplicationsServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/additionalapplications/UploadAdditionalApplicationsServiceTest.java
@@ -550,10 +550,8 @@ class UploadAdditionalApplicationsServiceTest {
         when(judicialService.getAllocatedJudgeAndLegalAdvisorRoleAssignments(eq(caseData.getId())))
             .thenReturn(List.of(RoleAssignment.builder().roleName("not-a-judge").build()));
 
-        UserLookupException thrownException = assertThrows(UserLookupException.class,
-            () -> underTest.getAllocatedJudgeOrLegalAdviserType(caseData));
-        assertThat(thrownException.getMessage())
-            .contains("Allocated judge or legal adviser has invalid am role for case id: 1234");
+        assertThat(underTest.getAllocatedJudgeOrLegalAdviserType(caseData))
+            .isEqualTo(JudicialMessageRoleType.CTSC);
     }
 
     @Test

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/additionalapplications/UploadAdditionalApplicationsServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/additionalapplications/UploadAdditionalApplicationsServiceTest.java
@@ -19,7 +19,6 @@ import uk.gov.hmcts.reform.fpl.enums.ParentalResponsibilityType;
 import uk.gov.hmcts.reform.fpl.enums.SupplementType;
 import uk.gov.hmcts.reform.fpl.enums.YesNo;
 import uk.gov.hmcts.reform.fpl.enums.notification.DocumentUploaderType;
-import uk.gov.hmcts.reform.fpl.exceptions.UserLookupException;
 import uk.gov.hmcts.reform.fpl.model.Address;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
 import uk.gov.hmcts.reform.fpl.model.HearingBooking;
@@ -62,7 +61,6 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DFPL-3145

Remove error message and replace with generic ctsc task when additional application is uploaded when no valid AM role for allocated judge/legal adviser on case

Required to allow closed cases and cases with invalid roles to upload additional apps

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
