### PR TITLE
DFPL-3151-Fix: Add ccd field to prevent failed import until main fix

### DIFF
--- a/ccd-definition/CaseField/CareSupervision/caseField.json
+++ b/ccd-definition/CaseField/CareSupervision/caseField.json
@@ -2426,6 +2426,15 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "ID": "respondentsSelectorV2",
+    "Label": "Select who should be notified",
+    "FieldType": "DynamicMultiSelectList",
+    "SecurityClassification": "Public",
+    "Searchable": "N"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
     "ID": "personSelector",
     "Label": "Select who should be notified",
     "FieldType": "PersonSelector",


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DFPL-3151

Add back definition to stop failed CCD imports until main fix is tested and pushed

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
