### PR TITLE
DFPL-2919: revert dmnBranch to master in Jenkinsfile_CNP

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -157,7 +157,7 @@ def deployWADmns() {
 
   def waStandaloneBranch = "master"
   // For testing DMNs, change this to the branch on the DMN repo, but ensure it is changed back to master before merging
-  def dmnBranch = "DFPL-2919-Urgency-Listing-Event"
+  def dmnBranch = "master"
 
   echo "Checking if we should use WA"
   if (githubApi.checkForLabel(env.BRANCH_NAME, 'pr-values:wa')) {


### PR DESCRIPTION


### JIRA link (if applicable) ###

[DFPL-2919](https://tools.hmcts.net/jira/browse/DFPL-2919)

### Change description ###

Reverted dmnBranch back to master in Jenkinsfile_CNP following the merge of ticket DFPL-2919 feature branch.

Does this PR introduce a breaking change?

[ ] Yes

[x] No