### PR TITLE
Grant new jenkins mi per environment on the KV

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -18,8 +18,8 @@ provider "azurerm" {
 provider "azurerm" {
   features {}
   resource_provider_registrations = "none"
-  alias                      = "postgres_network"
-  subscription_id            = var.aks_subscription_id
+  alias                           = "postgres_network"
+  subscription_id                 = var.aks_subscription_id
 }
 
 resource "azurerm_resource_group" "rg" {

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -69,6 +69,12 @@ module "key-vault" {
   product_group_name      = "dcd_group_fpl_v2"
   common_tags             = var.common_tags
   create_managed_identity = true
+  jenkins_object_id       = data.azurerm_user_assigned_identity.jenkins.principal_id
+}
+
+data "azurerm_user_assigned_identity" "jenkins" {
+  name                = "jenkins-${var.env}-mi"
+  resource_group_name = "managed-identities-${var.env}-rg"
 }
 
 module "fpl-scheduler-postgres-v15-flexible-server" {

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -1,3 +1,3 @@
 output "microserviceName" {
-  value = "${var.component}"
+  value = var.component
 }

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -1,5 +1,5 @@
 docmosis_subscription_id = "00b9a00a-20eb-4173-b7b6-468e00836a33"
-docmosis_resource_group = "docmosis-iaas-prod-rg"
-docmosis_vault = "docmosisiaasprodkv"
-enable_alerts = true
+docmosis_resource_group  = "docmosis-iaas-prod-rg"
+docmosis_vault           = "docmosisiaasprodkv"
+enable_alerts            = true
 

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -16,7 +16,7 @@ variable "env" {
 }
 
 variable "common_tags" {
-  type = map
+  type = map(any)
 }
 
 variable "tenant_id" {


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] PR's title includes JIRA ticket number and follow [Conventional Commits](https://www.conventionalcommits.org/) specification
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] [SonarCloud](https://sonarcloud.io/project/pull_requests_list?id=FPL%3Aservice) has been reviewed

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-30481

### Change description ###

We (Platform Operations) are adding an additional Jenkins MIs that are per-environment.
This will ensure that pipeline for this repository does not break once we start enforcing access segmentation within Jenkins
Here is the epic for some context: https://tools.hmcts.net/jira/browse/DTSPO-29659
Essentially we want to make sure each pipeline only has the access to whatever is necessary and nothing more, this means going from generalised Managed Identity used for all jobs across environments to environment specific ones.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
