### PR TITLE
DFPL-2839: ManageHearing- No Judge details displayed

### DIFF
--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ManageHearingsControllerAboutToStartTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ManageHearingsControllerAboutToStartTest.java
@@ -106,6 +106,7 @@ class ManageHearingsControllerAboutToStartTest extends ManageHearingsControllerT
             .isEqualTo(dynamicList(futureHearing1, futureHearing2, todayHearing, pastHearing1, pastHearing2));
         assertThat(updatedCaseData.getSelectedHearingId()).isNull();
     }
+
     @Test
     void shouldReturnValidationErrorWhenAllocatedJudgeIsNull() {
         // Arrange - Setup a case context with no allocated judge
@@ -118,9 +119,8 @@ class ManageHearingsControllerAboutToStartTest extends ManageHearingsControllerT
         AboutToStartOrSubmitCallbackResponse response = postAboutToStartEvent(initialCaseData);
 
         // Assert - Verify the callback blocks execution with the correct error message
-        assertThat(response.getErrors()).containsExactly(
-            "You will need to add a judge or legal adviser using the allocated judge event before you can proceed to use manage hearings"
-        );
+        assertThat(response.getErrors()).containsExactly("You will need to add a judge or legal adviser "
+            + "using the allocated judge event before you can proceed to use manage hearings");
     }
 
 }

--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ManageHearingsControllerAboutToStartTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/ManageHearingsControllerAboutToStartTest.java
@@ -106,5 +106,21 @@ class ManageHearingsControllerAboutToStartTest extends ManageHearingsControllerT
             .isEqualTo(dynamicList(futureHearing1, futureHearing2, todayHearing, pastHearing1, pastHearing2));
         assertThat(updatedCaseData.getSelectedHearingId()).isNull();
     }
+    @Test
+    void shouldReturnValidationErrorWhenAllocatedJudgeIsNull() {
+        // Arrange - Setup a case context with no allocated judge
+        CaseData initialCaseData = CaseData.builder()
+            .id(12345L)
+            .allocatedJudge(null)
+            .build();
+
+        // Act - Post to webhook endpoint using base infrastructure
+        AboutToStartOrSubmitCallbackResponse response = postAboutToStartEvent(initialCaseData);
+
+        // Assert - Verify the callback blocks execution with the correct error message
+        assertThat(response.getErrors()).containsExactly(
+            "You will need to add a judge or legal adviser using the allocated judge event before you can proceed to use manage hearings"
+        );
+    }
 
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/ManageHearingsController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/ManageHearingsController.java
@@ -98,6 +98,10 @@ public class ManageHearingsController extends CallbackController {
         if (caseData.getAllocatedJudge() != null) {
             caseDetails.getData().put("judgeAndLegalAdvisor", setAllocatedJudgeLabel(caseData.getAllocatedJudge()));
             caseDetails.getData().put("allocatedJudgeLabel", buildAllocatedJudgeLabel(caseData.getAllocatedJudge()));
+        } else {
+            // Add error message when allocated judge is null
+            return respond(caseDetails, List.of("You will need to add a judge or legal adviser using the allocated"
+                + "judge event before you can proceed to use manage hearings"));
         }
 
         boolean isFirstHearing = isEmpty(caseData.getAllHearings());

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/ManageHearingsController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/ManageHearingsController.java
@@ -36,6 +36,7 @@ import uk.gov.hmcts.reform.fpl.validation.groups.HearingEndDateGroup;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -94,14 +95,15 @@ public class ManageHearingsController extends CallbackController {
         caseDetails.getData().remove(SELECTED_HEARING_ID);
 
         CaseData caseData = getCaseData(caseDetails);
+        List<String> errors = new ArrayList<>();
 
         if (caseData.getAllocatedJudge() != null) {
             caseDetails.getData().put("judgeAndLegalAdvisor", setAllocatedJudgeLabel(caseData.getAllocatedJudge()));
             caseDetails.getData().put("allocatedJudgeLabel", buildAllocatedJudgeLabel(caseData.getAllocatedJudge()));
         } else {
-            // Add error message when allocated judge is null
-            return respond(caseDetails, List.of("You will need to add a judge or legal adviser using the allocated"
-                + "judge event before you can proceed to use manage hearings"));
+            // Capture the error
+            errors.add("You will need to add a judge or legal adviser using the allocated "
+                + "judge event before you can proceed to use manage hearings");
         }
 
         boolean isFirstHearing = isEmpty(caseData.getAllHearings());
@@ -116,7 +118,8 @@ public class ManageHearingsController extends CallbackController {
 
         caseDetails.getData().putAll(hearingsService.populateHearingLists(caseData));
 
-        return respond(caseDetails);
+        // Return everything together. If errors list has items, display them to the user.
+        return respond(caseDetails, errors);
     }
 
     @PostMapping("/edit-hearing/mid-event")


### PR DESCRIPTION



### JIRA link ###
[DFPL-2839](https://tools.hmcts.net/jira/browse/DFPL-2839)


### Change description ###
Display a clear and Instructional error message to user at the start when a hearing is selected, prompting the user to choose a judge, instead of showing the error at the end.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
