### PR TITLE
Dfpl 3190 Add check for WA flag before case-allocator check

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -291,13 +291,25 @@ withPipeline(type, product, component) {
   }
 
   before('smoketest:preview') {
-    sh """
-      set -eu
-      eval \$(./bin/variables/load-preview-environment-variables.sh ${CHANGE_ID})
-      ./bin/add-ccd-user-roles.sh
-      ./bin/add-role-assignments.sh --skip-system-update-am-role-seeding
-      bash ./bin/wait-for-system-update-am-role.sh 18 10
-    """
+    def githubApi = new GithubAPI(this)
+    // Only run WA-specific role assignment + wait when WA is enabled via PR label.
+    if (githubApi.checkForLabel(env.BRANCH_NAME, 'pr-values:wa')) {
+      sh """
+        set -eu
+        eval \$(./bin/variables/load-preview-environment-variables.sh ${CHANGE_ID})
+        ./bin/add-ccd-user-roles.sh
+        ./bin/add-role-assignments.sh --skip-system-update-am-role-seeding
+        bash ./bin/wait-for-system-update-am-role.sh 18 10
+      """
+    } else {
+      echo "Skipping system-update AM role wait because 'pr-values:wa' label is not present"
+      sh """
+        set -eu
+        eval \$(./bin/variables/load-preview-environment-variables.sh ${CHANGE_ID})
+        ./bin/add-ccd-user-roles.sh
+        ./bin/add-role-assignments.sh --skip-system-update-am-role-seeding
+      """
+    }
 
     archiveCoreCaseDataDefinitions('preview')
     uploadCoreCaseDataDefinitions('preview', '0')

--- a/bin/wait-for-system-update-am-role.sh
+++ b/bin/wait-for-system-update-am-role.sh
@@ -6,6 +6,7 @@ MAX_ATTEMPTS="${1:-6}"
 SLEEP_SECONDS="${2:-10}"
 TARGET_ROLE_NAME="case-allocator"
 TARGET_ROLE_CATEGORY="SYSTEM"
+TARGET_STATUS="LIVE"
 
 SYSTEM_UPDATE_TOKEN=$(./bin/utils/idam-lease-user-token.sh "${SYSTEM_UPDATE_USER_USERNAME}" "${SYSTEM_UPDATE_USER_PASSWORD}")
 SYSTEM_UPDATE_USER_ID=$(./bin/utils/idam-user-id.sh "${SYSTEM_UPDATE_TOKEN}")
@@ -31,28 +32,58 @@ for ATTEMPT in $(seq 1 "${MAX_ATTEMPTS}"); do
     -X POST \
     -d "${QUERY_BODY}" \
     "${ROLE_ASSIGNMENT_URL}/am/role-assignments/query"); then
-    MATCHING_TOTAL="$(echo "${QUERY_JSON}" | jq -r \
-      --arg roleName "${TARGET_ROLE_NAME}" \
-      --arg roleCategory "${TARGET_ROLE_CATEGORY}" '
+
+    MATCHING_TOTAL=$(echo "${QUERY_JSON}" | jq -r --arg roleName "${TARGET_ROLE_NAME}" --arg roleCategory "${TARGET_ROLE_CATEGORY}" '
+      [(.roleAssignmentResponse // [])[]
+       | select(.roleName == $roleName and ((.roleCategory // "") | ascii_upcase) == $roleCategory)]
+      | length
+    ')
+
+    MATCHING_LIVE=$(echo "${QUERY_JSON}" | jq -r --arg roleName "${TARGET_ROLE_NAME}" --arg roleCategory "${TARGET_ROLE_CATEGORY}" --arg targetStatus "${TARGET_STATUS}" '
+      [(.roleAssignmentResponse // [])[]
+       | select(.roleName == $roleName
+                and ((.roleCategory // "") | ascii_upcase) == $roleCategory
+                and ((.status // "") | ascii_upcase) == $targetStatus)]
+      | length
+    ')
+
+    MATCHING_UNKNOWN=$(echo "${QUERY_JSON}" | jq -r --arg roleName "${TARGET_ROLE_NAME}" --arg roleCategory "${TARGET_ROLE_CATEGORY}" '
       [(.roleAssignmentResponse // [])[]
        | select(.roleName == $roleName and ((.roleCategory // "") | ascii_upcase) == $roleCategory)
-      ]
-      | length')"
+       | ((.status // "UNKNOWN") | ascii_upcase)
+       | select(. == "UNKNOWN")]
+      | length
+    ')
 
-    if [[ "${MATCHING_TOTAL}" -gt 0 ]]; then
-      echo "System-update AM ${TARGET_ROLE_NAME} role is available (matches=${MATCHING_TOTAL})"
+    STATUS_SUMMARY=$(echo "${QUERY_JSON}" | jq -r --arg roleName "${TARGET_ROLE_NAME}" --arg roleCategory "${TARGET_ROLE_CATEGORY}" '
+      [(.roleAssignmentResponse // [])[]
+       | select(.roleName == $roleName and ((.roleCategory // "") | ascii_upcase) == $roleCategory)
+       | (.status // "UNKNOWN")]
+      | if length == 0
+        then "none"
+        else (sort | group_by(.) | map("\(.[0])=\(length)") | join(","))
+        end
+    ')
+
+    if [[ "${MATCHING_LIVE}" -gt 0 ]]; then
+      echo "System-update AM ${TARGET_ROLE_NAME} role is ${TARGET_STATUS} (matches=${MATCHING_TOTAL}, statuses=${STATUS_SUMMARY})"
       exit 0
     fi
 
-    echo "System-update AM ${TARGET_ROLE_NAME} role not ready (attempt ${ATTEMPT}/${MAX_ATTEMPTS}): matches=${MATCHING_TOTAL}"
+    if [[ "${MATCHING_TOTAL}" -gt 0 && "${MATCHING_UNKNOWN}" -eq "${MATCHING_TOTAL}" ]]; then
+      echo "System-update AM ${TARGET_ROLE_NAME} role found with UNKNOWN status only; accepting fallback (matches=${MATCHING_TOTAL}, statuses=${STATUS_SUMMARY})"
+      exit 0
+    fi
+
+    echo "System-update AM ${TARGET_ROLE_NAME} role not ${TARGET_STATUS} yet (attempt ${ATTEMPT}/${MAX_ATTEMPTS}): matches=${MATCHING_TOTAL}, statuses=${STATUS_SUMMARY}"
   else
-    echo "AM query failed (attempt ${ATTEMPT}/${MAX_ATTEMPTS})"
+    echo "AM query failed while checking system-update ${TARGET_ROLE_NAME} role (attempt ${ATTEMPT}/${MAX_ATTEMPTS})"
   fi
 
   echo "Waiting ${SLEEP_SECONDS}s before retry"
   sleep "${SLEEP_SECONDS}"
 done
 
-echo "System-update AM ${TARGET_ROLE_NAME} role did not become available after ${MAX_ATTEMPTS} attempts"
+echo "System-update AM ${TARGET_ROLE_NAME} role did not become ${TARGET_STATUS} after ${MAX_ATTEMPTS} attempts"
 exit 1
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DFPL-3190

### Change description ###
Add check that we have the WA flag set on the PR before running the case-allocator check in our smoke tests.

Also add explicit UNKNOWN check plus additional logging to case-allocator check.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
