### PR TITLE
DFPL-EXPOSE-AM-RETRY: Remove try catch to allow AM role retry

### DIFF
--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/config/SystemUserRoleAssignment.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/config/SystemUserRoleAssignment.java
@@ -21,12 +21,8 @@ public class SystemUserRoleAssignment {
     @PostConstruct
     @Retryable(retryFor = Exception.class, label = "Create system update user in AM")
     public void init() {
-        try {
-            log.info("Attempting to assign system-update user role");
-            roleAssignmentService.assignSystemUserRole();
-            log.info("Assigned role successfully");
-        } catch (Exception e) {
-            log.error("Could not automatically create system user role assignment", e);
-        }
+        log.info("Attempting to assign system-update user role");
+        roleAssignmentService.assignSystemUserRole();
+        log.info("Assigned role successfully");
     }
 }


### PR DESCRIPTION
Remove try catch from system-update-user role create and use bash script in WA pr tag to retry adding allocator role



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
