### PR TITLE
DFPL-3296: Case migration to filter solicitor from placement records

### DIFF
--- a/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseControllerTest.java
+++ b/service/src/integrationTest/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseControllerTest.java
@@ -1,15 +1,33 @@
 package uk.gov.hmcts.reform.fpl.controllers.support;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.fpl.controllers.AbstractCallbackTest;
 import uk.gov.hmcts.reform.fpl.model.CaseData;
+import uk.gov.hmcts.reform.fpl.model.Respondent;
+import uk.gov.hmcts.reform.fpl.model.RespondentSolicitor;
 
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import java.util.NoSuchElementException;
+import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.http.MediaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @WebMvcTest(MigrateCaseController.class)
@@ -21,6 +39,10 @@ class MigrateCaseControllerTest extends AbstractCallbackTest {
     }
 
     private static final String INVALID_MIGRATION_ID = "invalid id";
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private com.fasterxml.jackson.databind.ObjectMapper mapper;
 
     @Test
     void shouldThrowExceptionWhenMigrationNotMappedForMigrationID() {
@@ -42,5 +64,151 @@ class MigrateCaseControllerTest extends AbstractCallbackTest {
     void setup() {
         givenSystemUser();
         givenFplService();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldFilterPlacementEmailsWhenMigrationIdMatches() throws Exception {
+        String migrationId = "DFPL-3296";
+        String targetEmail = "****@***";
+
+
+        RespondentSolicitor solicitor = RespondentSolicitor.builder()
+            .email(targetEmail)
+            .build();
+
+        Respondent respondent = Respondent.builder()
+            .solicitor(solicitor)
+            .build();
+
+        Map<String, Object> respondentElement = Map.of(
+            "id", UUID.randomUUID().toString(),
+            "value", respondent
+        );
+
+        Map<String, Object> placementValue = new HashMap<>();
+        placementValue.put("placementChildName", "test child");
+        placementValue.put("placementRespondentsToNotify", List.of(respondentElement));
+
+        Map<String, Object> placementElement = Map.of(
+            "id", UUID.randomUUID().toString(),
+            "value", placementValue
+        );
+
+        // Wrap within CaseDetails
+        CaseData caseData = CaseData.builder().id(1767800818952560L).build();
+        CaseDetails caseDetails = asCaseDetails(caseData);
+
+        caseDetails.getData().put("migrationId", migrationId);
+        caseDetails.getData().put("placements", new ArrayList<>(List.of(placementElement)));
+        caseDetails.getData().put("placementsNonConfidential", new ArrayList<>(List.of(placementElement)));
+        caseDetails.getData().put("placementsNonConfidentialNotices", new ArrayList<>(List.of(placementElement)));
+
+        //  Construct raw callback request
+        CallbackRequest callbackRequest = CallbackRequest.builder()
+            .caseDetails(caseDetails)
+            .eventId("migrate-case")
+            .build();
+
+        // MockMvc to simulate rest call
+        String responseContent = mockMvc.perform(MockMvcRequestBuilders.post("/callback/migrate-case/about-to-submit")
+                .header("authorization", "Bearer token")
+                .header("user-id", "1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new ObjectMapper().writeValueAsString(callbackRequest)))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        // setting up Jackson and raw JSON content dynamically
+        ObjectMapper testMapper = new ObjectMapper();
+        testMapper.registerModule(new JavaTimeModule());
+
+        Map<String, Object> responseMap = testMapper.readValue(responseContent, new TypeReference<>() {});
+        Map<String, Object> dataField = (Map<String, Object>) responseMap.get("data");
+
+        // Assertions
+        assertThat(dataField).containsKeys(
+            "placements", "placementsNonConfidential", "placementsNonConfidentialNotices");
+
+        List<Map<String, Object>> noticesList = (List<Map<String, Object>>) dataField
+            .get("placementsNonConfidentialNotices");
+        assertThat(noticesList).hasSize(1);
+
+        Map<String, Object> innerValue = (Map<String, Object>) noticesList.getFirst().get("value");
+        List<?> respondentsToNotify = (List<?>) innerValue.get("placementRespondentsToNotify");
+
+        assertThat(respondentsToNotify).isEmpty();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldLogSkipMessageWhenMigrationIdMatchesButTargetEmailIsNotFound() throws Exception {
+        String migrationId = "DFPL-3296";
+
+        // Create a respondent with a completely different email address
+        RespondentSolicitor solicitor = RespondentSolicitor.builder()
+            .email("completely-different-email@test.com")
+            .build();
+
+        Respondent respondent = Respondent.builder()
+            .solicitor(solicitor)
+            .build();
+
+        Map<String, Object> respondentElement = Map.of(
+            "id", UUID.randomUUID().toString(),
+            "value", respondent
+        );
+
+        Map<String, Object> placementValue = new HashMap<>();
+        placementValue.put("placementChildName", "test child");
+        placementValue.put("placementRespondentsToNotify", List.of(respondentElement));
+
+        Map<String, Object> placementElement = Map.of(
+            "id", UUID.randomUUID().toString(),
+            "value", placementValue
+        );
+
+        // Wrap within CaseDetails using the exact expected Case ID
+        CaseData caseData = CaseData.builder().id(1767800818952560L).build();
+        CaseDetails caseDetails = asCaseDetails(caseData);
+
+        caseDetails.getData().put("migrationId", migrationId);
+        caseDetails.getData().put("placements", new ArrayList<>(List.of(placementElement)));
+        caseDetails.getData().put("placementsNonConfidential", new ArrayList<>(List.of(placementElement)));
+        caseDetails.getData().put("placementsNonConfidentialNotices", new ArrayList<>(List.of(placementElement)));
+
+        //  callback request
+        CallbackRequest callbackRequest = CallbackRequest.builder()
+            .caseDetails(caseDetails)
+            .eventId("migrate-case")
+            .build();
+
+        //  Hit MockMvc endpoint
+        String responseContent = mockMvc.perform(MockMvcRequestBuilders.post("/callback/migrate-case/about-to-submit")
+                .header("authorization", "Bearer token")
+                .header("user-id", "1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new ObjectMapper().writeValueAsString(callbackRequest)))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        //  Check response
+        ObjectMapper testMapper = new ObjectMapper();
+        testMapper.registerModule(new JavaTimeModule());
+
+        Map<String, Object> responseMap = testMapper.readValue(responseContent, new TypeReference<>() {});
+        Map<String, Object> dataField = (Map<String, Object>) responseMap.get("data");
+
+        //  Assertions
+        List<Map<String, Object>> noticesList = (List<Map<String, Object>>) dataField
+            .get("placementsNonConfidentialNotices");
+        Map<String, Object> innerValue = (Map<String, Object>) noticesList.getFirst().get("value");
+        List<?> respondentsToNotify = (List<?>) innerValue.get("placementRespondentsToNotify");
+
+        assertThat(respondentsToNotify).hasSize(1);
     }
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/controllers/support/MigrateCaseController.java
@@ -32,7 +32,8 @@ public class MigrateCaseController extends CallbackController {
 
     private final Map<String, Consumer<CaseDetails>> migrations = Map.of(
         "DFPL-log", this::runLog,
-        "DFPL-3290", this::run3290
+        "DFPL-3290", this::run3290,
+        "DFPL-3296", this::run3296
     );
 
     @PostMapping("/about-to-submit")
@@ -74,4 +75,25 @@ public class MigrateCaseController extends CallbackController {
         ), LASOLICITOR);
 
     }
+
+    private void run3296(CaseDetails caseDetails) {
+        final String migrationId = "DFPL-3296";
+        final long expectedCaseId = 1767800818952560L;
+        final String targetEmail = "****@***";
+
+        Long caseId = caseDetails.getId();
+        migrateCaseService.doCaseIdCheck(caseId, expectedCaseId, migrationId);
+
+        log.info("Migration {} started for case {}", migrationId, caseId);
+
+        boolean isModified = migrateCaseService.removeSolicitorEmailFromPlacementNotices(caseDetails, targetEmail);
+
+        if (isModified) {
+            log.info("Migration {} successfully removed {} from placement notification list on case {}",
+                migrationId, targetEmail, caseId);
+        } else {
+            log.info("Migration {} skipped: Target email not found in any placement records.", migrationId);
+        }
+    }
+
 }

--- a/service/src/main/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseService.java
+++ b/service/src/main/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseService.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.reform.fpl.service;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -108,6 +110,7 @@ public class MigrateCaseService {
     public final CourtLookUpService courtLookUpService;
 
     private static final Map<String, HearingType>  HEARING_TYPE_DETAILS_MAPPING = initialiseHearingMapping();
+    private final ObjectMapper mapper;
 
 
     private static Map<String, HearingType> initialiseHearingMapping() {
@@ -1471,4 +1474,89 @@ public class MigrateCaseService {
 
         return Map.of("others", updatedOthers);
     }
+
+    public boolean removeSolicitorEmailFromPlacementNotices(CaseDetails caseDetails, String targetEmail) {
+        // Flag to track if modifications happen anywhere across the three fields
+        boolean dynamicModified = false;
+
+        // Process standard placements
+        if (caseDetails.getData().get(PLACEMENT) != null) {
+            List<Element<Placement>> placements = getPlacementList(caseDetails, PLACEMENT);
+            if (processPlacementsList(placements, targetEmail)) {
+                caseDetails.getData().put(PLACEMENT, placements);
+                dynamicModified = true;
+            }
+        }
+
+        // Process placementsNonConfidentialNotices
+        if (caseDetails.getData().get(PLACEMENT_NON_CONFIDENTIAL_NOTICES) != null) {
+            List<Element<Placement>> notices = getPlacementList(caseDetails, PLACEMENT_NON_CONFIDENTIAL_NOTICES);
+            if (processPlacementsList(notices, targetEmail)) {
+                caseDetails.getData().put(PLACEMENT_NON_CONFIDENTIAL_NOTICES, notices);
+                dynamicModified = true;
+            }
+        }
+
+        // Process placementsNonConfidential
+        if (caseDetails.getData().get(PLACEMENT_NON_CONFIDENTIAL) != null) {
+            List<Element<Placement>> nonConf = getPlacementList(caseDetails, PLACEMENT_NON_CONFIDENTIAL);
+            if (processPlacementsList(nonConf, targetEmail)) {
+                caseDetails.getData().put(PLACEMENT_NON_CONFIDENTIAL, nonConf);
+                dynamicModified = true;
+            }
+        }
+
+        return dynamicModified;
+    }
+
+
+    private List<Element<Placement>> getPlacementList(CaseDetails caseDetails, String key) {
+        return mapper.convertValue(caseDetails.getData().get(key), new TypeReference<>() {
+        });
+    }
+
+    private boolean processPlacementsList(List<Element<Placement>> placements, String targetEmail) {
+        boolean modified = false;
+
+        for (Element<Placement> placementElement : placements) {
+            Placement placement = placementElement.getValue();
+
+            if (placement != null && placement.getPlacementRespondentsToNotify() != null) {
+                List<Element<Respondent>> originalList = placement.getPlacementRespondentsToNotify();
+                List<Element<Respondent>> filteredList = filterRespondentsBySolicitor(originalList, targetEmail);
+
+                if (filteredList.size() != originalList.size()) {
+                    placement.setPlacementRespondentsToNotify(filteredList);
+                    modified = true;
+                }
+            }
+        }
+
+        return modified;
+    }
+
+    private List<Element<Respondent>> filterRespondentsBySolicitor(List<Element<Respondent>> respondents,
+                                                                   String targetEmail) {
+        List<Element<Respondent>> updatedRespondents = new ArrayList<>();
+
+        for (Element<Respondent> respondentEl : respondents) {
+            if (shouldKeepRespondentSolicitor(respondentEl, targetEmail)) {
+                updatedRespondents.add(respondentEl);
+            }
+        }
+
+        return updatedRespondents;
+    }
+
+    private boolean shouldKeepRespondentSolicitor(Element<Respondent> respondentEl, String targetEmail) {
+        if (respondentEl.getValue() == null
+            || respondentEl.getValue().getSolicitor() == null
+            || respondentEl.getValue().getSolicitor().getEmail() == null) {
+            return true;
+        }
+
+        String currentEmail = respondentEl.getValue().getSolicitor().getEmail();
+        return !targetEmail.equalsIgnoreCase(currentEmail);
+    }
+
 }

--- a/service/src/test/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseServiceTest.java
+++ b/service/src/test/java/uk/gov/hmcts/reform/fpl/service/MigrateCaseServiceTest.java
@@ -114,6 +114,10 @@ import static uk.gov.hmcts.reform.fpl.enums.YesNo.YES;
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.element;
 import static uk.gov.hmcts.reform.fpl.utils.ElementUtils.wrapElementsWithUUIDs;
 import static uk.gov.hmcts.reform.fpl.utils.TestDataHelper.testAddress;
+import uk.gov.hmcts.reform.fpl.model.RespondentSolicitor;
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.mockito.Mockito;
+
 
 @ExtendWith({MockitoExtension.class})
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -135,6 +139,9 @@ class MigrateCaseServiceTest {
 
     @Mock
     private CaseNoteService caseNoteService;
+
+    @Mock
+    private com.fasterxml.jackson.databind.ObjectMapper mapper;
 
     @InjectMocks
     private MigrateCaseService underTest;
@@ -3928,6 +3935,261 @@ class MigrateCaseServiceTest {
                 .build();
 
             assertThrows(AssertionError.class, () -> underTest.removeFirstOther(MIGRATION_ID, caseData));
+        }
+    }
+
+    @Nested
+    class RemoveSolicitorEmailFromPlacementNotices {
+        private static final String TARGET_EMAIL = "****@***";
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void shouldReturnTrueAndRemoveMatchingRespondentFromAllThreePlacementFields() {
+            // Set up a matching respondent
+            RespondentSolicitor targetSolicitor = RespondentSolicitor.builder()
+                .email(TARGET_EMAIL)
+                .build();
+
+            Respondent targetRespondent = Respondent.builder()
+                .solicitor(targetSolicitor)
+                .build();
+
+            Element<Respondent> matchingElement = Element.<Respondent>builder()
+                .id(UUID.randomUUID())
+                .value(targetRespondent)
+                .build();
+
+            // Set up a non-matching respondent
+            RespondentSolicitor keepSolicitor = RespondentSolicitor.builder()
+                .email("keep-me@test.com")
+                .build();
+
+            Respondent keepRespondent = Respondent.builder()
+                .solicitor(keepSolicitor)
+                .build();
+
+            Element<Respondent> keepElement = Element.<Respondent>builder()
+                .id(UUID.randomUUID())
+                .value(keepRespondent)
+                .build();
+
+            // Assemble the placements list containing both items
+            Placement placementValue = Placement.builder()
+                .placementRespondentsToNotify(List.of(matchingElement, keepElement))
+                .build();
+
+            Element<Placement> placementElement = Element.<Placement>builder()
+                .id(UUID.randomUUID())
+                .value(placementValue)
+                .build();
+
+            List<Element<Placement>> mockPlacementList = List.of(placementElement);
+
+            //  return  mocked placement list
+            Mockito.when(mapper.convertValue(
+                Mockito.any(),
+                Mockito.any(TypeReference.class)
+            )).thenReturn(mockPlacementList);
+
+
+            Map<String, Object> placementDataMock = new HashMap<>();
+            placementDataMock.put("id", UUID.randomUUID().toString());
+            placementDataMock.put("value", new HashMap<>());
+
+            Map<String, Object> caseDataMap = new HashMap<>();
+            caseDataMap.put("placements", new ArrayList<>(List.of(placementDataMock)));
+            caseDataMap.put("placementsNonConfidential", new ArrayList<>(List.of(placementDataMock)));
+            caseDataMap.put("placementsNonConfidentialNotices", new ArrayList<>(List.of(placementDataMock)));
+
+            CaseDetails testCaseDetails = CaseDetails.builder()
+                .id(1767800818952560L)
+                .data(caseDataMap)
+                .build();
+
+
+            boolean isModified = underTest.removeSolicitorEmailFromPlacementNotices(testCaseDetails, TARGET_EMAIL);
+
+            //Assert
+            assertThat(isModified).isTrue();
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void shouldReturnFalseWhenNoMatchingEmailIsFound() {
+            // Arrange
+            Map<String, Object> solicitor = Map.of("email", "different@test.com");
+            Map<String, Object> respondent = Map.of("solicitor", solicitor);
+            List<Map<String, Object>> placementRespondents = List.of(Map.of("id", UUID.randomUUID().toString(),
+                "value", respondent));
+            Map<String, Object> placementElement = Map.of("id", UUID.randomUUID().toString(), "value",
+                Map.of("placementRespondentsToNotify", placementRespondents));
+
+            Map<String, Object> caseDataMap = new HashMap<>();
+            caseDataMap.put("placements", List.of(placementElement));
+            caseDataMap.put("placementsNonConfidential", List.of(placementElement));
+            caseDataMap.put("placementsNonConfidentialNotices", List.of(placementElement));
+
+            CaseDetails testCaseDetails = CaseDetails.builder().data(caseDataMap).build();
+
+            // prevent NullPointerException
+            RespondentSolicitor diffSolicitor = RespondentSolicitor.builder()
+                .email("different@test.com")
+                .build();
+
+            Respondent diffRespondent = Respondent.builder()
+                .solicitor(diffSolicitor)
+                .build();
+
+            Element<Respondent> respElement = Element.<Respondent>builder()
+                .id(UUID.randomUUID())
+                .value(diffRespondent)
+                .build();
+
+            Placement placementValue = Placement.builder()
+                .placementRespondentsToNotify(List.of(respElement))
+                .build();
+
+            Element<Placement> placementWrap = Element.<Placement>builder()
+                .id(UUID.randomUUID())
+                .value(placementValue)
+                .build();
+
+            List<Element<Placement>> mockPlacementList = List.of(placementWrap);
+
+            // Stub the mapper
+            Mockito.when(mapper.convertValue(
+                Mockito.any(),
+                Mockito.any(TypeReference.class)
+            )).thenReturn(mockPlacementList);
+
+
+            boolean isModified = underTest.removeSolicitorEmailFromPlacementNotices(testCaseDetails, TARGET_EMAIL);
+
+            // Assert
+            assertThat(isModified).isFalse();
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void shouldReturnTrueWhenRespondentOrSolicitorOrEmailIsNull() {
+            //  Element value is null
+            Element<Respondent> nullValueElement = Element.<Respondent>builder()
+                .id(UUID.randomUUID())
+                .value(null)
+                .build();
+
+            // Solicitor is null
+            Respondent nullSolicitorRespondent = Respondent.builder()
+                .solicitor(null)
+                .build();
+            Element<Respondent> nullSolicitorElement = Element.<Respondent>builder()
+                .id(UUID.randomUUID())
+                .value(nullSolicitorRespondent)
+                .build();
+
+            //  Solicitor email is null
+            RespondentSolicitor nullEmailSolicitor = RespondentSolicitor.builder()
+                .email(null)
+                .build();
+            Respondent nullEmailRespondent = Respondent.builder()
+                .solicitor(nullEmailSolicitor)
+                .build();
+            Element<Respondent> nullEmailElement = Element.<Respondent>builder()
+                .id(UUID.randomUUID())
+                .value(nullEmailRespondent)
+                .build();
+
+            Placement corruptPlacementValue = Placement.builder()
+                .placementRespondentsToNotify(List.of(nullValueElement, nullSolicitorElement, nullEmailElement))
+                .build();
+
+            Element<Placement> placementElement = Element.<Placement>builder()
+                .id(UUID.randomUUID())
+                .value(corruptPlacementValue)
+                .build();
+
+            List<Element<Placement>> mockPlacementList = List.of(placementElement);
+
+            // Stub the mapper
+            Mockito.when(mapper.convertValue(
+                Mockito.any(),
+                Mockito.any(TypeReference.class)
+            )).thenReturn(mockPlacementList);
+
+
+            Map<String, Object> placementDataMock = new HashMap<>();
+            placementDataMock.put("id", UUID.randomUUID().toString());
+            placementDataMock.put("value", new HashMap<>());
+
+            Map<String, Object> caseDataMap = new HashMap<>();
+            caseDataMap.put("placements", new ArrayList<>(List.of(placementDataMock)));
+            caseDataMap.put("placementsNonConfidential", new ArrayList<>(List.of(placementDataMock)));
+            caseDataMap.put("placementsNonConfidentialNotices", new ArrayList<>(List.of(placementDataMock)));
+
+            CaseDetails testCaseDetails = CaseDetails.builder()
+                .id(1767800818952560L)
+                .data(caseDataMap)
+                .build();
+
+
+            boolean isModified = underTest.removeSolicitorEmailFromPlacementNotices(testCaseDetails, TARGET_EMAIL);
+
+            // Assert
+            assertThat(isModified).isFalse();
+        }
+
+        @Test
+        void shouldReturnFalseAndSkipProcessingWhenAllPlacementFieldsAreNull() {
+
+            Map<String, Object> emptyCaseDataMap = new HashMap<>();
+
+            CaseDetails testCaseDetails = CaseDetails.builder()
+                .id(1767800818952560L)
+                .data(emptyCaseDataMap)
+                .build();
+
+            boolean isModified = underTest.removeSolicitorEmailFromPlacementNotices(testCaseDetails, TARGET_EMAIL);
+
+            //  Assert
+            assertThat(isModified).isFalse();
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void shouldForceTrueBranchExecutionForAllInnerPlacementBlocks() {
+
+            // Create elements containing the target email
+            java.util.function.Supplier<List<Element<Placement>>> matchSupplier = () -> {
+                RespondentSolicitor targetSolicitor = RespondentSolicitor.builder().email(TARGET_EMAIL).build();
+                Respondent targetRespondent = Respondent.builder().solicitor(targetSolicitor).build();
+                Element<Respondent> matchingElement = Element.<Respondent>builder().id(UUID.randomUUID())
+                    .value(targetRespondent).build();
+                Placement matchingPlacement = Placement.builder()
+                    .placementRespondentsToNotify(List.of(matchingElement)).build();
+                return List.of(Element.<Placement>builder().id(UUID.randomUUID()).value(matchingPlacement).build());
+            };
+
+
+            Mockito.when(mapper.convertValue(Mockito.any(), Mockito.any(TypeReference.class)))
+                .thenReturn(matchSupplier.get())  //get ("placements")
+                .thenReturn(matchSupplier.get())  // get ("placementsNonConfidentialNotices")
+                .thenReturn(matchSupplier.get()); // get ("placementsNonConfidential")
+
+
+            Map<String, Object> caseDataMap = new HashMap<>();
+            caseDataMap.put("placements", new ArrayList<>(List.of(new HashMap<>())));
+            caseDataMap.put("placementsNonConfidential", new ArrayList<>(List.of(new HashMap<>())));
+            caseDataMap.put("placementsNonConfidentialNotices", new ArrayList<>(List.of(new HashMap<>())));
+
+            CaseDetails testCaseDetails = CaseDetails.builder()
+                .id(1767800818952560L)
+                .data(caseDataMap)
+                .build();
+
+            boolean isModified = underTest.removeSolicitorEmailFromPlacementNotices(testCaseDetails, TARGET_EMAIL);
+
+            //Assert
+            assertThat(isModified).isTrue();
         }
     }
 }


### PR DESCRIPTION



### JIRA link (if applicable) ###

[DFPL-3296](https://tools.hmcts.net/jira/browse/DFPL-3296)

### Change description ###
Filters out the target respondent solicitor email from all three placement record fields within case data

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
